### PR TITLE
fix stale active turn id and normalize turn id handling

### DIFF
--- a/apps/android/app/src/main/java/com/litter/android/ui/LitterAppShell.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/LitterAppShell.kt
@@ -51,6 +51,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.ArrowUpward
 import androidx.compose.material.icons.filled.AttachFile
@@ -79,6 +80,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -1463,15 +1465,63 @@ private fun InputBar(
             }
 
             Row(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                OutlinedButton(onClick = onAttachImage, enabled = !isSending) {
-                    Icon(Icons.Default.AttachFile, contentDescription = "Attach image", modifier = Modifier.size(16.dp))
-                }
-                OutlinedButton(onClick = onCaptureImage, enabled = !isSending) {
-                    Icon(Icons.Default.CameraAlt, contentDescription = "Capture image", modifier = Modifier.size(16.dp))
+                Box {
+                    var showAttachMenu by remember { mutableStateOf(false) }
+                    IconButton(
+                        onClick = { showAttachMenu = true },
+                        enabled = !isSending,
+                        modifier = Modifier
+                            .size(40.dp)
+                            .background(LitterTheme.surface, CircleShape)
+                    ) {
+                        Icon(
+                            Icons.Default.Add,
+                            contentDescription = "Attach",
+                            tint = LitterTheme.textPrimary,
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
+                    DropdownMenu(
+                        expanded = showAttachMenu,
+                        onDismissRequest = { showAttachMenu = false }
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("Upload File") },
+                            onClick = {
+                                showAttachMenu = false
+                                onAttachImage()
+                            },
+                            leadingIcon = {
+                                Icon(
+                                    Icons.Default.AttachFile,
+                                    contentDescription = null,
+                                    tint = LitterTheme.textPrimary,
+                                    modifier = Modifier.size(20.dp)
+                                )
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Camera") },
+                            onClick = {
+                                showAttachMenu = false
+                                onCaptureImage()
+                            },
+                            leadingIcon = {
+                                Icon(
+                                    Icons.Default.CameraAlt,
+                                    contentDescription = null,
+                                    tint = LitterTheme.textPrimary,
+                                    modifier = Modifier.size(20.dp)
+                                )
+                            }
+                        )
+                    }
                 }
 
                 OutlinedTextField(
@@ -1482,23 +1532,57 @@ private fun InputBar(
                         refreshComposerPopups(nextValue)
                     },
                     modifier = Modifier.weight(1f),
-                    placeholder = { Text("Message litter...") },
+                    placeholder = { Text("Message litter...", color = LitterTheme.textMuted) },
                     minLines = 1,
                     maxLines = 5,
+                    shape = RoundedCornerShape(24.dp),
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = LitterTheme.accent.copy(alpha = 0.5f),
+                        unfocusedBorderColor = LitterTheme.border,
+                        focusedContainerColor = LitterTheme.surface,
+                        unfocusedContainerColor = LitterTheme.surface,
+                        focusedTextColor = LitterTheme.textPrimary,
+                        unfocusedTextColor = LitterTheme.textPrimary,
+                        cursorColor = LitterTheme.accent
+                    )
                 )
 
-                Button(
-                    onClick = {
-                        onSend(composerValue.text)
-                        hideComposerPopups()
-                    },
-                    enabled = (composerValue.text.isNotBlank() || attachedImagePath != null) && !isSending,
-                ) {
-                    Icon(Icons.AutoMirrored.Filled.Send, contentDescription = "Send", modifier = Modifier.size(16.dp))
-                }
-
-                OutlinedButton(onClick = onInterrupt, enabled = isSending) {
-                    Icon(Icons.Default.Stop, contentDescription = "Interrupt", modifier = Modifier.size(16.dp))
+                if (isSending) {
+                    IconButton(
+                        onClick = onInterrupt,
+                        modifier = Modifier
+                            .size(40.dp)
+                            .background(LitterTheme.surface, CircleShape)
+                    ) {
+                        Icon(
+                            Icons.Default.Stop,
+                            contentDescription = "Interrupt",
+                            tint = LitterTheme.textPrimary,
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                } else {
+                    val canSend = composerValue.text.isNotBlank() || attachedImagePath != null
+                    IconButton(
+                        onClick = {
+                            onSend(composerValue.text)
+                            hideComposerPopups()
+                        },
+                        enabled = canSend,
+                        modifier = Modifier
+                            .size(40.dp)
+                            .background(
+                                if (canSend) LitterTheme.accent else LitterTheme.surface,
+                                CircleShape
+                            )
+                    ) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.Send,
+                            contentDescription = "Send",
+                            tint = if (canSend) Color.Black else LitterTheme.textMuted,
+                            modifier = Modifier.size(18.dp)
+                        )
+                    }
                 }
             }
         }

--- a/apps/android/scripts/deploy-dev.sh
+++ b/apps/android/scripts/deploy-dev.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -e
+
+# Auto-detect Java from Android Studio if JAVA_HOME not set
+if [ -z "$JAVA_HOME" ]; then
+    AS_JAVA="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+    [ -d "$AS_JAVA" ] && export JAVA_HOME="$AS_JAVA"
+fi
+
+export PATH="$PATH:$HOME/Library/Android/sdk/platform-tools"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ANDROID_DIR="$SCRIPT_DIR/.."
+APK="$ANDROID_DIR/app/build/outputs/apk/onDevice/debug/app-onDevice-debug.apk"
+
+echo "==> Building onDevice debug APK..."
+"$ANDROID_DIR/gradlew" -p "$ANDROID_DIR" :app:assembleOnDeviceDebug
+
+echo "==> Installing to all connected devices..."
+DEVICES=$(adb devices | awk '/\tdevice$/{print $1}')
+
+if [ -z "$DEVICES" ]; then
+    echo "No devices/emulators found. Connect a device or start an emulator first."
+    exit 1
+fi
+
+for SERIAL in $DEVICES; do
+    echo "  -> Installing on $SERIAL"
+    adb -s "$SERIAL" install -r "$APK"
+done
+
+echo "==> Done."

--- a/apps/ios/Sources/Litter/Bridge/CodexProtocol.swift
+++ b/apps/ios/Sources/Litter/Bridge/CodexProtocol.swift
@@ -135,11 +135,20 @@ struct TurnStartParams: Encodable {
 }
 
 struct TurnStartResponse: Decodable {
+    // New shape: { turn: { id } }; old shape: { turnId }
     let turnId: String?
+    let turn: TurnInfo?
+
+    struct TurnInfo: Decodable {
+        let id: String?
+    }
+
+    var resolvedTurnId: String? { turn?.id ?? turnId }
 }
 
 struct TurnInterruptParams: Encodable {
     let threadId: String
+    let turnId: String?
 }
 
 // MARK: - Review

--- a/apps/ios/Sources/Litter/Models/ServerConnection.swift
+++ b/apps/ios/Sources/Litter/Models/ServerConnection.swift
@@ -177,19 +177,19 @@ final class ServerConnection: ObservableObject, Identifiable {
             lower.contains("missing codex-linux-sandbox executable path")
     }
 
-    func sendTurn(threadId: String, text: String, model: String? = nil, effort: String? = nil) async throws {
-        let _: TurnStartResponse = try await client.sendRequest(
+    func sendTurn(threadId: String, text: String, model: String? = nil, effort: String? = nil) async throws -> TurnStartResponse {
+        try await client.sendRequest(
             method: "turn/start",
             params: TurnStartParams(threadId: threadId, input: [UserInput(type: "text", text: text)], model: model, effort: effort),
             responseType: TurnStartResponse.self
         )
     }
 
-    func interrupt(threadId: String) async {
+    func interrupt(threadId: String, turnId: String?) async {
         struct Empty: Decodable {}
         _ = try? await client.sendRequest(
             method: "turn/interrupt",
-            params: TurnInterruptParams(threadId: threadId),
+            params: TurnInterruptParams(threadId: threadId, turnId: turnId),
             responseType: Empty.self
         )
     }

--- a/apps/ios/Sources/Litter/Models/ThreadState.swift
+++ b/apps/ios/Sources/Litter/Models/ThreadState.swift
@@ -18,6 +18,7 @@ final class ThreadState: ObservableObject, Identifiable {
     @Published var preview: String = ""
     @Published var cwd: String = ""
     @Published var updatedAt: Date = Date()
+    var activeTurnId: String? = nil
 
     var id: ThreadKey { key }
 


### PR DESCRIPTION
## summary
- track turn ids from both `turn.id` and legacy `turnId` payloads on ios and android
- include `turnId` in `turn/interrupt` requests when available
- clear `activeTurnId` when turns complete, including the fallback completion path without `threadId`
- refresh android input actions and add a small deploy helper script

## bug
on ios, the fallback `turn/completed` path (used when the event has no `threadId`) set the thread to ready but did not clear `activeTurnId`.
that stale id could be reused by a later interrupt request, causing an interrupt failure or targeting the wrong turn.

## fix
clear `activeTurnId` in the fallback completion loop so thread state is consistent across both completion paths.
