### PR TITLE
Add rate limit indicators

### DIFF
--- a/apps/ios/Sources/Litter/Bridge/CodexProtocol.swift
+++ b/apps/ios/Sources/Litter/Bridge/CodexProtocol.swift
@@ -1397,3 +1397,35 @@ struct AccountLoginCompletedNotification: Decodable {
 struct AccountUpdatedNotification: Decodable {
     let authMode: String?   // "apiKey" | "chatgpt" | nil
 }
+
+// MARK: - Rate Limits
+
+struct RateLimitWindow: Decodable {
+    let usedPercent: Double
+    let windowDurationMins: Int?
+    let resetsAt: Double?
+}
+
+struct CreditsSnapshot: Decodable {
+    let hasCredits: Bool
+    let unlimited: Bool
+    let balance: String?
+}
+
+struct RateLimitSnapshot: Decodable {
+    let limitId: String?
+    let limitName: String?
+    let primary: RateLimitWindow?
+    let secondary: RateLimitWindow?
+    let credits: CreditsSnapshot?
+    let planType: String?
+}
+
+struct GetAccountRateLimitsResponse: Decodable {
+    let rateLimits: RateLimitSnapshot
+    let rateLimitsByLimitId: [String: RateLimitSnapshot]?
+}
+
+struct AccountRateLimitsUpdatedNotification: Decodable {
+    let rateLimits: RateLimitSnapshot
+}

--- a/apps/ios/Sources/Litter/Models/ServerConnection.swift
+++ b/apps/ios/Sources/Litter/Models/ServerConnection.swift
@@ -16,6 +16,7 @@ final class ServerConnection: ObservableObject, Identifiable {
     @Published var loginCompleted = false
     @Published var models: [CodexModel] = []
     @Published var modelsLoaded = false
+    @Published var rateLimits: RateLimitSnapshot?
 
     let client = JSONRPCClient()
     private var serverURL: URL?
@@ -76,6 +77,7 @@ final class ServerConnection: ObservableObject, Identifiable {
             connectionPhase = "ready"
             Task { [weak self] in
                 await self?.checkAuth()
+                await self?.fetchRateLimits()
             }
         } catch {
             connectionPhase = "error: \(error.localizedDescription)"
@@ -86,6 +88,7 @@ final class ServerConnection: ObservableObject, Identifiable {
         Task { await client.disconnect() }
         isConnected = false
         serverURL = nil
+        rateLimits = nil
     }
 
     func forwardOAuthCallback(_ url: URL) {
@@ -438,6 +441,18 @@ final class ServerConnection: ObservableObject, Identifiable {
         oauthURL = nil
     }
 
+    // MARK: - Rate Limits
+
+    func fetchRateLimits() async {
+        struct EmptyParams: Encodable {}
+        guard let resp = try? await client.sendRequest(
+            method: "account/rateLimits/read",
+            params: EmptyParams(),
+            responseType: GetAccountRateLimitsResponse.self
+        ) else { return }
+        rateLimits = resp.rateLimits
+    }
+
     // MARK: - Account Notifications
 
     func handleAccountNotification(method: String, data: Data) {
@@ -452,6 +467,10 @@ final class ServerConnection: ObservableObject, Identifiable {
             }
         case "account/updated":
             Task { await self.checkAuth() }
+        case "account/rateLimits/updated":
+            if let notif = try? JSONDecoder().decode(AccountRateLimitsUpdatedNotification.self, from: extractParams(data)) {
+                rateLimits = notif.rateLimits
+            }
         default:
             break
         }

--- a/apps/ios/Sources/Litter/Models/ServerManager.swift
+++ b/apps/ios/Sources/Litter/Models/ServerManager.swift
@@ -985,7 +985,7 @@ final class ServerManager: ObservableObject {
 
     func handleNotification(serverId: String, method: String, data: Data) {
         switch method {
-        case "account/login/completed", "account/updated":
+        case "account/login/completed", "account/updated", "account/rateLimits/updated":
             connections[serverId]?.handleAccountNotification(method: method, data: data)
 
         case "sessionConfigured":
@@ -1175,6 +1175,7 @@ final class ServerManager: ObservableObject {
                     }
                 }
             }
+            Task { await connections[serverId]?.fetchRateLimits() }
 
         case "turn/diff/updated":
             handleTurnDiffNotification(serverId: serverId, data: data)

--- a/apps/ios/Sources/Litter/Views/ConversationView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationView.swift
@@ -180,6 +180,26 @@ struct ContextBadgeView: View, Equatable {
     }
 }
 
+struct RateLimitBadgeView: View, Equatable {
+    let label: String
+    let percent: Int
+
+    private var tint: Color {
+        if percent <= 10 { return LitterTheme.danger }
+        if percent <= 30 { return LitterTheme.warning }
+        return LitterTheme.textMuted
+    }
+
+    var body: some View {
+        HStack(spacing: 3) {
+            Text(label)
+                .font(.system(size: 7.5, weight: .semibold, design: .monospaced))
+                .foregroundColor(LitterTheme.textSecondary)
+            ContextBadgeView(percent: percent, tint: tint)
+        }
+    }
+}
+
 private struct BottomMarkerMaxYPreferenceKey: PreferenceKey {
     static var defaultValue: CGFloat = .greatestFiniteMagnitude
 
@@ -623,6 +643,13 @@ private struct ConversationInputBar: View {
                 .padding(.top, 8)
             }
             composerRow
+                .overlay(alignment: .bottomTrailing) {
+                    if bottomInset > 20 {
+                        contextBar
+                            .offset(y: 16)
+                    }
+                }
+                .padding(.bottom, bottomInset)
         }
         .overlay(alignment: .bottom) {
             if showSlashPopup {
@@ -920,7 +947,67 @@ private struct ConversationInputBar: View {
         }
         .padding(.horizontal, 12)
         .padding(.top, 6)
-        .padding(.bottom, max(bottomInset, 8))
+        .padding(.bottom, 6)
+    }
+
+    @ViewBuilder
+    private var contextBar: some View {
+        let rateLimits = serverManager.activeConnection?.rateLimits
+        let contextPct = contextPercent(thread: serverManager.activeThread)
+        let hasAnything = rateLimits?.primary != nil || rateLimits?.secondary != nil || contextPct != nil
+
+        if hasAnything {
+            HStack(spacing: 4) {
+                if let primary = rateLimits?.primary {
+                    RateLimitBadgeView(
+                        label: formatWindowLabel(primary),
+                        percent: normalizedPercent(primary.usedPercent)
+                    )
+                }
+                if let secondary = rateLimits?.secondary {
+                    RateLimitBadgeView(
+                        label: formatWindowLabel(secondary),
+                        percent: normalizedPercent(secondary.usedPercent)
+                    )
+                }
+                if let percent = contextPct {
+                    ContextBadgeView(percent: Int(percent), tint: contextTint(percent: percent))
+                }
+            }
+            .padding(.trailing, 40)
+        }
+    }
+
+    private func normalizedPercent(_ raw: Double) -> Int {
+        if raw > 1 { return min(Int(raw), 100) }
+        return min(Int(raw * 100), 100)
+    }
+
+    private func formatWindowLabel(_ window: RateLimitWindow) -> String {
+        guard let mins = window.windowDurationMins else { return "" }
+        if mins >= 1440 { return "\(mins / 1440)d" }
+        if mins >= 60 { return "\(mins / 60)h" }
+        return "\(mins)m"
+    }
+
+    private func contextPercent(thread: ThreadState?) -> Int64? {
+        guard let thread, let contextWindow = thread.modelContextWindow else { return nil }
+        let baseline: Int64 = 12_000
+        guard contextWindow > baseline else { return 0 }
+        let totalTokens = thread.contextTokensUsed ?? baseline
+        let effectiveWindow = contextWindow - baseline
+        let usedTokens = max(0, totalTokens - baseline)
+        let remainingTokens = max(0, effectiveWindow - usedTokens)
+        let percent = Int64((Double(remainingTokens) / Double(effectiveWindow) * 100).rounded())
+        return min(max(percent, 0), 100)
+    }
+
+    private func contextTint(percent: Int64) -> Color {
+        switch percent {
+        case ...15: return LitterTheme.danger
+        case ...35: return LitterTheme.warning
+        default: return LitterTheme.accentStrong
+        }
     }
 
     private var slashSuggestionPopup: some View {

--- a/apps/ios/Sources/Litter/Views/HeaderView.swift
+++ b/apps/ios/Sources/Litter/Views/HeaderView.swift
@@ -2,8 +2,6 @@ import SwiftUI
 import Inject
 
 struct HeaderView: View {
-    private static let contextBaselineTokens: Int64 = 12_000
-
     @ObserveInjection var inject
     @EnvironmentObject var serverManager: ServerManager
     @EnvironmentObject var appState: AppState
@@ -57,14 +55,11 @@ struct HeaderView: View {
                         .lineLimit(1)
                         .minimumScaleFactor(0.75)
 
-                        HStack(spacing: 6) {
-                            Text(sessionDirectoryLabel)
-                                .font(LitterFont.styled(.caption2, weight: .semibold))
-                                .foregroundColor(LitterTheme.textSecondary)
-                                .lineLimit(1)
-                                .truncationMode(.middle)
-                            ContextBadgeView(percent: Int(sessionContextPercent ?? 100), tint: sessionContextTint)
-                        }
+                        Text(sessionDirectoryLabel)
+                            .font(LitterFont.styled(.caption2, weight: .semibold))
+                            .foregroundColor(LitterTheme.textSecondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
                     }
                     .padding(.horizontal, 12)
                     .padding(.vertical, 6)
@@ -187,20 +182,6 @@ struct HeaderView: View {
         return "default"
     }
 
-    private var sessionContextTint: Color {
-        guard let percent = sessionContextPercent else {
-            return LitterTheme.textSecondary
-        }
-        switch percent {
-        case ...15:
-            return LitterTheme.danger
-        case ...35:
-            return LitterTheme.warning
-        default:
-            return LitterTheme.accentStrong
-        }
-    }
-
     private var sessionDirectoryLabel: String {
         let currentDirectory = serverManager.activeThread?.cwd.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if !currentDirectory.isEmpty {
@@ -213,19 +194,6 @@ struct HeaderView: View {
         }
 
         return "~"
-    }
-
-    private var sessionContextPercent: Int64? {
-        guard let thread = serverManager.activeThread,
-              let contextWindow = thread.modelContextWindow else {
-            return nil
-        }
-
-        let totalTokens = thread.contextTokensUsed ?? Self.contextBaselineTokens
-        return percentOfContextWindowRemaining(
-            totalTokens: totalTokens,
-            contextWindow: contextWindow
-        )
     }
 
     private func loadModelsIfNeeded() async {
@@ -297,18 +265,6 @@ struct HeaderView: View {
         }
         .accessibilityIdentifier("header.reloadButton")
         .disabled(isReloading || !serverManager.hasAnyConnection)
-    }
-
-    private func percentOfContextWindowRemaining(totalTokens: Int64, contextWindow: Int64) -> Int64 {
-        let baseline = Self.contextBaselineTokens
-        guard contextWindow > baseline else { return 0 }
-
-        let effectiveWindow = contextWindow - baseline
-        let usedTokens = max(0, totalTokens - baseline)
-        let remainingTokens = max(0, effectiveWindow - usedTokens)
-        let remainingFraction = Double(remainingTokens) / Double(effectiveWindow)
-        let percent = Int64((remainingFraction * 100).rounded())
-        return min(max(percent, 0), 100)
     }
 
 }


### PR DESCRIPTION
## Summary
- Add rate limit protocol types (`RateLimitSnapshot`, `RateLimitWindow`, etc.) and fetch/notification handling in `ServerConnection`
- Show 5h and 7d rate limit badges alongside the context badge below the input bar
- Move context badge from header to bottom-right overlay under the composer
- Fetch rate limits on connect and after every turn completion, plus handle `account/rateLimits/updated` push notifications
- Clean up stale rate limits on disconnect

## Test plan
- [ ] Verify rate limit badges appear below input bar when keyboard is dismissed
- [ ] Verify badges hide when keyboard is shown
- [ ] Verify rate limits update after sending a message (turn completion)
- [ ] Verify badge colors: green/muted when healthy, orange when low, red when critical
- [ ] Verify context badge still shows and updates correctly
- [ ] Test both light and dark mode