### PR TITLE
Docs: Add Mac SSH setup guide for exposing Codex sessions in Litter

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Bootstrap them locally before building:
   brew install xcodegen
   ```
 
-## Connect to a Mac over SSH from Litter (Codex app-server)
+## Connect Your Mac to Litter Over SSH
 
 Use this flow to make Codex sessions from your Mac visible in the iOS/Android app.
 


### PR DESCRIPTION
This PR adds a new README section to help users connect a Mac host to Litter over SSH and make remote Codex sessions visible in the app.

  ### What’s included

  - Added a dedicated setup guide section: Connect Your Mac to Litter Over
    SSH
  - Documented how to enable macOS Remote Login (UI and CLI paths)
  - Added troubleshooting for:
      - setremotelogin requiring Full Disk Access
  - Added verification commands for:
      - SSH connectivity
      - codex / codex-app-server availability in non-interactive shells
  - Documented app-side connection flow in Discovery (codex running vs SSH)
  - Added manual fallback flow using:
      - codex app-server --listen ws://0.0.0.0:8390
      - manual host/port entry in app
  - Added note that session visibility is cwd-scoped

  ### Why

  Users can get blocked on macOS permissions and shell-path issues when connecting over SSH. This guide makes setup deterministic and reduces support/debug time.

  ### Testing

  Documentation-only change; no runtime behavior changed.