### PR TITLE
ios: keyboard fix, OAuth callback forwarding, auth UX

### DIFF
--- a/apps/ios/Litter.xcodeproj/project.pbxproj
+++ b/apps/ios/Litter.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 63;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -203,13 +203,13 @@
 		4F2C91E2BA1A8F93DA7FF4EF /* CodexProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexProtocol.swift; sourceTree = "<group>"; };
 		50CFDCB6C4655E3D2D76B41B /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		545E3E3890AFDE088424F0C1 /* commandDictionary.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = commandDictionary.plist; sourceTree = "<group>"; };
-		55A7968182C0B25044D38C00 /* Litter.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Litter.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		55A7968182C0B25044D38C00 /* Litter.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Litter.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		615E709D4D5722523052907E /* SnapshotHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
 		67AFB81F773863EB4A05235C /* ThreadState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadState.swift; sourceTree = "<group>"; };
 		6A9876F2929290D47ED57D77 /* SSHLoginSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHLoginSheet.swift; sourceTree = "<group>"; };
 		7043F325D81EDDF6CE12024E /* extraCommandsDictionary.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = extraCommandsDictionary.plist; sourceTree = "<group>"; };
 		73840201673E0D1EE9E9DEBF /* ServerConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerConnection.swift; sourceTree = "<group>"; };
-		74E5DF89D0937E6C17F2BB94 /* brand_logo.svg */ = {isa = PBXFileReference; path = brand_logo.svg; sourceTree = "<group>"; };
+		74E5DF89D0937E6C17F2BB94 /* brand_logo.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = brand_logo.svg; sourceTree = "<group>"; };
 		754A6F0D26DFBE19A8C6625F /* SSHSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHSessionManager.swift; sourceTree = "<group>"; };
 		7779BD02F3B304F9C3AD32A1 /* DiscoveredServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveredServer.swift; sourceTree = "<group>"; };
 		7EAAD91EA135C03B2759124D /* SidebarOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarOverlay.swift; sourceTree = "<group>"; };
@@ -557,7 +557,6 @@
 				AF6B0A94FF765E17953F7B72 /* XCRemoteSwiftPackageReference "Inject" */,
 				4F6C9060920234B3E9A86BD3 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
 			);
-			preferredProjectObjectVersion = 77;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -738,6 +737,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = UH66Q8ZAYG;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"Frameworks\"",
@@ -749,7 +749,11 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				OTHER_LDFLAGS = "$(inherited) -lc++ -lz";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lc++",
+					"-lz",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.sigkitten.litter;
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_BRIDGING_HEADER = Sources/Litter/Bridge/codex_bridge_objc.h;
@@ -762,6 +766,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = UH66Q8ZAYG;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"Frameworks\"",
@@ -850,7 +855,11 @@
 				MARKETING_VERSION = 1.0.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
-				OTHER_LDFLAGS = "$(inherited) -lc++ -lz";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lc++",
+					"-lz",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -938,7 +947,11 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = "$(inherited) -lc++ -lz";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lc++",
+					"-lz",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -1027,7 +1040,11 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				OTHER_LDFLAGS = "$(inherited) -lc++ -lz";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lc++",
+					"-lz",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.sigkitten.litter.remote;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) LITTER_DISABLE_ON_DEVICE_CODEX";

--- a/apps/ios/Sources/Litter/LitterApp.swift
+++ b/apps/ios/Sources/Litter/LitterApp.swift
@@ -1,5 +1,7 @@
 import SwiftUI
+import Combine
 import Inject
