### PR TITLE
ios: light mode, font family setting, code block scaling

### DIFF
--- a/apps/ios/Sources/Litter/Extensions.swift
+++ b/apps/ios/Sources/Litter/Extensions.swift
@@ -13,30 +13,56 @@ extension Color {
     }
 }
 
+extension UIColor {
+    convenience init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let r = CGFloat((int >> 16) & 0xFF) / 255
+        let g = CGFloat((int >> 8) & 0xFF) / 255
+        let b = CGFloat(int & 0xFF) / 255
+        self.init(red: r, green: g, blue: b, alpha: 1)
+    }
+}
+
 // MARK: - Central Theme
 
 enum LitterTheme {
-    static let accent       = Color(hex: "#B0B0B0")
-    static let accentStrong = Color(hex: "#00FF9C")
-    static let textPrimary  = Color.white
-    static let textSecondary = Color(hex: "#888888")
-    static let textMuted    = Color(hex: "#555555")
-    static let textBody     = Color(hex: "#E0E0E0")
-    static let textSystem   = Color(hex: "#C6D0CA")
-    static let surface      = Color(hex: "#1A1A1A")
-    static let surfaceLight = Color(hex: "#2A2A2A")
-    static let border       = Color(hex: "#333333")
-    static let separator    = Color(hex: "#1E1E1E")
-    static let danger       = Color(hex: "#FF5555")
-    static let success      = Color(hex: "#6EA676")
-    static let warning      = Color(hex: "#E2A644")
-    static let overlayScrim = Color.black.opacity(0.5)
+    static func adaptive(light: String, dark: String) -> Color {
+        Color(uiColor: UIColor { $0.userInterfaceStyle == .dark ? UIColor(hex: dark) : UIColor(hex: light) })
+    }
 
-    static let gradientColors: [Color] = [
-        Color(hex: "#0A0A0A"),
-        Color(hex: "#0F0F0F"),
-        Color(hex: "#080808")
-    ]
+    static let accent        = adaptive(light: "#4A4A4A", dark: "#B0B0B0")
+    static let accentStrong  = adaptive(light: "#00995D", dark: "#00FF9C")
+    static let textPrimary   = adaptive(light: "#1A1A1A", dark: "#FFFFFF")
+    static let textSecondary = adaptive(light: "#6B6B6B", dark: "#888888")
+    static let textMuted     = adaptive(light: "#9E9E9E", dark: "#555555")
+    static let textBody      = adaptive(light: "#2D2D2D", dark: "#E0E0E0")
+    static let textSystem    = adaptive(light: "#3A4A3F", dark: "#C6D0CA")
+    static let surface       = adaptive(light: "#F2F2F7", dark: "#1A1A1A")
+    static let surfaceLight  = adaptive(light: "#E5E5EA", dark: "#2A2A2A")
+    static let border        = adaptive(light: "#D1D1D6", dark: "#333333")
+    static let separator     = adaptive(light: "#E0E0E0", dark: "#1E1E1E")
+    static let danger        = adaptive(light: "#D32F2F", dark: "#FF5555")
+    static let success       = adaptive(light: "#2E7D32", dark: "#6EA676")
+    static let warning       = adaptive(light: "#E65100", dark: "#E2A644")
+    static let textOnAccent  = adaptive(light: "#FFFFFF", dark: "#0D0D0D")
+    static let codeBackground = adaptive(light: "#F0F0F5", dark: "#111111")
+
+    static let overlayScrim: Color = Color(uiColor: UIColor { traits in
+        traits.userInterfaceStyle == .dark
+            ? UIColor.black.withAlphaComponent(0.5)
+            : UIColor.black.withAlphaComponent(0.3)
+    })
+
+    static var gradientColors: [Color] {
+        let isDark = UITraitCollection.current.userInterfaceStyle == .dark
+        if isDark {
+            return [Color(hex: "#0A0A0A"), Color(hex: "#0F0F0F"), Color(hex: "#080808")]
+        } else {
+            return [Color(hex: "#FFFFFF"), Color(hex: "#F8F8FA"), Color(hex: "#F5F5F7")]
+        }
+    }
 
     static var backgroundGradient: LinearGradient {
         LinearGradient(
@@ -45,14 +71,62 @@ enum LitterTheme {
             endPoint: .bottomTrailing
         )
     }
+
+    static var headerScrim: [Color] {
+        let isDark = UITraitCollection.current.userInterfaceStyle == .dark
+        if isDark {
+            return [.black.opacity(0.5), .black.opacity(0.2), .clear]
+        } else {
+            return [.white.opacity(0.7), .white.opacity(0.3), .clear]
+        }
+    }
+}
+
+enum FontFamilyOption: String, CaseIterable, Identifiable {
+    case mono = "mono"
+    case system = "system"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .mono: return "Monospaced"
+        case .system: return "System (SF Pro)"
+        }
+    }
+
+    var isMono: Bool { self == .mono }
 }
 
 enum LitterFont {
     private static let berkeleyRegular = "BerkeleyMono-Regular"
     private static let berkeleyBold = "BerkeleyMono-Bold"
 
+    static var storedFamily: FontFamilyOption {
+        let raw = UserDefaults.standard.string(forKey: "fontFamily") ?? "mono"
+        return FontFamilyOption(rawValue: raw) ?? .mono
+    }
+
     static var markdownFontName: String {
-        preferredFontName(weight: .regular) ?? "SFMono-Regular"
+        switch storedFamily {
+        case .mono:
+            return preferredMonoFontName(weight: .regular) ?? "SFMono-Regular"
+        case .system:
+            return ".AppleSystemUIFont"
+        }
+    }
+
+    static func styled(
+        _ style: Font.TextStyle,
+        weight: Font.Weight = .regular,
+        scale: CGFloat = 1.0
+    ) -> Font {
+        let pointSize = UIFont.preferredFont(forTextStyle: style.uiTextStyle).pointSize * scale
+        return styled(size: pointSize, weight: weight, relativeTo: style)
+    }
+
+    static func styled(size: CGFloat, weight: Font.Weight = .regular, scale: CGFloat = 1.0) -> Font {
+        styled(size: size * scale, weight: weight, relativeTo: nil)
     }
 
     static func monospaced(
@@ -61,15 +135,25 @@ enum LitterFont {
         scale: CGFloat = 1.0
     ) -> Font {
         let pointSize = UIFont.preferredFont(forTextStyle: style.uiTextStyle).pointSize * scale
-        return monospaced(size: pointSize, weight: weight, relativeTo: style)
+        return monoFont(size: pointSize, weight: weight, relativeTo: style)
     }
 
     static func monospaced(size: CGFloat, weight: Font.Weight = .regular, scale: CGFloat = 1.0) -> Font {
-        monospaced(size: size * scale, weight: weight, relativeTo: nil)
+        monoFont(size: size * scale, weight: weight, relativeTo: nil)
     }
 
-    private static func monospaced(size: CGFloat, weight: Font.Weight, relativeTo style: Font.TextStyle?) -> Font {
-        if let fontName = preferredFontName(weight: weight) {
+    private static func styled(size: CGFloat, weight: Font.Weight, relativeTo style: Font.TextStyle?) -> Font {
+        if storedFamily.isMono {
+            return monoFont(size: size, weight: weight, relativeTo: style)
+        }
+        if let style {
+            return .system(style, weight: weight)
+        }
+        return .system(size: size, weight: weight)
+    }
+
+    private static func monoFont(size: CGFloat, weight: Font.Weight, relativeTo style: Font.TextStyle?) -> Font {
+        if let fontName = preferredMonoFontName(weight: weight) {
             if let style {
                 return .custom(fontName, size: size, relativeTo: style)
             }
@@ -81,7 +165,7 @@ enum LitterFont {
         return .system(size: size, weight: weight, design: .monospaced)
     }
 
-    private static func preferredFontName(weight: Font.Weight) -> String? {
+    private static func preferredMonoFontName(weight: Font.Weight) -> String? {
         let preferred = isBold(weight: weight) ? berkeleyBold : berkeleyRegular
         if UIFont(name: preferred, size: 12) != nil {
             return preferred
@@ -99,6 +183,20 @@ enum LitterFont {
         default:
             return false
         }
+    }
+
+    static func uiMonoFont(size: CGFloat, bold: Bool = false) -> UIFont {
+        let name = bold
+            ? preferredMonoFontName(weight: .bold) ?? "SFMono-Bold"
+            : preferredMonoFontName(weight: .regular) ?? "SFMono-Regular"
+        return UIFont(name: name, size: size) ?? UIFont.monospacedSystemFont(ofSize: size, weight: bold ? .bold : .regular)
+    }
+
+    static func sampleFont(family: FontFamilyOption, size: CGFloat, weight: Font.Weight = .regular) -> Font {
+        if family.isMono {
+            return monoFont(size: size, weight: weight, relativeTo: nil)
+        }
+        return .system(size: size, weight: weight)
     }
 }
 
@@ -166,11 +264,11 @@ struct GlassRectModifier: ViewModifier {
             }
         } else {
             content
-                .background(LitterTheme.surface.opacity(0.9))
+                .background(LitterTheme.surfaceLight.opacity(0.9))
                 .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
                 .overlay(
                     RoundedRectangle(cornerRadius: cornerRadius)
-                        .stroke((tint ?? LitterTheme.surfaceLight).opacity(0.4), lineWidth: 1)
+                        .stroke((tint ?? LitterTheme.border).opacity(0.4), lineWidth: 1)
                 )
         }
     }

--- a/apps/ios/Sources/Litter/LitterApp.swift
+++ b/apps/ios/Sources/Litter/LitterApp.swift
@@ -11,7 +11,6 @@ struct LitterApp: App {
         WindowGroup {
             ContentView()
                 .environmentObject(serverManager)
-                .preferredColorScheme(.dark)
                 .task { await serverManager.reconnectAll() }
         }
     }
@@ -103,7 +102,6 @@ struct ContentView: View {
                 })
                 .environmentObject(serverManager)
             }
-            .preferredColorScheme(.dark)
         }
     }
 
@@ -172,7 +170,6 @@ private struct HomeNavigationView: View {
                 SessionSidebarView()
                     .navigationTitle("Sessions")
                     .navigationBarTitleDisplayMode(.inline)
-                    .toolbarColorScheme(.dark, for: .navigationBar)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .background(LitterTheme.backgroundGradient.ignoresSafeArea())
             }
@@ -215,29 +212,29 @@ private struct ApprovalPromptView: View {
 
             VStack(alignment: .leading, spacing: 12) {
                 Text(title)
-                    .font(LitterFont.monospaced(.headline))
+                    .font(LitterFont.styled(.headline))
                     .foregroundColor(LitterTheme.textPrimary)
 
                 if let reason = approval.reason, !reason.isEmpty {
                     Text(reason)
-                        .font(LitterFont.monospaced(.footnote))
+                        .font(LitterFont.styled(.footnote))
                         .foregroundColor(LitterTheme.textSecondary)
                 }
 
                 if let requesterLabel {
                     Text("Requester: \(requesterLabel)")
-                        .font(LitterFont.monospaced(.caption))
+                        .font(LitterFont.styled(.caption))
                         .foregroundColor(LitterTheme.textMuted)
                 }
 
                 if let command = approval.command, !command.isEmpty {
                     VStack(alignment: .leading, spacing: 6) {
                         Text("Command")
-                            .font(LitterFont.monospaced(.caption))
+                            .font(LitterFont.styled(.caption))
                             .foregroundColor(LitterTheme.textMuted)
                         ScrollView(.horizontal, showsIndicators: false) {
                             Text(command)
-                                .font(LitterFont.monospaced(.footnote))
+                                .font(LitterFont.styled(.footnote))
                                 .foregroundColor(LitterTheme.textBody)
                                 .padding(10)
                                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -249,13 +246,13 @@ private struct ApprovalPromptView: View {
 
                 if let cwd = approval.cwd, !cwd.isEmpty {
                     Text("CWD: \(cwd)")
-                        .font(LitterFont.monospaced(.caption))
+                        .font(LitterFont.styled(.caption))
                         .foregroundColor(LitterTheme.textMuted)
                 }
 
                 if let grantRoot = approval.grantRoot, !grantRoot.isEmpty {
                     Text("Grant Root: \(grantRoot)")
-                        .font(LitterFont.monospaced(.caption))
+                        .font(LitterFont.styled(.caption))
                         .foregroundColor(LitterTheme.textMuted)
                 }
 
@@ -280,7 +277,7 @@ private struct ApprovalPromptView: View {
                             .frame(maxWidth: .infinity)
                     }
                 }
-                .font(LitterFont.monospaced(.callout))
+                .font(LitterFont.styled(.callout))
             }
             .padding(16)
             .modifier(GlassRectModifier(cornerRadius: 14))
@@ -301,7 +298,7 @@ struct LaunchView: View {
             VStack(spacing: 24) {
                 BrandLogo(size: 132)
                 Text("AI coding agent on iOS")
-                    .font(LitterFont.monospaced(.body))
+                    .font(LitterFont.styled(.body))
                     .foregroundColor(LitterTheme.textMuted)
             }
         }

--- a/apps/ios/Sources/Litter/Views/AccountView.swift
+++ b/apps/ios/Sources/Litter/Views/AccountView.swift
@@ -35,7 +35,6 @@ struct AccountView: View {
             }
             .navigationTitle("Account")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbarColorScheme(.dark, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") { dismiss() }
@@ -43,7 +42,6 @@ struct AccountView: View {
                 }
             }
         }
-        .preferredColorScheme(.dark)
         .sheet(isPresented: $showOAuth) {
             oauthSheet
         }
@@ -61,7 +59,7 @@ struct AccountView: View {
     private var currentAccountSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("CURRENT ACCOUNT")
-                .font(LitterFont.monospaced(.caption))
+                .font(LitterFont.styled(.caption))
                 .foregroundColor(LitterTheme.textMuted)
                 .padding(.horizontal, 20)
 
@@ -71,11 +69,11 @@ struct AccountView: View {
                     .frame(width: 10, height: 10)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(authTitle)
-                        .font(LitterFont.monospaced(.subheadline))
-                        .foregroundColor(.white)
+                        .font(LitterFont.styled(.subheadline))
+                        .foregroundColor(LitterTheme.textPrimary)
                     if let sub = authSubtitle {
                         Text(sub)
-                            .font(LitterFont.monospaced(.caption))
+                            .font(LitterFont.styled(.caption))
                             .foregroundColor(LitterTheme.textSecondary)
                     }
                 }
@@ -84,8 +82,8 @@ struct AccountView: View {
                     Button("Logout") {
                         Task { await conn?.logout() }
                     }
-                    .font(LitterFont.monospaced(.footnote))
-                    .foregroundColor(Color(hex: "#FF5555"))
+                    .font(LitterFont.styled(.footnote))
+                    .foregroundColor(LitterTheme.danger)
                 }
             }
             .padding(.horizontal, 20)
@@ -99,7 +97,7 @@ struct AccountView: View {
     private var loginSection: some View {
         VStack(alignment: .leading, spacing: 16) {
             Text("LOGIN")
-                .font(LitterFont.monospaced(.caption))
+                .font(LitterFont.styled(.caption))
                 .foregroundColor(LitterTheme.textMuted)
                 .padding(.horizontal, 20)
 
@@ -113,13 +111,13 @@ struct AccountView: View {
             } label: {
                 HStack {
                     if isWorking {
-                        ProgressView().tint(Color(hex: "#0D0D0D")).scaleEffect(0.8)
+                        ProgressView().tint(LitterTheme.textOnAccent).scaleEffect(0.8)
                     }
                     Image(systemName: "person.crop.circle.badge.checkmark")
                     Text("Login with ChatGPT")
-                        .font(LitterFont.monospaced(.subheadline))
+                        .font(LitterFont.styled(.subheadline))
                 }
-                .foregroundColor(Color(hex: "#0D0D0D"))
+                .foregroundColor(LitterTheme.textOnAccent)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 14)
                 .background(LitterTheme.accent)
@@ -129,14 +127,14 @@ struct AccountView: View {
             .disabled(isWorking)
 
             Text("— or use an API key —")
-                .font(LitterFont.monospaced(.caption))
+                .font(LitterFont.styled(.caption))
                 .foregroundColor(LitterTheme.textMuted)
                 .frame(maxWidth: .infinity)
 
             VStack(alignment: .leading, spacing: 8) {
                 SecureField("sk-...", text: $apiKey)
-                    .font(LitterFont.monospaced(.subheadline))
-                    .foregroundColor(.white)
+                    .font(LitterFont.styled(.subheadline))
+                    .foregroundColor(LitterTheme.textPrimary)
                     .padding(12)
                     .background(LitterTheme.surface)
                     .cornerRadius(8)
@@ -154,7 +152,7 @@ struct AccountView: View {
                     }
                 } label: {
                     Text("Save API Key")
-                        .font(LitterFont.monospaced(.subheadline))
+                        .font(LitterFont.styled(.subheadline))
                         .foregroundColor(LitterTheme.accent)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 12)
@@ -181,14 +179,13 @@ struct AccountView: View {
                 .ignoresSafeArea()
                 .navigationTitle("Login with ChatGPT")
                 .navigationBarTitleDisplayMode(.inline)
-                .toolbarColorScheme(.dark, for: .navigationBar)
                 .toolbar {
                     ToolbarItem(placement: .topBarLeading) {
                         Button("Cancel") {
                             Task { await conn?.cancelLogin() }
                             showOAuth = false
                         }
-                        .foregroundColor(Color(hex: "#FF5555"))
+                        .foregroundColor(LitterTheme.danger)
                     }
                 }
             }

--- a/apps/ios/Sources/Litter/Views/BrandLogo.swift
+++ b/apps/ios/Sources/Litter/Views/BrandLogo.swift
@@ -30,6 +30,5 @@ struct BrandLogo: View {
         LitterTheme.backgroundGradient.ignoresSafeArea()
         BrandLogo(size: 128)
     }
-    .preferredColorScheme(.dark)
 }
 #endif

--- a/apps/ios/Sources/Litter/Views/CodeBlockView.swift
+++ b/apps/ios/Sources/Litter/Views/CodeBlockView.swift
@@ -5,6 +5,7 @@ import Highlightr
 struct CodeBlockView: View {
     let language: String
     let code: String
+    var fontSize: CGFloat = 13
     @State private var copied = false
 
     var body: some View {
@@ -38,20 +39,20 @@ struct CodeBlockView: View {
 
             ScrollView(.horizontal, showsIndicators: false) {
                 Group {
-                    if let highlighted = CodeBlockHighlighter.shared.highlight(code: code, language: language) {
+                    if let highlighted = CodeBlockHighlighter.shared.highlight(code: code, language: language, fontSize: fontSize) {
                         Text(highlighted)
                             .textSelection(.enabled)
                     } else {
                         Text(code)
-                            .font(LitterFont.monospaced(.footnote))
-                            .foregroundColor(Color(hex: "#CCCCCC"))
+                            .font(LitterFont.monospaced(size: fontSize))
+                            .foregroundColor(LitterTheme.textBody)
                             .textSelection(.enabled)
                     }
                 }
                 .padding(12)
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .background(Color(hex: "#111111").opacity(0.8))
+            .background(LitterTheme.codeBackground.opacity(0.8))
         }
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .modifier(GlassRectModifier(cornerRadius: 8))
@@ -62,38 +63,57 @@ struct CodeBlockView: View {
 private final class CodeBlockHighlighter {
     static let shared = CodeBlockHighlighter()
 
-    private let highlightr: Highlightr? = {
-        let highlighter = Highlightr()
-        highlighter?.setTheme(to: "atom-one-dark")
-        return highlighter
+    private let darkHighlightr: Highlightr? = {
+        let h = Highlightr()
+        h?.setTheme(to: "atom-one-dark")
+        return h
     }()
-    private var cache: [String: AttributedString] = [:]
+    private let lightHighlightr: Highlightr? = {
+        let h = Highlightr()
+        h?.setTheme(to: "atom-one-light")
+        return h
+    }()
+    private var cache: [Int: AttributedString] = [:]
 
-    func highlight(code: String, language: String) -> AttributedString? {
-        let key = cacheKey(code: code, language: language)
+    func highlight(code: String, language: String, fontSize: CGFloat) -> AttributedString? {
+        let isDark = UITraitCollection.current.userInterfaceStyle == .dark
+        let key = cacheKey(code: code, language: language, isDark: isDark, fontSize: fontSize)
         if let cached = cache[key] {
             return cached
         }
-        guard let highlightr else { return nil }
+        guard let highlightr = isDark ? darkHighlightr : lightHighlightr else { return nil }
         let normalized = language.trimmingCharacters(in: .whitespacesAndNewlines)
         let attributed = highlightr.highlight(code, as: normalized.isEmpty ? nil : normalized)
         guard let attributed else { return nil }
-        guard let rendered = try? AttributedString(attributed, including: \.uiKit) else {
+        let scaled = NSMutableAttributedString(attributedString: attributed)
+        let monoFont = LitterFont.uiMonoFont(size: fontSize)
+        scaled.enumerateAttribute(.font, in: NSRange(location: 0, length: scaled.length)) { value, range, _ in
+            if let existing = value as? UIFont {
+                let traits = existing.fontDescriptor.symbolicTraits
+                if traits.contains(.traitBold) {
+                    scaled.addAttribute(.font, value: LitterFont.uiMonoFont(size: fontSize, bold: true), range: range)
+                } else {
+                    scaled.addAttribute(.font, value: monoFont, range: range)
+                }
+            }
+        }
+        guard let rendered = try? AttributedString(scaled, including: \.uiKit) else {
             return nil
         }
         cache[key] = rendered
-        if cache.count > 256 {
+        if cache.count > 512 {
             cache.removeAll(keepingCapacity: true)
         }
         return rendered
     }
 
-    private func cacheKey(code: String, language: String) -> String {
-        let normalized = language.trimmingCharacters(in: .whitespacesAndNewlines)
+    private func cacheKey(code: String, language: String, isDark: Bool, fontSize: CGFloat) -> Int {
         var hasher = Hasher()
-        hasher.combine(normalized)
+        hasher.combine(language.trimmingCharacters(in: .whitespacesAndNewlines))
         hasher.combine(code)
-        return "\(hasher.finalize())"
+        hasher.combine(isDark)
+        hasher.combine(fontSize)
+        return hasher.finalize()
     }
 }
 
@@ -115,6 +135,5 @@ private final class CodeBlockHighlighter {
         )
         .padding(20)
     }
-    .preferredColorScheme(.dark)
 }
 #endif

--- a/apps/ios/Sources/Litter/Views/ConversationView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationView.swift
@@ -426,9 +426,9 @@ private struct ScrollToBottomIndicator: View {
                     .font(.system(.caption, weight: .bold))
                     .offset(y: bob ? 1.5 : -1.5)
                 Text("Latest")
-                    .font(LitterFont.monospaced(.caption, weight: .semibold))
+                    .font(LitterFont.styled(.caption, weight: .semibold))
             }
-            .foregroundColor(.white)
+            .foregroundColor(LitterTheme.textPrimary)
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
             .modifier(GlassCapsuleModifier())
@@ -689,8 +689,8 @@ private struct ConversationInputBar: View {
                             VStack(alignment: .leading, spacing: 4) {
                                 HStack {
                                     Text(preset.title)
-                                        .foregroundColor(.white)
-                                        .font(LitterFont.monospaced(.subheadline))
+                                        .foregroundColor(LitterTheme.textPrimary)
+                                        .font(LitterFont.styled(.subheadline))
                                     Spacer()
                                     if preset.approvalPolicy == appState.approvalPolicy && preset.sandboxMode == appState.sandboxMode {
                                         Image(systemName: "checkmark")
@@ -699,7 +699,7 @@ private struct ConversationInputBar: View {
                                 }
                                 Text(preset.description)
                                     .foregroundColor(LitterTheme.textSecondary)
-                                    .font(LitterFont.monospaced(.caption))
+                                    .font(LitterFont.styled(.caption))
                             }
                         }
                         .listRowBackground(LitterTheme.surface.opacity(0.6))
@@ -716,7 +716,6 @@ private struct ConversationInputBar: View {
                     }
                 }
             }
-            .preferredColorScheme(.dark)
         }
         .sheet(isPresented: $showExperimentalSheet) {
             NavigationStack {
@@ -725,7 +724,7 @@ private struct ConversationInputBar: View {
                         ProgressView().tint(LitterTheme.accent)
                     } else if experimentalFeatures.isEmpty {
                         Text("No experimental features available")
-                            .font(LitterFont.monospaced(.footnote))
+                            .font(LitterFont.styled(.footnote))
                             .foregroundColor(LitterTheme.textMuted)
                     } else {
                         List {
@@ -733,10 +732,10 @@ private struct ConversationInputBar: View {
                                 HStack(alignment: .top, spacing: 10) {
                                     VStack(alignment: .leading, spacing: 4) {
                                         Text(feature.displayName ?? feature.name)
-                                            .font(LitterFont.monospaced(.subheadline))
-                                            .foregroundColor(.white)
+                                            .font(LitterFont.styled(.subheadline))
+                                            .foregroundColor(LitterTheme.textPrimary)
                                         Text(feature.description ?? feature.stage)
-                                            .font(LitterFont.monospaced(.caption))
+                                            .font(LitterFont.styled(.caption))
                                             .foregroundColor(LitterTheme.textSecondary)
                                     }
                                     Spacer(minLength: 0)
@@ -773,7 +772,6 @@ private struct ConversationInputBar: View {
                     }
                 }
             }
-            .preferredColorScheme(.dark)
         }
         .sheet(isPresented: $showSkillsSheet) {
             NavigationStack {
@@ -782,7 +780,7 @@ private struct ConversationInputBar: View {
                         ProgressView().tint(LitterTheme.accent)
                     } else if skills.isEmpty {
                         Text("No skills available for this workspace")
-                            .font(LitterFont.monospaced(.footnote))
+                            .font(LitterFont.styled(.footnote))
                             .foregroundColor(LitterTheme.textMuted)
                     } else {
                         List {
@@ -790,20 +788,20 @@ private struct ConversationInputBar: View {
                                 VStack(alignment: .leading, spacing: 4) {
                                     HStack {
                                         Text(skill.name)
-                                            .font(LitterFont.monospaced(.subheadline))
-                                            .foregroundColor(.white)
+                                            .font(LitterFont.styled(.subheadline))
+                                            .foregroundColor(LitterTheme.textPrimary)
                                         Spacer()
                                         if skill.enabled {
                                             Text("enabled")
-                                                .font(LitterFont.monospaced(.caption2))
+                                                .font(LitterFont.styled(.caption2))
                                                 .foregroundColor(LitterTheme.accent)
                                         }
                                     }
                                     Text(skill.description)
-                                        .font(LitterFont.monospaced(.caption))
+                                        .font(LitterFont.styled(.caption))
                                         .foregroundColor(LitterTheme.textSecondary)
                                     Text(skill.path)
-                                        .font(LitterFont.monospaced(.caption2))
+                                        .font(LitterFont.styled(.caption2))
                                         .foregroundColor(LitterTheme.textMuted)
                                 }
                                 .listRowBackground(LitterTheme.surface.opacity(0.6))
@@ -827,7 +825,6 @@ private struct ConversationInputBar: View {
                     }
                 }
             }
-            .preferredColorScheme(.dark)
         }
         .alert("Rename Thread", isPresented: Binding(
             get: { showRenamePrompt },
@@ -866,7 +863,7 @@ private struct ConversationInputBar: View {
             Button { showAttachMenu = true } label: {
                 Image(systemName: "plus")
                     .font(.system(.subheadline, weight: .semibold))
-                    .foregroundColor(.white)
+                    .foregroundColor(LitterTheme.textPrimary)
                     .frame(width: 32, height: 32)
                     .modifier(GlassCircleModifier())
             }
@@ -874,7 +871,7 @@ private struct ConversationInputBar: View {
             HStack(spacing: 0) {
                 TextField("Message litter...", text: $inputText, axis: .vertical)
                     .font(.system(.body))
-                    .foregroundColor(.white)
+                    .foregroundColor(LitterTheme.textPrimary)
                     .lineLimit(1...5)
                     .focused(inputFocused)
                     .textInputAutocapitalization(.never)
@@ -935,10 +932,10 @@ private struct ConversationInputBar: View {
                     } label: {
                         HStack(spacing: 10) {
                             Text("/\(command.rawValue)")
-                                .font(LitterFont.monospaced(.body))
-                                .foregroundColor(Color(hex: "#6EA676"))
+                                .font(LitterFont.styled(.body))
+                                .foregroundColor(LitterTheme.success)
                             Text(command.description)
-                                .font(LitterFont.monospaced(.body))
+                                .font(LitterFont.styled(.body))
                                 .foregroundColor(LitterTheme.textSecondary)
                                 .lineLimit(1)
                             Spacer(minLength: 0)
@@ -960,21 +957,21 @@ private struct ConversationInputBar: View {
         suggestionPopup {
             if fileSearchLoading {
                 Text("Searching files...")
-                    .font(LitterFont.monospaced(.footnote))
+                    .font(LitterFont.styled(.footnote))
                     .foregroundColor(LitterTheme.textSecondary)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 12)
                     .padding(.vertical, 10)
             } else if let fileSearchError, !fileSearchError.isEmpty {
                 Text(fileSearchError)
-                    .font(LitterFont.monospaced(.footnote))
+                    .font(LitterFont.styled(.footnote))
                     .foregroundColor(.red)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 12)
                     .padding(.vertical, 10)
             } else if fileSuggestions.isEmpty {
                 Text("No matches")
-                    .font(LitterFont.monospaced(.footnote))
+                    .font(LitterFont.styled(.footnote))
                     .foregroundColor(LitterTheme.textSecondary)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 12)
@@ -990,8 +987,8 @@ private struct ConversationInputBar: View {
                                     .font(.system(.caption))
                                     .foregroundColor(LitterTheme.textSecondary)
                                 Text(suggestion.path)
-                                    .font(LitterFont.monospaced(.footnote))
-                                    .foregroundColor(.white)
+                                    .font(LitterFont.styled(.footnote))
+                                    .foregroundColor(LitterTheme.textPrimary)
                                     .lineLimit(1)
                                 Spacer(minLength: 0)
                             }
@@ -1013,14 +1010,14 @@ private struct ConversationInputBar: View {
         suggestionPopup {
             if skillsLoading && skillSuggestions.isEmpty {
                 Text("Loading skills...")
-                    .font(LitterFont.monospaced(.footnote))
+                    .font(LitterFont.styled(.footnote))
                     .foregroundColor(LitterTheme.textSecondary)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 12)
                     .padding(.vertical, 10)
             } else if skillSuggestions.isEmpty {
                 Text("No skills found")
-                    .font(LitterFont.monospaced(.footnote))
+                    .font(LitterFont.styled(.footnote))
                     .foregroundColor(LitterTheme.textSecondary)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 12)
@@ -1033,10 +1030,10 @@ private struct ConversationInputBar: View {
                         } label: {
                             HStack(spacing: 8) {
                                 Text("$\(skill.name)")
-                                    .font(LitterFont.monospaced(.footnote))
-                                    .foregroundColor(Color(hex: "#6EA676"))
+                                    .font(LitterFont.styled(.footnote))
+                                    .foregroundColor(LitterTheme.success)
                                 Text(skill.description)
-                                    .font(LitterFont.monospaced(.footnote))
+                                    .font(LitterFont.styled(.footnote))
                                     .foregroundColor(LitterTheme.textSecondary)
                                     .lineLimit(1)
                                 Spacer(minLength: 0)
@@ -1915,6 +1912,5 @@ struct CameraView: UIViewControllerRepresentable {
 #Preview("Conversation") {
     ContentView()
         .environmentObject(LitterPreviewData.makeServerManager(messages: LitterPreviewData.longConversation))
-        .preferredColorScheme(.dark)
 }
 #endif

--- a/apps/ios/Sources/Litter/Views/DirectoryPickerView.swift
+++ b/apps/ios/Sources/Litter/Views/DirectoryPickerView.swift
@@ -383,7 +383,6 @@ struct DirectoryPickerView: View {
         }
         .navigationTitle(DirectoryPickerStrings.title)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarColorScheme(.dark, for: .navigationBar)
         .interactiveDismissDisabled(model.canNavigateUp)
         .task(id: selectedServerId) {
             onServerChanged?(selectedServerId)
@@ -421,7 +420,7 @@ struct DirectoryPickerView: View {
                             DirectoryPickerStrings.noServerSelected
                     )
                 )
-                .font(LitterFont.monospaced(.caption))
+                .font(LitterFont.styled(.caption))
                 .foregroundColor(selectedServerOption == nil ? LitterTheme.textMuted : LitterTheme.textSecondary)
                 .lineLimit(1)
 
@@ -435,7 +434,7 @@ struct DirectoryPickerView: View {
                             }
                         }
                     }
-                    .font(LitterFont.monospaced(.caption))
+                    .font(LitterFont.styled(.caption))
                     .foregroundColor(LitterTheme.accent)
                 }
 
@@ -459,8 +458,8 @@ struct DirectoryPickerView: View {
                     DirectoryPickerStrings.searchFolders,
                     text: $model.searchQuery
                 )
-                .font(LitterFont.monospaced(.caption))
-                .foregroundColor(.white)
+                .font(LitterFont.styled(.caption))
+                .foregroundColor(LitterTheme.textPrimary)
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled(true)
 
@@ -494,7 +493,7 @@ struct DirectoryPickerView: View {
                         }
                     } label: {
                         Label(DirectoryPickerStrings.upOneLevel, systemImage: "arrow.up.backward")
-                            .font(LitterFont.monospaced(.caption))
+                            .font(LitterFont.styled(.caption))
                     }
                     .disabled(!model.canNavigateUp)
 
@@ -509,8 +508,8 @@ struct DirectoryPickerView: View {
                             }
                         } label: {
                             Text(segment.label)
-                                .font(LitterFont.monospaced(.caption))
-                                .foregroundColor(segment.path == model.currentPath ? .black : LitterTheme.textSecondary)
+                                .font(LitterFont.styled(.caption))
+                                .foregroundColor(segment.path == model.currentPath ? LitterTheme.textOnAccent : LitterTheme.textSecondary)
                                 .padding(.horizontal, 10)
                                 .padding(.vertical, 6)
                                 .background(
@@ -535,10 +534,10 @@ struct DirectoryPickerView: View {
         } else if let err = model.errorMessage {
             VStack(spacing: 12) {
                 Text(DirectoryPickerStrings.loadError)
-                    .font(LitterFont.monospaced(.caption))
+                    .font(LitterFont.styled(.caption))
                     .foregroundColor(LitterTheme.danger)
                 Text(err)
-                    .font(LitterFont.monospaced(.caption2))
+                    .font(LitterFont.styled(.caption2))
                     .foregroundColor(LitterTheme.textSecondary)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, 32)
@@ -582,11 +581,11 @@ struct DirectoryPickerView: View {
                                 .frame(width: 20)
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(DirectoryPickerStrings.continueIn((recent.path as NSString).lastPathComponent))
-                                    .font(LitterFont.monospaced(.subheadline))
-                                    .foregroundColor(.white)
+                                    .font(LitterFont.styled(.subheadline))
+                                    .foregroundColor(LitterTheme.textPrimary)
                                     .lineLimit(1)
                                 Text(recent.path)
-                                    .font(LitterFont.monospaced(.caption2))
+                                    .font(LitterFont.styled(.caption2))
                                     .foregroundColor(LitterTheme.textMuted)
                                     .lineLimit(1)
                             }
@@ -612,17 +611,17 @@ struct DirectoryPickerView: View {
                                     .frame(width: 20)
                                 VStack(alignment: .leading, spacing: 2) {
                                     Text((recent.path as NSString).lastPathComponent)
-                                        .font(LitterFont.monospaced(.subheadline))
-                                        .foregroundColor(.white)
+                                        .font(LitterFont.styled(.subheadline))
+                                        .foregroundColor(LitterTheme.textPrimary)
                                         .lineLimit(1)
                                     Text(recent.path)
-                                        .font(LitterFont.monospaced(.caption2))
+                                        .font(LitterFont.styled(.caption2))
                                         .foregroundColor(LitterTheme.textMuted)
                                         .lineLimit(1)
                                 }
                                 Spacer()
                                 Text(model.relativeDate(for: recent.lastUsedAt))
-                                    .font(LitterFont.monospaced(.caption2))
+                                    .font(LitterFont.styled(.caption2))
                                     .foregroundColor(LitterTheme.textSecondary)
                                     .lineLimit(1)
                             }
@@ -639,7 +638,7 @@ struct DirectoryPickerView: View {
                 } header: {
                     HStack {
                         Text(DirectoryPickerStrings.recentDirectories)
-                            .font(LitterFont.monospaced(.caption))
+                            .font(LitterFont.styled(.caption))
                             .foregroundColor(LitterTheme.textSecondary)
                         Spacer()
                         Menu {
@@ -653,7 +652,7 @@ struct DirectoryPickerView: View {
                     }
                 } footer: {
                     Text(DirectoryPickerStrings.recentFooter)
-                        .font(LitterFont.monospaced(.caption2))
+                        .font(LitterFont.styled(.caption2))
                         .foregroundColor(LitterTheme.textMuted)
                 }
             }
@@ -661,7 +660,7 @@ struct DirectoryPickerView: View {
             let visibleEntries = model.visibleEntries()
             if visibleEntries.isEmpty {
                 Text(model.emptyMessage())
-                    .font(LitterFont.monospaced(.caption))
+                    .font(LitterFont.styled(.caption))
                     .foregroundColor(LitterTheme.textMuted)
                     .listRowBackground(LitterTheme.surface.opacity(0.6))
             } else {
@@ -681,8 +680,8 @@ struct DirectoryPickerView: View {
                                 .foregroundColor(LitterTheme.accent)
                                 .frame(width: 20)
                             Text(entry)
-                                .font(LitterFont.monospaced(.subheadline))
-                                .foregroundColor(.white)
+                                .font(LitterFont.styled(.subheadline))
+                                .foregroundColor(LitterTheme.textPrimary)
                             Spacer()
                             Image(systemName: "chevron.right")
                                 .foregroundColor(LitterTheme.textMuted)
@@ -702,14 +701,14 @@ struct DirectoryPickerView: View {
         VStack(alignment: .leading, spacing: 8) {
             if !model.currentPath.isEmpty {
                 Text(model.currentPath)
-                    .font(LitterFont.monospaced(.caption))
+                    .font(LitterFont.styled(.caption))
                     .foregroundColor(LitterTheme.textMuted)
                     .lineLimit(1)
                     .truncationMode(.middle)
                     .frame(maxWidth: .infinity, alignment: .leading)
             } else if !canSelectPath {
                 Text(DirectoryPickerStrings.chooseFolderHelper)
-                    .font(LitterFont.monospaced(.caption))
+                    .font(LitterFont.styled(.caption))
                     .foregroundColor(LitterTheme.textSecondary)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -718,7 +717,7 @@ struct DirectoryPickerView: View {
                     onDismissRequested?()
                 }
                 .buttonStyle(.plain)
-                .font(LitterFont.monospaced(.subheadline))
+                .font(LitterFont.styled(.subheadline))
                 .foregroundColor(LitterTheme.textSecondary)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 10)
@@ -738,8 +737,8 @@ struct DirectoryPickerView: View {
                 .accessibilityIdentifier("directoryPicker.selectFolderButton")
                 .disabled(!canSelectPath)
                 .buttonStyle(.plain)
-                .font(LitterFont.monospaced(.subheadline))
-                .foregroundColor(canSelectPath ? .black : LitterTheme.textMuted)
+                .font(LitterFont.styled(.subheadline))
+                .foregroundColor(canSelectPath ? LitterTheme.textOnAccent : LitterTheme.textMuted)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 10)
                 .background(canSelectPath ? LitterTheme.accent : LitterTheme.surface.opacity(0.65))
@@ -784,5 +783,4 @@ struct DirectoryPickerView: View {
         )
         .environmentObject(ServerManager())
     }
-    .preferredColorScheme(.dark)
 }

--- a/apps/ios/Sources/Litter/Views/DiscoveryView.swift
+++ b/apps/ios/Sources/Litter/Views/DiscoveryView.swift
@@ -144,7 +144,6 @@ struct DiscoveryView: View {
         }
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarColorScheme(.dark, for: .navigationBar)
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 Button { showSettings = true } label: {
@@ -244,13 +243,13 @@ struct DiscoveryView: View {
                     HStack {
                         ProgressView().tint(LitterTheme.textMuted).scaleEffect(0.7)
                         Text("Scanning...")
-                            .font(LitterFont.monospaced(.footnote))
+                            .font(LitterFont.styled(.footnote))
                             .foregroundColor(LitterTheme.textMuted)
                     }
                     .listRowBackground(LitterTheme.surface.opacity(0.6))
                 } else {
                     Text("No servers found")
-                        .font(LitterFont.monospaced(.footnote))
+                        .font(LitterFont.styled(.footnote))
                         .foregroundColor(LitterTheme.textMuted)
                         .listRowBackground(LitterTheme.surface.opacity(0.6))
                 }
@@ -284,7 +283,7 @@ struct DiscoveryView: View {
                     Image(systemName: "plus.circle")
                         .foregroundColor(LitterTheme.accent)
                     Text("Add Server")
-                        .font(LitterFont.monospaced(.subheadline))
+                        .font(LitterFont.styled(.subheadline))
                         .foregroundColor(LitterTheme.accent)
                 }
             }
@@ -306,16 +305,16 @@ struct DiscoveryView: View {
                     .frame(width: 24)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(server.name)
-                        .font(LitterFont.monospaced(.subheadline))
-                        .foregroundColor(.white)
+                        .font(LitterFont.styled(.subheadline))
+                        .foregroundColor(LitterTheme.textPrimary)
                     Text(serverSubtitle(server))
-                        .font(LitterFont.monospaced(.caption))
+                        .font(LitterFont.styled(.caption))
                         .foregroundColor(LitterTheme.textSecondary)
                 }
                 Spacer()
                 if serverManager.connections[server.id]?.isConnected == true {
                     Text("connected")
-                        .font(LitterFont.monospaced(.caption2))
+                        .font(LitterFont.styled(.caption2))
                         .foregroundColor(LitterTheme.accent)
                         .padding(.horizontal, 6)
                         .padding(.vertical, 2)
@@ -646,25 +645,25 @@ struct DiscoveryView: View {
 
                     Section {
                         TextField("hostname or IP", text: $manualHost)
-                            .font(LitterFont.monospaced(.footnote))
-                            .foregroundColor(.white)
+                            .font(LitterFont.styled(.footnote))
+                            .foregroundColor(LitterTheme.textPrimary)
                             .textInputAutocapitalization(.never)
                             .autocorrectionDisabled(true)
                         TextField(manualConnectionMode.portPlaceholder, text: portBinding(for: manualConnectionMode))
-                            .font(LitterFont.monospaced(.footnote))
-                            .foregroundColor(.white)
+                            .font(LitterFont.styled(.footnote))
+                            .foregroundColor(LitterTheme.textPrimary)
                             .keyboardType(.numberPad)
                         if manualConnectionMode == .ssh {
                             Toggle(isOn: $manualUseSSHPortForward) {
                                 Text("Use SSH port forward")
-                                    .font(LitterFont.monospaced(.footnote))
-                                    .foregroundColor(.white)
+                                    .font(LitterFont.styled(.footnote))
+                                    .foregroundColor(LitterTheme.textPrimary)
                             }
                             .tint(LitterTheme.accent)
                         }
                         TextField("wake MAC (optional)", text: $manualWakeMAC)
-                            .font(LitterFont.monospaced(.footnote))
-                            .foregroundColor(.white)
+                            .font(LitterFont.styled(.footnote))
+                            .foregroundColor(LitterTheme.textPrimary)
                             .textInputAutocapitalization(.never)
                             .autocorrectionDisabled(true)
                     } header: {
@@ -678,7 +677,7 @@ struct DiscoveryView: View {
                             submitManualEntry()
                         }
                         .foregroundColor(LitterTheme.accent)
-                        .font(LitterFont.monospaced(.subheadline))
+                        .font(LitterFont.styled(.subheadline))
                     }
                     .listRowBackground(LitterTheme.surface.opacity(0.6))
                 }
@@ -686,7 +685,6 @@ struct DiscoveryView: View {
             }
             .navigationTitle("Add Server")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbarColorScheme(.dark, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("Cancel") { showManualEntry = false }
@@ -694,7 +692,6 @@ struct DiscoveryView: View {
                 }
             }
         }
-        .preferredColorScheme(.dark)
     }
 
     private func maybeStartSimulatorAutoSSH() {

--- a/apps/ios/Sources/Litter/Views/HeaderView.swift
+++ b/apps/ios/Sources/Litter/Views/HeaderView.swift
@@ -26,7 +26,7 @@ struct HeaderView: View {
                 } label: {
                     Image(systemName: "line.3.horizontal")
                         .font(.system(size: 16, weight: .medium))
-                        .foregroundColor(Color(hex: "#999999"))
+                        .foregroundColor(LitterTheme.textSecondary)
                         .frame(width: 44, height: 44)
                         .modifier(GlassCircleModifier())
                 }
@@ -45,7 +45,7 @@ struct HeaderView: View {
                                 .fill(authDotColor)
                                 .frame(width: 6, height: 6)
                             Text(sessionModelLabel)
-                                .foregroundColor(.white)
+                                .foregroundColor(LitterTheme.textPrimary)
                             Text(sessionReasoningLabel)
                                 .foregroundColor(LitterTheme.textSecondary)
                             Image(systemName: "chevron.down")
@@ -53,13 +53,13 @@ struct HeaderView: View {
                                 .foregroundColor(LitterTheme.textSecondary)
                                 .rotationEffect(.degrees(appState.showModelSelector ? 180 : 0))
                         }
-                        .font(LitterFont.monospaced(.subheadline, weight: .semibold))
+                        .font(LitterFont.styled(.subheadline, weight: .semibold))
                         .lineLimit(1)
                         .minimumScaleFactor(0.75)
 
                         HStack(spacing: 6) {
                             Text(sessionDirectoryLabel)
-                                .font(LitterFont.monospaced(.caption2, weight: .semibold))
+                                .font(LitterFont.styled(.caption2, weight: .semibold))
                                 .foregroundColor(LitterTheme.textSecondary)
                                 .lineLimit(1)
                                 .truncationMode(.middle)
@@ -93,7 +93,7 @@ struct HeaderView: View {
         }
         .background(
             LinearGradient(
-                colors: [.black.opacity(0.5), .black.opacity(0.2), .clear],
+                colors: LitterTheme.headerScrim,
                 startPoint: .top,
                 endPoint: .bottom
             )
@@ -143,14 +143,13 @@ struct HeaderView: View {
                     .ignoresSafeArea()
                     .navigationTitle("Login with ChatGPT")
                     .navigationBarTitleDisplayMode(.inline)
-                    .toolbarColorScheme(.dark, for: .navigationBar)
                     .toolbar {
                         ToolbarItem(placement: .topBarLeading) {
                             Button("Cancel") {
                                 Task { await conn.cancelLogin() }
                                 showOAuth = false
                             }
-                            .foregroundColor(Color(hex: "#FF5555"))
+                            .foregroundColor(LitterTheme.danger)
                         }
                     }
                 }
@@ -340,11 +339,11 @@ struct InlineModelSelectorView: View {
                                 VStack(alignment: .leading, spacing: 2) {
                                     HStack(spacing: 6) {
                                         Text(model.displayName)
-                                            .font(LitterFont.monospaced(.footnote))
-                                            .foregroundColor(.white)
+                                            .font(LitterFont.styled(.footnote))
+                                            .foregroundColor(LitterTheme.textPrimary)
                                         if model.isDefault {
                                             Text("default")
-                                                .font(LitterFont.monospaced(.caption2, weight: .medium))
+                                                .font(LitterFont.styled(.caption2, weight: .medium))
                                                 .foregroundColor(LitterTheme.accent)
                                                 .padding(.horizontal, 6)
                                                 .padding(.vertical, 1)
@@ -353,7 +352,7 @@ struct InlineModelSelectorView: View {
                                         }
                                     }
                                     Text(model.description)
-                                        .font(LitterFont.monospaced(.caption2))
+                                        .font(LitterFont.styled(.caption2))
                                         .foregroundColor(LitterTheme.textSecondary)
                                 }
                                 Spacer()
@@ -384,8 +383,8 @@ struct InlineModelSelectorView: View {
                                 appState.reasoningEffort = effort.reasoningEffort
                             } label: {
                                 Text(effort.reasoningEffort)
-                                    .font(LitterFont.monospaced(.caption2, weight: .medium))
-                                    .foregroundColor(effort.reasoningEffort == appState.reasoningEffort ? .black : .white)
+                                    .font(LitterFont.styled(.caption2, weight: .medium))
+                                    .foregroundColor(effort.reasoningEffort == appState.reasoningEffort ? LitterTheme.textOnAccent : LitterTheme.textPrimary)
                                     .padding(.horizontal, 10)
                                     .padding(.vertical, 5)
                                     .background(effort.reasoningEffort == appState.reasoningEffort ? LitterTheme.accent : LitterTheme.surfaceLight)
@@ -427,11 +426,11 @@ struct ModelSelectorSheet: View {
                         VStack(alignment: .leading, spacing: 2) {
                             HStack(spacing: 6) {
                                 Text(model.displayName)
-                                    .font(LitterFont.monospaced(.footnote))
-                                    .foregroundColor(.white)
+                                    .font(LitterFont.styled(.footnote))
+                                    .foregroundColor(LitterTheme.textPrimary)
                                 if model.isDefault {
                                     Text("default")
-                                        .font(LitterFont.monospaced(.caption2, weight: .medium))
+                                        .font(LitterFont.styled(.caption2, weight: .medium))
                                         .foregroundColor(LitterTheme.accent)
                                         .padding(.horizontal, 6)
                                         .padding(.vertical, 1)
@@ -440,7 +439,7 @@ struct ModelSelectorSheet: View {
                                 }
                             }
                             Text(model.description)
-                                .font(LitterFont.monospaced(.caption2))
+                                .font(LitterFont.styled(.caption2))
                                 .foregroundColor(LitterTheme.textSecondary)
                         }
                         Spacer()
@@ -464,8 +463,8 @@ struct ModelSelectorSheet: View {
                                 appState.reasoningEffort = effort.reasoningEffort
                             } label: {
                                 Text(effort.reasoningEffort)
-                                    .font(LitterFont.monospaced(.caption2, weight: .medium))
-                                    .foregroundColor(effort.reasoningEffort == appState.reasoningEffort ? .black : .white)
+                                    .font(LitterFont.styled(.caption2, weight: .medium))
+                                    .foregroundColor(effort.reasoningEffort == appState.reasoningEffort ? LitterTheme.textOnAccent : LitterTheme.textPrimary)
                                     .padding(.horizontal, 10)
                                     .padding(.vertical, 5)
                                     .background(effort.reasoningEffort == appState.reasoningEffort ? LitterTheme.accent : LitterTheme.surfaceLight)

--- a/apps/ios/Sources/Litter/Views/MessageBubbleView.swift
+++ b/apps/ios/Sources/Litter/Views/MessageBubbleView.swift
@@ -88,8 +88,8 @@ struct MessageBubbleView: View {
             }
             if !message.text.isEmpty {
                 Text(message.text)
-                    .font(LitterFont.monospaced(.callout, scale: textScale))
-                    .foregroundColor(.white)
+                    .font(LitterFont.styled(.callout, scale: textScale))
+                    .foregroundColor(LitterTheme.textPrimary)
                     .textSelection(.enabled)
             }
         }
@@ -116,7 +116,7 @@ struct MessageBubbleView: View {
         return VStack(alignment: .leading, spacing: 8) {
             if let assistantLabel = assistantAgentLabel {
                 Text(assistantLabel)
-                    .font(LitterFont.monospaced(.caption2, weight: .semibold, scale: textScale))
+                    .font(LitterFont.styled(.caption2, weight: .semibold, scale: textScale))
                     .foregroundColor(LitterTheme.textSecondary)
             }
             ForEach(parsed) { segment in
@@ -148,7 +148,7 @@ struct MessageBubbleView: View {
     private var reasoningContent: some View {
         let (_, body) = extractSystemTitleAndBody(message.text)
         return Text(normalizedReasoningText(body))
-            .font(LitterFont.monospaced(.footnote, scale: textScale))
+            .font(LitterFont.styled(.footnote, scale: textScale))
             .italic()
             .foregroundColor(LitterTheme.textSecondary)
             .textSelection(.enabled)
@@ -177,7 +177,7 @@ struct MessageBubbleView: View {
                     .font(.system(.caption2, weight: .semibold))
                     .foregroundColor(LitterTheme.accent)
                 Text(displayTitle.uppercased())
-                    .font(LitterFont.monospaced(.caption2, weight: .bold, scale: textScale))
+                    .font(LitterFont.styled(.caption2, weight: .bold, scale: textScale))
                     .foregroundColor(LitterTheme.accent)
                 Spacer()
             }
@@ -410,7 +410,7 @@ extension MarkdownUI.Theme {
                     .markdownTextStyle {
                         FontWeight(.bold)
                         FontSize(bodySize * 1.43)
-                        ForegroundColor(.white)
+                        ForegroundColor(LitterTheme.textPrimary)
                     }
                     .markdownMargin(top: 16, bottom: 8)
             }
@@ -419,7 +419,7 @@ extension MarkdownUI.Theme {
                     .markdownTextStyle {
                         FontWeight(.semibold)
                         FontSize(bodySize * 1.21)
-                        ForegroundColor(.white)
+                        ForegroundColor(LitterTheme.textPrimary)
                     }
                     .markdownMargin(top: 12, bottom: 6)
             }
@@ -428,13 +428,13 @@ extension MarkdownUI.Theme {
                     .markdownTextStyle {
                         FontWeight(.semibold)
                         FontSize(bodySize * 1.07)
-                        ForegroundColor(.white)
+                        ForegroundColor(LitterTheme.textPrimary)
                     }
                     .markdownMargin(top: 10, bottom: 4)
             }
             .strong {
                 FontWeight(.semibold)
-                ForegroundColor(.white)
+                ForegroundColor(LitterTheme.textPrimary)
             }
             .emphasis {
                 FontStyle(.italic)
@@ -451,7 +451,8 @@ extension MarkdownUI.Theme {
             .codeBlock { configuration in
                 CodeBlockView(
                     language: configuration.language ?? "",
-                    code: configuration.content
+                    code: configuration.content,
+                    fontSize: codeSize
                 )
                 .markdownMargin(top: 8, bottom: 8)
             }
@@ -492,7 +493,7 @@ extension MarkdownUI.Theme {
                     .markdownTextStyle {
                         FontWeight(.bold)
                         FontSize(bodySize * 1.31)
-                        ForegroundColor(.white)
+                        ForegroundColor(LitterTheme.textPrimary)
                     }
                     .markdownMargin(top: 12, bottom: 6)
             }
@@ -501,7 +502,7 @@ extension MarkdownUI.Theme {
                     .markdownTextStyle {
                         FontWeight(.semibold)
                         FontSize(bodySize * 1.15)
-                        ForegroundColor(.white)
+                        ForegroundColor(LitterTheme.textPrimary)
                     }
                     .markdownMargin(top: 10, bottom: 4)
             }
@@ -510,13 +511,13 @@ extension MarkdownUI.Theme {
                     .markdownTextStyle {
                         FontWeight(.semibold)
                         FontSize(bodySize * 1.08)
-                        ForegroundColor(.white)
+                        ForegroundColor(LitterTheme.textPrimary)
                     }
                     .markdownMargin(top: 8, bottom: 4)
             }
             .strong {
                 FontWeight(.semibold)
-                ForegroundColor(.white)
+                ForegroundColor(LitterTheme.textPrimary)
             }
             .emphasis {
                 FontStyle(.italic)
@@ -533,7 +534,8 @@ extension MarkdownUI.Theme {
             .codeBlock { configuration in
                 CodeBlockView(
                     language: configuration.language ?? "",
-                    code: configuration.content
+                    code: configuration.content,
+                    fontSize: codeSize
                 )
                 .markdownMargin(top: 6, bottom: 6)
             }

--- a/apps/ios/Sources/Litter/Views/PreviewSupport.swift
+++ b/apps/ios/Sources/Litter/Views/PreviewSupport.swift
@@ -409,7 +409,6 @@ struct LitterPreviewScene<Content: View>: View {
         }
         .environmentObject(serverManager)
         .environmentObject(appState)
-        .preferredColorScheme(.dark)
     }
 }
 #endif

--- a/apps/ios/Sources/Litter/Views/SSHLoginSheet.swift
+++ b/apps/ios/Sources/Litter/Views/SSHLoginSheet.swift
@@ -51,10 +51,10 @@ struct SSHLoginSheet: View {
                                 .foregroundColor(LitterTheme.accent)
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(server.name)
-                                    .font(LitterFont.monospaced(.subheadline))
-                                    .foregroundColor(.white)
+                                    .font(LitterFont.styled(.subheadline))
+                                    .foregroundColor(LitterTheme.textPrimary)
                                 Text(hostDisplay)
-                                    .font(LitterFont.monospaced(.caption))
+                                    .font(LitterFont.styled(.caption))
                                     .foregroundColor(LitterTheme.textSecondary)
                             }
                         }
@@ -63,8 +63,8 @@ struct SSHLoginSheet: View {
 
                     Section {
                         TextField("username", text: $username)
-                            .font(LitterFont.monospaced(.footnote))
-                            .foregroundColor(.white)
+                            .font(LitterFont.styled(.footnote))
+                            .foregroundColor(LitterTheme.textPrimary)
                             .textInputAutocapitalization(.never)
                             .autocorrectionDisabled(true)
                     } header: {
@@ -83,14 +83,14 @@ struct SSHLoginSheet: View {
 
                         if useKey {
                             TextEditor(text: $privateKey)
-                                .font(LitterFont.monospaced(.caption))
-                                .foregroundColor(.white)
+                                .font(LitterFont.styled(.caption))
+                                .foregroundColor(LitterTheme.textPrimary)
                                 .scrollContentBackground(.hidden)
                                 .frame(minHeight: 100)
                                 .overlay(alignment: .topLeading) {
                                     if privateKey.isEmpty {
                                         Text("Paste private key here...")
-                                            .font(LitterFont.monospaced(.caption))
+                                            .font(LitterFont.styled(.caption))
                                             .foregroundColor(LitterTheme.textMuted)
                                             .padding(.top, 8)
                                             .padding(.leading, 4)
@@ -98,12 +98,12 @@ struct SSHLoginSheet: View {
                                     }
                                 }
                             SecureField("passphrase (optional)", text: $passphrase)
-                                .font(LitterFont.monospaced(.footnote))
-                                .foregroundColor(.white)
+                                .font(LitterFont.styled(.footnote))
+                                .foregroundColor(LitterTheme.textPrimary)
                         } else {
                             SecureField("password", text: $password)
-                                .font(LitterFont.monospaced(.footnote))
-                                .foregroundColor(.white)
+                                .font(LitterFont.styled(.footnote))
+                                .foregroundColor(LitterTheme.textPrimary)
                         }
                     } header: {
                         Text("Authentication")
@@ -114,8 +114,8 @@ struct SSHLoginSheet: View {
                     Section {
                         Toggle(isOn: $rememberCredentials) {
                             Text("Remember credentials on this device")
-                                .font(LitterFont.monospaced(.footnote))
-                                .foregroundColor(.white)
+                                .font(LitterFont.styled(.footnote))
+                                .foregroundColor(LitterTheme.textPrimary)
                         }
                         .tint(LitterTheme.accent)
 
@@ -124,7 +124,7 @@ struct SSHLoginSheet: View {
                                 forgetSavedCredentials()
                             } label: {
                                 Text("Forget saved credentials")
-                                    .font(LitterFont.monospaced(.footnote))
+                                    .font(LitterFont.styled(.footnote))
                             }
                         }
                     } header: {
@@ -143,7 +143,7 @@ struct SSHLoginSheet: View {
                                 }
                                 Text("Connect")
                                     .foregroundColor(LitterTheme.accent)
-                                    .font(LitterFont.monospaced(.subheadline))
+                                    .font(LitterFont.styled(.subheadline))
                             }
                         }
                         .disabled(isConnecting || username.isEmpty || (!useKey && password.isEmpty) || (useKey && privateKey.isEmpty))
@@ -154,7 +154,7 @@ struct SSHLoginSheet: View {
                         Section {
                             Text(err)
                                 .foregroundColor(.red)
-                                .font(LitterFont.monospaced(.caption))
+                                .font(LitterFont.styled(.caption))
                         }
                         .listRowBackground(LitterTheme.surface.opacity(0.6))
                     }
@@ -163,7 +163,6 @@ struct SSHLoginSheet: View {
             }
             .navigationTitle("SSH Login")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbarColorScheme(.dark, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Button("Cancel") { dismiss() }
@@ -171,7 +170,6 @@ struct SSHLoginSheet: View {
                 }
             }
         }
-        .preferredColorScheme(.dark)
         .task {
             guard autoLoadSavedCredentials else { return }
             loadSavedCredentialsIfNeeded()

--- a/apps/ios/Sources/Litter/Views/SessionListView.swift
+++ b/apps/ios/Sources/Litter/Views/SessionListView.swift
@@ -45,7 +45,7 @@ struct SessionListView: View {
             } else if let err = errorMessage, sessions.isEmpty {
                 VStack(spacing: 12) {
                     Text(err)
-                        .font(LitterFont.monospaced(.caption))
+                        .font(LitterFont.styled(.caption))
                         .foregroundColor(.red)
                     Button("Retry") { Task { await loadSessions() } }
                         .foregroundColor(LitterTheme.accent)
@@ -56,14 +56,13 @@ struct SessionListView: View {
         }
         .navigationTitle(cwdLabel)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarColorScheme(.dark, for: .navigationBar)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button("New Session") {
                     Task { await startNew() }
                 }
                 .foregroundColor(LitterTheme.accent)
-                .font(LitterFont.monospaced(.footnote))
+                .font(LitterFont.styled(.footnote))
             }
         }
         .navigationDestination(isPresented: $navigateToConversation) {
@@ -83,7 +82,7 @@ struct SessionListView: View {
         List {
             if let err = errorMessage {
                 Text(err)
-                    .font(LitterFont.monospaced(.caption))
+                    .font(LitterFont.styled(.caption))
                     .foregroundColor(.red)
                     .padding(.vertical, 6)
                     .listRowBackground(LitterTheme.surface.opacity(0.6))
@@ -92,11 +91,11 @@ struct SessionListView: View {
             if sessions.isEmpty {
                 VStack(spacing: 12) {
                     Text("No previous sessions")
-                        .font(LitterFont.monospaced(.subheadline))
+                        .font(LitterFont.styled(.subheadline))
                         .foregroundColor(LitterTheme.textMuted)
                     Text("Start a new session to begin")
-                        .font(LitterFont.monospaced(.caption))
-                        .foregroundColor(Color(hex: "#444444"))
+                        .font(LitterFont.styled(.caption))
+                        .foregroundColor(LitterTheme.textMuted)
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 40)
@@ -116,7 +115,7 @@ struct SessionListView: View {
             if nextCursor != nil {
                 Button("Load more") { Task { await loadMore() } }
                     .foregroundColor(LitterTheme.accent)
-                    .font(LitterFont.monospaced(.footnote))
+                    .font(LitterFont.styled(.footnote))
                     .frame(maxWidth: .infinity)
                     .listRowBackground(LitterTheme.surface.opacity(0.6))
             }
@@ -128,8 +127,8 @@ struct SessionListView: View {
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 8) {
                 Text(session.preview.isEmpty ? "Untitled session" : session.preview)
-                    .font(LitterFont.monospaced(.footnote))
-                    .foregroundColor(.white)
+                    .font(LitterFont.styled(.footnote))
+                    .foregroundColor(LitterTheme.textPrimary)
                     .lineLimit(2)
                 Spacer(minLength: 0)
                 if resumingThreadId == session.id {
@@ -140,10 +139,10 @@ struct SessionListView: View {
             }
             HStack(spacing: 8) {
                 Text(relativeDate(session.updatedAt))
-                    .font(LitterFont.monospaced(.caption))
+                    .font(LitterFont.styled(.caption))
                     .foregroundColor(LitterTheme.textSecondary)
                 Text(session.modelProvider)
-                    .font(LitterFont.monospaced(.caption2))
+                    .font(LitterFont.styled(.caption2))
                     .foregroundColor(LitterTheme.accent)
                     .padding(.horizontal, 6)
                     .padding(.vertical, 2)

--- a/apps/ios/Sources/Litter/Views/SessionSidebarView.swift
+++ b/apps/ios/Sources/Litter/Views/SessionSidebarView.swift
@@ -89,7 +89,6 @@ struct SessionSidebarView: View {
                 )
                 .environmentObject(serverManager)
             }
-            .preferredColorScheme(.dark)
         }
     }
 
@@ -232,7 +231,7 @@ struct SessionSidebarView: View {
             } else if derived.allThreads.isEmpty {
                 Spacer()
                 Text("No sessions yet")
-                    .font(LitterFont.monospaced(.footnote))
+                    .font(LitterFont.styled(.footnote))
                     .foregroundColor(LitterTheme.textMuted)
                     .frame(maxWidth: .infinity)
                 Spacer()
@@ -243,7 +242,7 @@ struct SessionSidebarView: View {
                 if derived.filteredThreads.isEmpty {
                     Spacer()
                     Text("No matches for \"\(trimmedSessionSearchQuery)\"")
-                        .font(LitterFont.monospaced(.footnote))
+                        .font(LitterFont.styled(.footnote))
                         .foregroundColor(LitterTheme.textMuted)
                         .frame(maxWidth: .infinity)
                     Spacer()
@@ -353,9 +352,9 @@ struct SessionSidebarView: View {
                     Image(systemName: "plus")
                         .font(.system(.subheadline, weight: .medium))
                     Text("New Session")
-                        .font(LitterFont.monospaced(.subheadline))
+                        .font(LitterFont.styled(.subheadline))
                 }
-                .foregroundColor(.black)
+                .foregroundColor(LitterTheme.textOnAccent)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 12)
                 .background(LitterTheme.accent)
@@ -375,7 +374,7 @@ struct SessionSidebarView: View {
                     .foregroundColor(LitterTheme.textMuted)
                     .frame(width: 20)
                 Text("Not connected")
-                    .font(LitterFont.monospaced(.footnote))
+                    .font(LitterFont.styled(.footnote))
                     .foregroundColor(LitterTheme.textMuted)
                 Spacer()
                 Button("Connect") {
@@ -383,22 +382,22 @@ struct SessionSidebarView: View {
                     appState.showServerPicker = true
                 }
                 .accessibilityIdentifier("sidebar.connectButton")
-                .font(LitterFont.monospaced(.caption))
+                .font(LitterFont.styled(.caption))
                 .foregroundColor(LitterTheme.accent)
             } else {
                 Image(systemName: "server.rack")
                     .foregroundColor(LitterTheme.accent)
                     .frame(width: 20)
                 Text("\(connected.count) server\(connected.count == 1 ? "" : "s")")
-                    .font(LitterFont.monospaced(.footnote))
-                    .foregroundColor(.white)
+                    .font(LitterFont.styled(.footnote))
+                    .foregroundColor(LitterTheme.textPrimary)
                 Spacer()
                 Button("Add") {
                     withAnimation(.easeInOut(duration: 0.25)) { appState.sidebarOpen = false }
                     appState.showServerPicker = true
                 }
                 .accessibilityIdentifier("sidebar.addServerButton")
-                .font(LitterFont.monospaced(.caption))
+                .font(LitterFont.styled(.caption))
                 .foregroundColor(LitterTheme.accent)
                 if let activeThread {
                     Button {
@@ -413,7 +412,7 @@ struct SessionSidebarView: View {
                         }
                     }
                     .disabled(isForkingActiveThread || activeThread.hasTurnActive)
-                    .font(LitterFont.monospaced(.caption))
+                    .font(LitterFont.styled(.caption))
                     .foregroundColor(activeThread.hasTurnActive ? LitterTheme.textMuted : LitterTheme.accent)
                 }
             }
@@ -426,11 +425,11 @@ struct SessionSidebarView: View {
         HStack(spacing: 8) {
             Image(systemName: "magnifyingglass")
                 .foregroundColor(LitterTheme.textMuted)
-                .font(LitterFont.monospaced(.caption))
+                .font(LitterFont.styled(.caption))
 
             TextField("Search sessions", text: $sessionSearchQuery)
-                .font(LitterFont.monospaced(.footnote))
-                .foregroundColor(.white)
+                .font(LitterFont.styled(.footnote))
+                .foregroundColor(LitterTheme.textPrimary)
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled(true)
 
@@ -502,7 +501,7 @@ struct SessionSidebarView: View {
                     selectedServerFilterId = nil
                     showOnlyForks = false
                 }
-                .font(LitterFont.monospaced(.caption))
+                .font(LitterFont.styled(.caption))
                 .foregroundColor(LitterTheme.accent)
             }
             Spacer(minLength: 0)
@@ -523,8 +522,8 @@ struct SessionSidebarView: View {
             Text(title)
                 .lineLimit(1)
         }
-        .font(LitterFont.monospaced(.caption))
-        .foregroundColor(isActive ? .black : LitterTheme.textSecondary)
+        .font(LitterFont.styled(.caption))
+        .foregroundColor(isActive ? LitterTheme.textOnAccent : LitterTheme.textSecondary)
         .padding(.horizontal, 8)
         .padding(.vertical, 6)
         .background(isActive ? LitterTheme.accent : LitterTheme.surface.opacity(0.65))
@@ -558,17 +557,17 @@ struct SessionSidebarView: View {
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(group.workspaceTitle)
-                        .font(LitterFont.monospaced(.caption))
-                        .foregroundColor(.white)
+                        .font(LitterFont.styled(.caption))
+                        .foregroundColor(LitterTheme.textPrimary)
                         .lineLimit(1)
 
                     Text(hostname)
-                        .font(LitterFont.monospaced(.caption2))
+                        .font(LitterFont.styled(.caption2))
                         .foregroundColor(LitterTheme.textMuted)
                         .lineLimit(1)
 
                     Text(abbreviateHomePath(group.workspacePath))
-                        .font(LitterFont.monospaced(.caption2))
+                        .font(LitterFont.styled(.caption2))
                         .foregroundColor(LitterTheme.textMuted)
                         .lineLimit(1)
                 }
@@ -593,7 +592,7 @@ struct SessionSidebarView: View {
                     ForEach(derived.workspaceSections) { section in
                         if let title = section.title {
                             Text(title)
-                                .font(LitterFont.monospaced(.caption2))
+                                .font(LitterFont.styled(.caption2))
                                 .foregroundColor(LitterTheme.textMuted)
                                 .padding(.horizontal, 2)
                         }
@@ -736,16 +735,16 @@ struct SessionSidebarView: View {
                     VStack(alignment: .leading, spacing: 3) {
                         HStack(alignment: .firstTextBaseline, spacing: 6) {
                             Text(sessionTitle(thread))
-                                .font(LitterFont.monospaced(.footnote))
-                                .foregroundColor(.white)
+                                .font(LitterFont.styled(.footnote))
+                                .foregroundColor(LitterTheme.textPrimary)
                                 .lineLimit(2)
                                 .multilineTextAlignment(.leading)
                                 .accessibilityIdentifier("sidebar.sessionTitle")
 
                             if thread.isFork {
                                 Text("Fork")
-                                    .font(LitterFont.monospaced(.caption2))
-                                    .foregroundColor(.black)
+                                    .font(LitterFont.styled(.caption2))
+                                    .foregroundColor(LitterTheme.textOnAccent)
                                     .padding(.horizontal, 5)
                                     .padding(.vertical, 2)
                                     .background(LitterTheme.accent)
@@ -777,7 +776,7 @@ struct SessionSidebarView: View {
                                     .foregroundColor(LitterTheme.textMuted)
                             }
                         }
-                        .font(LitterFont.monospaced(.caption2))
+                        .font(LitterFont.styled(.caption2))
                         .lineLimit(1)
                     }
                 }
@@ -857,7 +856,7 @@ struct SessionSidebarView: View {
 
     private func lineageChip(title: String, count: Int, isInteractive: Bool) -> some View {
         Text("\(title) \(count)")
-            .font(LitterFont.monospaced(.caption2))
+            .font(LitterFont.styled(.caption2))
             .foregroundColor(isInteractive ? LitterTheme.accent : LitterTheme.textMuted)
             .padding(.horizontal, 6)
             .padding(.vertical, 4)

--- a/apps/ios/Sources/Litter/Views/SettingsView.swift
+++ b/apps/ios/Sources/Litter/Views/SettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct SettingsView: View {
     @EnvironmentObject var serverManager: ServerManager
     @Environment(\.dismiss) private var dismiss
+    @AppStorage("fontFamily") private var fontFamily = FontFamilyOption.mono.rawValue
     @State private var apiKey = ""
     @State private var isAuthWorking = false
     @State private var authError: String?
@@ -29,6 +30,7 @@ struct SettingsView: View {
             ZStack {
                 LitterTheme.backgroundGradient.ignoresSafeArea()
                 Form {
+                    fontSection
                     accountSection
                     serversSection
                 }
@@ -36,7 +38,6 @@ struct SettingsView: View {
             }
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbarColorScheme(.dark, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") { dismiss() }
@@ -44,7 +45,6 @@ struct SettingsView: View {
                 }
             }
         }
-        .preferredColorScheme(.dark)
         .sheet(isPresented: $showOAuth) {
             oauthSheet
         }
@@ -59,6 +59,39 @@ struct SettingsView: View {
         }
     }
 
+    // MARK: - Font Section
+
+    private var fontSection: some View {
+        Section {
+            ForEach(FontFamilyOption.allCases) { option in
+                Button {
+                    fontFamily = option.rawValue
+                } label: {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(option.displayName)
+                                .font(LitterFont.styled(.subheadline))
+                                .foregroundColor(LitterTheme.textPrimary)
+                            Text("The quick brown fox")
+                                .font(LitterFont.sampleFont(family: option, size: 14))
+                                .foregroundColor(LitterTheme.textSecondary)
+                        }
+                        Spacer()
+                        if fontFamily == option.rawValue {
+                            Image(systemName: "checkmark")
+                                .font(.system(.subheadline, weight: .semibold))
+                                .foregroundColor(LitterTheme.accentStrong)
+                        }
+                    }
+                }
+                .listRowBackground(LitterTheme.surface.opacity(0.6))
+            }
+        } header: {
+            Text("Font")
+                .foregroundColor(LitterTheme.textSecondary)
+        }
+    }
+
     // MARK: - Account Section (inline, no nested sheet)
 
     private var accountSection: some View {
@@ -70,11 +103,11 @@ struct SettingsView: View {
                     .frame(width: 10, height: 10)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(authTitle)
-                        .font(LitterFont.monospaced(.subheadline))
-                        .foregroundColor(.white)
+                        .font(LitterFont.styled(.subheadline))
+                        .foregroundColor(LitterTheme.textPrimary)
                     if let sub = authSubtitle {
                         Text(sub)
-                            .font(LitterFont.monospaced(.caption))
+                            .font(LitterFont.styled(.caption))
                             .foregroundColor(LitterTheme.textSecondary)
                     }
                 }
@@ -83,7 +116,7 @@ struct SettingsView: View {
                     Button("Logout") {
                         Task { await conn?.logout() }
                     }
-                    .font(LitterFont.monospaced(.caption))
+                    .font(LitterFont.styled(.caption))
                     .foregroundColor(LitterTheme.danger)
                 }
             }
@@ -101,11 +134,11 @@ struct SettingsView: View {
                 } label: {
                     HStack {
                         if isAuthWorking {
-                            ProgressView().tint(.white).scaleEffect(0.8)
+                            ProgressView().tint(LitterTheme.textPrimary).scaleEffect(0.8)
                         }
                         Image(systemName: "person.crop.circle.badge.checkmark")
                         Text("Login with ChatGPT")
-                            .font(LitterFont.monospaced(.subheadline))
+                            .font(LitterFont.styled(.subheadline))
                     }
                     .foregroundColor(LitterTheme.accent)
                 }
@@ -114,8 +147,8 @@ struct SettingsView: View {
 
                 HStack(spacing: 8) {
                     SecureField("sk-...", text: $apiKey)
-                        .font(LitterFont.monospaced(.footnote))
-                        .foregroundColor(.white)
+                        .font(LitterFont.styled(.footnote))
+                        .foregroundColor(LitterTheme.textPrimary)
                         .textInputAutocapitalization(.never)
                     Button("Save") {
                         let key = apiKey.trimmingCharacters(in: .whitespaces)
@@ -127,7 +160,7 @@ struct SettingsView: View {
                             isAuthWorking = false
                         }
                     }
-                    .font(LitterFont.monospaced(.caption))
+                    .font(LitterFont.styled(.caption))
                     .foregroundColor(LitterTheme.accent)
                     .disabled(apiKey.trimmingCharacters(in: .whitespaces).isEmpty || isAuthWorking)
                 }
@@ -136,14 +169,14 @@ struct SettingsView: View {
 
             if case .unknown = authStatus, conn == nil {
                 Text("Connect to a server first")
-                    .font(LitterFont.monospaced(.caption))
+                    .font(LitterFont.styled(.caption))
                     .foregroundColor(LitterTheme.textMuted)
                     .listRowBackground(LitterTheme.surface.opacity(0.6))
             }
 
             if let err = authError {
                 Text(err)
-                    .font(LitterFont.monospaced(.caption))
+                    .font(LitterFont.styled(.caption))
                     .foregroundColor(LitterTheme.danger)
                     .listRowBackground(LitterTheme.surface.opacity(0.6))
             }
@@ -159,7 +192,7 @@ struct SettingsView: View {
         Section {
             if connectedServers.isEmpty {
                 Text("No servers connected")
-                    .font(LitterFont.monospaced(.footnote))
+                    .font(LitterFont.styled(.footnote))
                     .foregroundColor(LitterTheme.textMuted)
                     .listRowBackground(LitterTheme.surface.opacity(0.6))
             } else {
@@ -170,17 +203,17 @@ struct SettingsView: View {
                             .frame(width: 20)
                         VStack(alignment: .leading, spacing: 2) {
                             Text(conn.server.name)
-                                .font(LitterFont.monospaced(.footnote))
-                                .foregroundColor(.white)
+                                .font(LitterFont.styled(.footnote))
+                                .foregroundColor(LitterTheme.textPrimary)
                             Text(conn.isConnected ? "Connected" : "Disconnected")
-                                .font(LitterFont.monospaced(.caption))
+                                .font(LitterFont.styled(.caption))
                                 .foregroundColor(conn.isConnected ? LitterTheme.accent : LitterTheme.textSecondary)
                         }
                         Spacer()
                         Button("Remove") {
                             serverManager.removeServer(id: conn.id)
                         }
-                        .font(LitterFont.monospaced(.caption))
+                        .font(LitterFont.styled(.caption))
                         .foregroundColor(LitterTheme.danger)
                     }
                     .listRowBackground(LitterTheme.surface.opacity(0.6))
@@ -206,7 +239,6 @@ struct SettingsView: View {
                 .ignoresSafeArea()
                 .navigationTitle("Login with ChatGPT")
                 .navigationBarTitleDisplayMode(.inline)
-                .toolbarColorScheme(.dark, for: .navigationBar)
                 .toolbar {
                     ToolbarItem(placement: .topBarLeading) {
                         Button("Cancel") {

--- a/apps/ios/Sources/Litter/Views/SidebarOverlay.swift
+++ b/apps/ios/Sources/Litter/Views/SidebarOverlay.swift
@@ -27,7 +27,12 @@ struct SidebarOverlay: View {
                     maxHeight: .infinity,
                     alignment: .topLeading
                 )
-                .background(.ultraThinMaterial)
+                .background {
+                    ZStack {
+                        LitterTheme.surface
+                        Rectangle().fill(.ultraThinMaterial)
+                    }
+                }
                 .ignoresSafeArea()
                 .offset(x: panelOffset)
                 .shadow(color: .black.opacity(0.35), radius: 20, x: 6, y: 0)

--- a/apps/ios/Sources/Litter/Views/ToolCallCardView.swift
+++ b/apps/ios/Sources/Litter/Views/ToolCallCardView.swift
@@ -17,7 +17,7 @@ struct ToolCallCardView: View {
                     .foregroundColor(kindAccent)
 
                 Text(model.summary)
-                    .font(LitterFont.monospaced(.caption))
+                    .font(LitterFont.styled(.caption))
                     .foregroundColor(LitterTheme.textSystem)
                     .lineLimit(1)
 
@@ -27,7 +27,7 @@ struct ToolCallCardView: View {
 
                 if let duration = model.duration, !duration.isEmpty {
                     Text(duration)
-                        .font(LitterFont.monospaced(.caption2))
+                        .font(LitterFont.styled(.caption2))
                         .foregroundColor(LitterTheme.textSecondary)
                         .padding(.horizontal, 6)
                         .padding(.vertical, 3)
@@ -74,7 +74,7 @@ struct ToolCallCardView: View {
 
     private var statusChip: some View {
         Text(model.status.label)
-            .font(LitterFont.monospaced(.caption2, weight: .semibold))
+            .font(LitterFont.styled(.caption2, weight: .semibold))
             .foregroundColor(statusChipText)
             .padding(.horizontal, 7)
             .padding(.vertical, 3)
@@ -85,32 +85,32 @@ struct ToolCallCardView: View {
     private var kindAccent: Color {
         switch model.kind {
         case .commandExecution, .commandOutput:
-            return Color(hex: "#C7B072")
+            return LitterTheme.adaptive(light: "#8B6914", dark: "#C7B072")
         case .fileChange:
-            return Color(hex: "#7CAFD9")
+            return LitterTheme.adaptive(light: "#2B6CB0", dark: "#7CAFD9")
         case .fileDiff:
-            return Color(hex: "#6FA9D8")
+            return LitterTheme.adaptive(light: "#2563AA", dark: "#6FA9D8")
         case .mcpToolCall:
-            return Color(hex: "#C797D8")
+            return LitterTheme.adaptive(light: "#8B3FAF", dark: "#C797D8")
         case .mcpToolProgress:
-            return Color(hex: "#D3A85E")
+            return LitterTheme.adaptive(light: "#9A6B20", dark: "#D3A85E")
         case .webSearch:
-            return Color(hex: "#88C6C7")
+            return LitterTheme.adaptive(light: "#3B8A8B", dark: "#88C6C7")
         case .collaboration:
-            return Color(hex: "#9BCF8E")
+            return LitterTheme.adaptive(light: "#3D7A30", dark: "#9BCF8E")
         case .imageView:
-            return Color(hex: "#E3A66F")
+            return LitterTheme.adaptive(light: "#B5712B", dark: "#E3A66F")
         }
     }
 
     private var statusChipBackground: Color {
         switch model.status {
         case .completed:
-            return Color(hex: "#6EA676").opacity(0.2)
+            return LitterTheme.success.opacity(0.2)
         case .inProgress:
-            return Color(hex: "#E2A644").opacity(0.2)
+            return LitterTheme.warning.opacity(0.2)
         case .failed:
-            return Color(hex: "#FF5555").opacity(0.2)
+            return LitterTheme.danger.opacity(0.2)
         case .unknown:
             return LitterTheme.surfaceLight.opacity(0.7)
         }
@@ -119,11 +119,11 @@ struct ToolCallCardView: View {
     private var statusChipText: Color {
         switch model.status {
         case .completed:
-            return Color(hex: "#6EA676")
+            return LitterTheme.success
         case .inProgress:
-            return Color(hex: "#E2A644")
+            return LitterTheme.warning
         case .failed:
-            return Color(hex: "#FF5555")
+            return LitterTheme.danger
         case .unknown:
             return LitterTheme.textSecondary
         }
@@ -140,10 +140,10 @@ struct ToolCallCardView: View {
                         ForEach(identifiedKeyValueEntries(entries)) { entry in
                             HStack(alignment: .top, spacing: 8) {
                                 Text(entry.value.key + ":")
-                                    .font(LitterFont.monospaced(.caption2, weight: .semibold))
+                                    .font(LitterFont.styled(.caption2, weight: .semibold))
                                     .foregroundColor(LitterTheme.textSecondary)
                                 Text(entry.value.value)
-                                    .font(LitterFont.monospaced(.caption2))
+                                    .font(LitterFont.styled(.caption2))
                                     .foregroundColor(LitterTheme.textSystem)
                                     .textSelection(.enabled)
                                 Spacer(minLength: 0)
@@ -171,10 +171,10 @@ struct ToolCallCardView: View {
                         ForEach(identifiedTextItems(items, prefix: "list")) { item in
                             HStack(alignment: .top, spacing: 6) {
                                 Text("•")
-                                    .font(LitterFont.monospaced(.caption))
+                                    .font(LitterFont.styled(.caption))
                                     .foregroundColor(LitterTheme.textSecondary)
                                 Text(item.value)
-                                    .font(LitterFont.monospaced(.caption))
+                                    .font(LitterFont.styled(.caption))
                                     .foregroundColor(LitterTheme.textSystem)
                                     .textSelection(.enabled)
                             }
@@ -198,7 +198,7 @@ struct ToolCallCardView: View {
                                     .frame(width: 6, height: 6)
                                     .padding(.top, 5)
                                 Text(item.value)
-                                    .font(LitterFont.monospaced(.caption))
+                                    .font(LitterFont.styled(.caption))
                                     .foregroundColor(LitterTheme.textSystem)
                                     .textSelection(.enabled)
                                 Spacer(minLength: 0)
@@ -215,7 +215,7 @@ struct ToolCallCardView: View {
 
     private func sectionLabel(_ label: String) -> some View {
         Text(label.uppercased())
-            .font(LitterFont.monospaced(.caption2, weight: .bold))
+            .font(LitterFont.styled(.caption2, weight: .bold))
             .foregroundColor(LitterTheme.textSecondary)
     }
 
@@ -289,6 +289,5 @@ private struct IndexedValue<Value>: Identifiable {
         ToolCallCardView(model: LitterPreviewData.sampleToolCallModel)
             .padding(20)
     }
-    .preferredColorScheme(.dark)
 }
 #endif


### PR DESCRIPTION
## Summary
- Convert all `LitterTheme` color tokens to adaptive `UIColor` dynamic providers — auto-switches with system appearance, zero changes at 100+ call sites
- Remove `.preferredColorScheme(.dark)` and `.toolbarColorScheme(.dark)` from all views and previews
- Replace hardcoded hex colors (`.foregroundColor(.white)`, `Color(hex: "#FF5555")`, etc.) with theme tokens
- Add dual Highlightr instances (atom-one-dark / atom-one-light) with theme-keyed cache
- Add font family setting (Monospaced / System SF Pro) via `@AppStorage("fontFamily")` and `LitterFont.styled()`
- Make `CodeBlockView` accept `fontSize` param so code blocks respect pinch-to-zoom text scale
- Override Highlightr attributed string fonts with Berkeley Mono at correct scaled size
- Fix sidebar dimness in light mode (solid surface behind ultraThinMaterial)
- Fix glass modifier fallback contrast in light mode (surfaceLight instead of surface)
- Make `textOnAccent` adaptive (white on dark buttons in light mode, black on light buttons in dark mode)

## Key changes
- `Extensions.swift` — adaptive theme colors, `FontFamilyOption` enum, `LitterFont.styled()`, `uiMonoFont()`, `headerScrim`
- `CodeBlockView.swift` — `fontSize` param, font override in highlighted attributed strings, dual highlighter
- `MessageBubbleView.swift` — pass `codeSize` to `CodeBlockView`, adaptive markdown heading colors
- `SettingsView.swift` — font family picker section
- `SidebarOverlay.swift` — solid surface behind material for light mode
- 12 other view files — `.preferredColorScheme`/`.toolbarColorScheme` removal, `.white`/`.black` → theme tokens

## Test plan
- [ ] Toggle system appearance (Settings > Developer > Dark Appearance) — verify all screens adapt
- [ ] Check conversation view, code blocks, tool call cards, header, sidebar, settings, discovery, SSH login, directory picker
- [ ] Verify code block syntax highlighting switches between light/dark themes
- [ ] Pinch-to-zoom in conversation — verify code blocks scale with body text
- [ ] Switch font family in Settings — verify non-code text updates, code blocks stay monospaced
- [ ] Verify accent green buttons (accentStrong) are readable in both modes