+import UIKit
 
 @main
 struct LitterApp: App {
@@ -21,6 +23,7 @@ struct ContentView: View {
     @StateObject private var appState = AppState()
     @State private var sidebarDragOffset: CGFloat = 0
     @State private var isEdgeOpeningSidebar = false
+    @State private var keyboardHeight: CGFloat = 0
 
     private let sidebarAnimation = Animation.spring(response: 0.3, dampingFraction: 0.86)
 
@@ -34,7 +37,7 @@ struct ContentView: View {
         ZStack {
             LitterTheme.backgroundGradient.ignoresSafeArea()
 
-            mainContent(topInset: geometry.safeAreaInsets.top, bottomInset: geometry.safeAreaInsets.bottom)
+            mainContent(topInset: geometry.safeAreaInsets.top, bottomInset: keyboardHeight > 0 ? 0 : geometry.safeAreaInsets.bottom)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .ignoresSafeArea(.container, edges: [.top, .bottom])
                 .overlay(alignment: .top) {
@@ -70,7 +73,15 @@ struct ContentView: View {
                 }
             }
         }
-        .ignoresSafeArea()
+        .ignoresSafeArea(.container)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { notification in
+            if let frame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
+                keyboardHeight = frame.height
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
+            keyboardHeight = 0
         }
         .environmentObject(appState)
         .onAppear {

--- a/apps/ios/Sources/Litter/Models/SSHSessionManager.swift
+++ b/apps/ios/Sources/Litter/Models/SSHSessionManager.swift
@@ -12,6 +12,7 @@ actor SSHSessionManager {
     private var forwardedLocalPort: UInt16?
     private var forwardedRemotePort: UInt16?
     private var forwardedRemoteHost: String?
+    private var launchedServerPID: Int?
     private let defaultRemotePort: UInt16 = 8390
 
     private enum ServerLaunchCommand {
@@ -161,8 +162,9 @@ actor SSHSessionManager {
             let listenAddr = wantsIPv6 ? "[::]:\(port)" : "0.0.0.0:\(port)"
             let logPath = "/tmp/codex-ios-app-server-\(port).log"
 
-            // Check if already running on this port
+            // Check if already running on this port (not launched by us)
             if let listening = try? await isPortListening(client: client, port: port), listening {
+                launchedServerPID = nil
                 return port
             }
 
@@ -179,6 +181,7 @@ actor SSHSessionManager {
                 for attempt in 0..<60 {
                     try await Task.sleep(for: .milliseconds(500))
                     if let listening = try? await isPortListening(client: client, port: port), listening {
+                        launchedServerPID = launchedPID
                         return port
                     }
                     if let pid = launchedPID, let alive = try? await isProcessAlive(client: client, pid: pid), !alive {
@@ -205,6 +208,7 @@ actor SSHSessionManager {
                        let pid = launchedPID,
                        let alive = try? await isProcessAlive(client: client, pid: pid),
                        alive {
+                        launchedServerPID = launchedPID
                         return port
                     }
                 }
@@ -397,6 +401,12 @@ actor SSHSessionManager {
         guard let output = try? await client.executeCommand(script) else { return nil }
         let raw = String(buffer: output).trimmingCharacters(in: .whitespacesAndNewlines)
         return DiscoveredServer.normalizeWakeMAC(raw)
+    }
+
+    func stopRemoteServer() async {
+        guard let client, let pid = launchedServerPID else { return }
+        _ = try? await client.executeCommand("kill \(pid) 2>/dev/null")
+        launchedServerPID = nil
     }
 
     func disconnect() async {

--- a/apps/ios/Sources/Litter/Models/ServerConnection.swift
+++ b/apps/ios/Sources/Litter/Models/ServerConnection.swift
@@ -88,6 +88,19 @@ final class ServerConnection: ObservableObject, Identifiable {
         serverURL = nil
     }
 
+    func forwardOAuthCallback(_ url: URL) {
+        switch target {
+        case .local:
+            Task { _ = try? await URLSession.shared.data(from: url) }
+        case .remote:
+            Task {
+                _ = try? await execCommand(["curl", "-s", "-4", "-L", "--max-time", "10", url.absoluteString])
+            }
+        case .sshThenRemote:
+            break
+        }
+    }
+
     // MARK: - RPC Methods
 
     func listThreads(cwd: String? = nil, cursor: String? = nil, limit: Int? = 20) async throws -> ThreadListResponse {

--- a/apps/ios/Sources/Litter/Models/ServerManager.swift
+++ b/apps/ios/Sources/Litter/Models/ServerManager.swift
@@ -292,6 +292,13 @@ final class ServerManager: ObservableObject {
     }
 
     func removeServer(id: String) {
+        if let conn = connections[id] {
+            if conn.target == .local {
+                Task { await CodexBridge.shared.stop() }
+            } else if conn.server.source == .ssh {
+                Task { await SSHSessionManager.shared.stopRemoteServer() }
+            }
+        }
         connections[id]?.disconnect()
         connections.removeValue(forKey: id)
         connectionSubscriptions.removeValue(forKey: id)

--- a/apps/ios/Sources/Litter/Views/AccountView.swift
+++ b/apps/ios/Sources/Litter/Views/AccountView.swift
@@ -173,7 +173,9 @@ struct AccountView: View {
     private var oauthSheet: some View {
         if let url = conn?.oauthURL {
             NavigationStack {
-                SafariView(url: url) {
+                OAuthWebView(url: url, onCallbackIntercepted: { callbackURL in
+                    conn?.forwardOAuthCallback(callbackURL)
+                }) {
                     Task { await conn?.cancelLogin() }
                 }
                 .ignoresSafeArea()

--- a/apps/ios/Sources/Litter/Views/HeaderView.swift
+++ b/apps/ios/Sources/Litter/Views/HeaderView.swift
@@ -8,6 +8,7 @@ struct HeaderView: View {
     @EnvironmentObject var serverManager: ServerManager
     @EnvironmentObject var appState: AppState
     @State private var isReloading = false
+    @State private var showOAuth = false
 
     var topInset: CGFloat = 0
 
@@ -40,6 +41,9 @@ struct HeaderView: View {
                 } label: {
                     VStack(spacing: 2) {
                         HStack(spacing: 6) {
+                            Circle()
+                                .fill(authDotColor)
+                                .frame(width: 6, height: 6)
                             Text(sessionModelLabel)
                                 .foregroundColor(.white)
                             Text(sessionReasoningLabel)
@@ -114,7 +118,54 @@ struct HeaderView: View {
             syncSelectionFromActiveThread()
             await loadModelsIfNeeded()
         }
+        .onChange(of: activeConn?.oauthURL) { _, url in
+            showOAuth = url != nil
+        }
+        .onChange(of: activeConn?.loginCompleted) { _, completed in
+            if completed == true {
+                showOAuth = false
+                activeConn?.loginCompleted = false
+                Task {
+                    await serverManager.refreshAllSessions()
+                    await serverManager.syncActiveThreadFromServer()
+                    syncSelectionFromActiveThread()
+                }
+            }
+        }
+        .sheet(isPresented: $showOAuth) {
+            if let conn = activeConn, let url = conn.oauthURL {
+                NavigationStack {
+                    OAuthWebView(url: url, onCallbackIntercepted: { callbackURL in
+                        conn.forwardOAuthCallback(callbackURL)
+                    }) {
+                        Task { await conn.cancelLogin() }
+                    }
+                    .ignoresSafeArea()
+                    .navigationTitle("Login with ChatGPT")
+                    .navigationBarTitleDisplayMode(.inline)
+                    .toolbarColorScheme(.dark, for: .navigationBar)
+                    .toolbar {
+                        ToolbarItem(placement: .topBarLeading) {
+                            Button("Cancel") {
+                                Task { await conn.cancelLogin() }
+                                showOAuth = false
+                            }
+                            .foregroundColor(Color(hex: "#FF5555"))
+                        }
+                    }
+                }
+            }
+        }
         .enableInjection()
+    }
+
+    private var authDotColor: Color {
+        let conn = activeConn ?? serverManager.connections.values.first(where: { $0.isConnected })
+        switch conn?.authStatus {
+        case .chatgpt, .apiKey: return LitterTheme.accentStrong
+        case .notLoggedIn: return LitterTheme.danger
+        case .unknown, .none: return LitterTheme.textMuted
+        }
     }
 
     private var sessionModelLabel: String {
@@ -219,9 +270,15 @@ struct HeaderView: View {
         Button {
             Task {
                 isReloading = true
-                await serverManager.refreshAllSessions()
-                await serverManager.syncActiveThreadFromServer()
-                syncSelectionFromActiveThread()
+                let conn = activeConn ?? serverManager.connections.values.first(where: { $0.isConnected })
+                if conn?.authStatus == .notLoggedIn {
+                    await conn?.logout()
+                    await conn?.loginWithChatGPT()
+                } else {
+                    await serverManager.refreshAllSessions()
+                    await serverManager.syncActiveThreadFromServer()
+                    syncSelectionFromActiveThread()
+                }
                 isReloading = false
             }
         } label: {

--- a/apps/ios/Sources/Litter/Views/SafariView.swift
+++ b/apps/ios/Sources/Litter/Views/SafariView.swift
@@ -1,27 +1,52 @@
 import SwiftUI
-import SafariServices
-import UIKit
+import WebKit
 
-struct SafariView: UIViewControllerRepresentable {
+struct OAuthWebView: UIViewRepresentable {
     let url: URL
+    var onCallbackIntercepted: ((URL) -> Void)?
     var onDismiss: (() -> Void)?
 
-    func makeUIViewController(context: Context) -> SFSafariViewController {
-        let vc = SFSafariViewController(url: url)
-        vc.delegate = context.coordinator
-        return vc
+    func makeUIView(context: Context) -> WKWebView {
+        let webView = WKWebView()
+        webView.navigationDelegate = context.coordinator
+        webView.isOpaque = false
+        webView.backgroundColor = .black
+        webView.scrollView.backgroundColor = .black
+        webView.load(URLRequest(url: url))
+        return webView
     }
 
-    func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) {}
+    func updateUIView(_ uiView: WKWebView, context: Context) {}
 
-    func makeCoordinator() -> Coordinator { Coordinator(onDismiss: onDismiss) }
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onCallbackIntercepted: onCallbackIntercepted, onDismiss: onDismiss)
+    }
 
-    final class Coordinator: NSObject, SFSafariViewControllerDelegate {
+    final class Coordinator: NSObject, WKNavigationDelegate {
+        let onCallbackIntercepted: ((URL) -> Void)?
         let onDismiss: (() -> Void)?
-        init(onDismiss: (() -> Void)?) { self.onDismiss = onDismiss }
+        init(onCallbackIntercepted: ((URL) -> Void)?, onDismiss: (() -> Void)?) {
+            self.onCallbackIntercepted = onCallbackIntercepted
+            self.onDismiss = onDismiss
+        }
 
-        func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
-            onDismiss?()
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+        ) {
+            if let url = navigationAction.request.url,
+               (url.host == "localhost" || url.host == "127.0.0.1"),
+               url.path.contains("/auth/callback") {
+                decisionHandler(.cancel)
+                if let handler = onCallbackIntercepted {
+                    handler(url)
+                } else {
+                    Task { _ = try? await URLSession.shared.data(from: url) }
+                }
+                return
+            }
+            decisionHandler(.allow)
         }
     }
 }

--- a/apps/ios/Sources/Litter/Views/SessionSidebarView.swift
+++ b/apps/ios/Sources/Litter/Views/SessionSidebarView.swift
@@ -253,8 +253,6 @@ struct SessionSidebarView: View {
                 }
             }
 
-            Divider().background(LitterTheme.separator)
-            settingsRow
         }
         .accessibilityIdentifier("sidebar.container")
     }
@@ -333,42 +331,38 @@ struct SessionSidebarView: View {
         return ids.first
     }
 
-    private var settingsRow: some View {
-        Button { showSettings = true } label: {
-            HStack(spacing: 10) {
-                Image(systemName: "gear")
-                    .foregroundColor(LitterTheme.textSecondary)
-                    .frame(width: 20)
-                Text("Settings")
-                    .font(LitterFont.monospaced(.footnote))
-                    .foregroundColor(LitterTheme.textSecondary)
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 14)
-        }
-    }
-
     private var newSessionButton: some View {
-        Button {
-            if let defaultServerId = defaultNewSessionServerId() {
-                directoryPickerSheet = DirectoryPickerSheetModel(selectedServerId: defaultServerId)
-            } else {
-                appState.showServerPicker = true
-            }
-        } label: {
-            HStack {
-                Image(systemName: "plus")
+        HStack(spacing: 10) {
+            Button { showSettings = true } label: {
+                Image(systemName: "gear")
                     .font(.system(.subheadline, weight: .medium))
-                Text("New Session")
-                    .font(LitterFont.monospaced(.subheadline))
+                    .foregroundColor(LitterTheme.textSecondary)
+                    .frame(width: 44, height: 44)
+                    .modifier(GlassRectModifier(cornerRadius: 10))
             }
-            .foregroundColor(.black)
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 12)
-            .background(LitterTheme.accent)
-            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .accessibilityIdentifier("sidebar.settingsButton")
+
+            Button {
+                if let defaultServerId = defaultNewSessionServerId() {
+                    directoryPickerSheet = DirectoryPickerSheetModel(selectedServerId: defaultServerId)
+                } else {
+                    appState.showServerPicker = true
+                }
+            } label: {
+                HStack {
+                    Image(systemName: "plus")
+                        .font(.system(.subheadline, weight: .medium))
+                    Text("New Session")
+                        .font(LitterFont.monospaced(.subheadline))
+                }
+                .foregroundColor(.black)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .background(LitterTheme.accent)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+            .accessibilityIdentifier("sidebar.newSessionButton")
         }
-        .accessibilityIdentifier("sidebar.newSessionButton")
         .padding(16)
     }
 

--- a/apps/ios/Sources/Litter/Views/SettingsView.swift
+++ b/apps/ios/Sources/Litter/Views/SettingsView.swift
@@ -198,7 +198,9 @@ struct SettingsView: View {
     private var oauthSheet: some View {
         if let url = conn?.oauthURL {
             NavigationStack {
-                SafariView(url: url) {
+                OAuthWebView(url: url, onCallbackIntercepted: { callbackURL in
+                    conn?.forwardOAuthCallback(callbackURL)
+                }) {
                     Task { await conn?.cancelLogin() }
                 }
                 .ignoresSafeArea()


### PR DESCRIPTION
## Summary
- Fix keyboard/input bar gap by switching to `.ignoresSafeArea(.container)` and tracking keyboard height
- Replace `SFSafariViewController` with `WKWebView` for OAuth — intercepts localhost callback redirects and forwards them to remote servers via `command/exec` curl (`-L` to follow redirects)
- Add auth status dot (green/red/gray) in header next to model name
- Refresh button triggers logout→login when auth is red
- Stop codex server on removal (local via `CodexBridge.stop()`, SSH via tracked PID)
- Move settings gear button next to "New Session" in sidebar

## Test plan
- [ ] Open a session, verify keyboard doesn't leave a gap between input bar and keyboard
- [ ] Connect to a remote server, login via ChatGPT OAuth, verify callback completes and auth dot turns green
- [ ] With auth dot red, tap refresh — verify it triggers logout→login flow
- [ ] Remove a server from settings, verify the server process is stopped
- [ ] Verify gear button in sidebar opens settings