### PR TITLE
ios: add voice transcription with mic button and waveform

### DIFF
--- a/apps/ios/Litter.xcodeproj/project.pbxproj
+++ b/apps/ios/Litter.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		1B27B62916B4D6AF66BDA9F8 /* SSHLoginSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A9876F2929290D47ED57D77 /* SSHLoginSheet.swift */; };
 		1DB21F6FFA11CE197FCFDBD5 /* shell.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 874C6CFBD438D4B4909DD1CF /* shell.xcframework */; };
 		1DBECB5F40FE8322F20A327F /* ServerConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73840201673E0D1EE9E9DEBF /* ServerConnection.swift */; };
+		1E4B6194A06FB712657A24C7 /* AudioWaveformView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D9ACF04F4018F2949FB7E0 /* AudioWaveformView.swift */; };
 		2079821AAFA0AB0D5D4E429C /* BerkeleyMono-Oblique.otf in Resources */ = {isa = PBXBuildFile; fileRef = ACD06DF72574CDDF16E1E41B /* BerkeleyMono-Oblique.otf */; };
 		20AD8AEA4E06442319C65002 /* text.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CECEF29277C1DB1AD1EF304D /* text.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		24B302B9C08601CF5EBAC0E4 /* PreviewSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E744000053715A5866060B15 /* PreviewSupport.swift */; };
@@ -78,6 +79,7 @@
 		863E974F904C137CB6669DE0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 35949923355BB19A7209FD65 /* Assets.xcassets */; };
 		8B8335F1D0AA1E5584BCAF20 /* CodexProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2C91E2BA1A8F93DA7FF4EF /* CodexProtocol.swift */; };
 		8C573877188B1CF76579523A /* DiscoveredServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7779BD02F3B304F9C3AD32A1 /* DiscoveredServer.swift */; };
+		8CA530EBFB89D5E73C52F9A0 /* VoiceTranscriptionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A57573910BEE96B3224934D2 /* VoiceTranscriptionManager.swift */; };
 		8D3CAAD692101400C18D1A38 /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F79D1C06A25D0ABAA5042BA /* SafariView.swift */; };
 		8D4C21469289291B968CBEF0 /* shell.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 874C6CFBD438D4B4909DD1CF /* shell.xcframework */; };
 		8E7625BCA1A3CBE748954944 /* ThreadState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67AFB81F773863EB4A05235C /* ThreadState.swift */; };
@@ -105,6 +107,7 @@
 		C9FE50288375157B79A052FB /* SessionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CB5C5E5705BBF5E25A30B7 /* SessionListView.swift */; };
 		CB1ED98E60C5E933170DD52D /* SessionSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB8AEFFE3EBB0B8C6DBB218B /* SessionSidebarView.swift */; };
 		CC8E05E303DE114ADA2C409B /* Network.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA4A8B1B0E48B3DDC9F44D90 /* Network.framework */; };
+		CCEC8DC921FB6DB93D821519 /* VoiceTranscriptionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A57573910BEE96B3224934D2 /* VoiceTranscriptionManager.swift */; };
 		CD03B7391871A06D022D42BA /* HeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 817117A5E16EBD02388DBBE1 /* HeaderView.swift */; };
 		CDE88674C0C5A1B4C801267E /* ConnectionTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4925417F70C546B80DBD9EFF /* ConnectionTarget.swift */; };
 		CFA5E4B56537F480AFECC903 /* DirectoryPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318F2F8563E91AB97950F5DA /* DirectoryPickerView.swift */; };
@@ -124,6 +127,7 @@
 		EA2D4DECB54E28C6E6080CFA /* extraCommandsDictionary.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7043F325D81EDDF6CE12024E /* extraCommandsDictionary.plist */; };
 		EF8743F1629EB0DCA20AE787 /* text.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CECEF29277C1DB1AD1EF304D /* text.xcframework */; };
 		F2A99B16F6AB41896865CD11 /* BerkeleyMono-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 3BD63CCD80D9E1F66879EF97 /* BerkeleyMono-Bold.otf */; };
+		F3280D586DF6ABC6EC3FC818 /* AudioWaveformView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D9ACF04F4018F2949FB7E0 /* AudioWaveformView.swift */; };
 		F32CF5F7E077ABCAB4ECE1C7 /* text.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CECEF29277C1DB1AD1EF304D /* text.xcframework */; };
 		F5DC89787AAD41A2462541CD /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50CFDCB6C4655E3D2D76B41B /* AppState.swift */; };
 		F91EC376599CBBEC881C53E4 /* DirectoryPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318F2F8563E91AB97950F5DA /* DirectoryPickerView.swift */; };
@@ -205,6 +209,7 @@
 		545E3E3890AFDE088424F0C1 /* commandDictionary.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = commandDictionary.plist; sourceTree = "<group>"; };
 		55A7968182C0B25044D38C00 /* Litter.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Litter.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		615E709D4D5722523052907E /* SnapshotHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
+		63D9ACF04F4018F2949FB7E0 /* AudioWaveformView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioWaveformView.swift; sourceTree = "<group>"; };
 		67AFB81F773863EB4A05235C /* ThreadState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadState.swift; sourceTree = "<group>"; };
 		6A9876F2929290D47ED57D77 /* SSHLoginSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHLoginSheet.swift; sourceTree = "<group>"; };
 		7043F325D81EDDF6CE12024E /* extraCommandsDictionary.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = extraCommandsDictionary.plist; sourceTree = "<group>"; };
@@ -222,6 +227,7 @@
 		9B00D3C4EBCC298CE54D2D02 /* ToolCallMessageParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolCallMessageParserTests.swift; sourceTree = "<group>"; };
 		9DEE7E6F96B1BE1235356947 /* CodexIOSTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = CodexIOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A32EC379763C60302C66E8F3 /* JSONRPCClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCClient.swift; sourceTree = "<group>"; };
+		A57573910BEE96B3224934D2 /* VoiceTranscriptionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceTranscriptionManager.swift; sourceTree = "<group>"; };
 		AA4A8B1B0E48B3DDC9F44D90 /* Network.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Network.framework; path = System/Library/Frameworks/Network.framework; sourceTree = SDKROOT; };
 		ACD06DF72574CDDF16E1E41B /* BerkeleyMono-Oblique.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "BerkeleyMono-Oblique.otf"; sourceTree = "<group>"; };
 		B0648D501D363553E86BAE63 /* BerkeleyMono-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "BerkeleyMono-Regular.otf"; sourceTree = "<group>"; };
@@ -401,6 +407,7 @@
 				D2741603625C765D5BC95E39 /* ServerManager.swift */,
 				754A6F0D26DFBE19A8C6625F /* SSHSessionManager.swift */,
 				67AFB81F773863EB4A05235C /* ThreadState.swift */,
+				A57573910BEE96B3224934D2 /* VoiceTranscriptionManager.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -409,6 +416,7 @@
 			isa = PBXGroup;
 			children = (
 				818BC73F3855A9BA29C8E868 /* AccountView.swift */,
+				63D9ACF04F4018F2949FB7E0 /* AudioWaveformView.swift */,
 				C361CBF40ED3D35C44D46880 /* BrandLogo.swift */,
 				EEDF2E1FEDF741D69062FDDD /* CodeBlockView.swift */,
 				BF245554F39E59E68B72EB22 /* ConversationView.swift */,
@@ -620,6 +628,7 @@
 			files = (
 				ADA061B4E1F520DB54601B39 /* AccountView.swift in Sources */,
 				F5DC89787AAD41A2462541CD /* AppState.swift in Sources */,
+				F3280D586DF6ABC6EC3FC818 /* AudioWaveformView.swift in Sources */,
 				D2AB8A7F991FD28255C56CD3 /* BrandLogo.swift in Sources */,
 				176D9DB2C19A759EE50DFE57 /* ChatTypes.swift in Sources */,
 				5F3B965EDA58D389B2761F05 /* CodeBlockView.swift in Sources */,
@@ -652,6 +661,7 @@
 				7326B68EB1C5AA725F7E5DE4 /* ThreadState.swift in Sources */,
 				73273C538728D9434D9E9E53 /* ToolCallCardView.swift in Sources */,
 				0C8911DDC605F71148FC7E29 /* ToolCallMessageParser.swift in Sources */,
+				8CA530EBFB89D5E73C52F9A0 /* VoiceTranscriptionManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -670,6 +680,7 @@
 			files = (
 				5128C7E1A7C94802C9F677BA /* AccountView.swift in Sources */,
 				7E7B4AC85F18366192E98E8B /* AppState.swift in Sources */,
+				1E4B6194A06FB712657A24C7 /* AudioWaveformView.swift in Sources */,
 				E41F675D5DA4CB9AAF30EDC4 /* BrandLogo.swift in Sources */,
 				5342E9DEE1FB318F01E27F7E /* ChatTypes.swift in Sources */,
 				8445E0A9CDF58E2E9A509018 /* CodeBlockView.swift in Sources */,
@@ -702,6 +713,7 @@
 				8E7625BCA1A3CBE748954944 /* ThreadState.swift in Sources */,
 				3E2EEDE5F9D0CC0EE517AF52 /* ToolCallCardView.swift in Sources */,
 				28534FD8D729C47A8EF1A670 /* ToolCallMessageParser.swift in Sources */,
+				CCEC8DC921FB6DB93D821519 /* VoiceTranscriptionManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ios/Sources/Litter/Bridge/CodexProtocol.swift
+++ b/apps/ios/Sources/Litter/Bridge/CodexProtocol.swift
@@ -1384,6 +1384,16 @@ struct GetAccountResponse: Decodable {
     }
 }
 
+struct GetAuthStatusParams: Encodable {
+    let includeToken: Bool
+    let refreshToken: Bool
+}
+
+struct GetAuthStatusResponse: Decodable {
+    let authMethod: String?
+    let authToken: String?
+}
+
 struct CancelLoginParams: Encodable {
     let loginId: String
 }

--- a/apps/ios/Sources/Litter/Extensions.swift
+++ b/apps/ios/Sources/Litter/Extensions.swift
@@ -274,6 +274,20 @@ struct GlassRectModifier: ViewModifier {
     }
 }
 
+struct GlassRoundedRectModifier: ViewModifier {
+    var cornerRadius: CGFloat = 16
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content.glassEffect(.regular, in: .rect(cornerRadius: cornerRadius))
+        } else {
+            content
+                .background(LitterTheme.surfaceLight)
+                .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+        }
+    }
+}
+
 struct GlassCapsuleModifier: ViewModifier {
     func body(content: Content) -> some View {
         if #available(iOS 26.0, *) {

--- a/apps/ios/Sources/Litter/Info.plist
+++ b/apps/ios/Sources/Litter/Info.plist
@@ -38,6 +38,8 @@
 	</array>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Codex discovers coding agents and SSH servers on your local network.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Litter uses the microphone for voice-to-text input.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>BerkeleyMono-Regular.otf</string>

--- a/apps/ios/Sources/Litter/Models/ServerConnection.swift
+++ b/apps/ios/Sources/Litter/Models/ServerConnection.swift
@@ -390,6 +390,19 @@ final class ServerConnection: ObservableObject, Identifiable {
         }
     }
 
+    func getAuthToken() async -> (method: String?, token: String?) {
+        do {
+            let resp: GetAuthStatusResponse = try await client.sendRequest(
+                method: "getAuthStatus",
+                params: GetAuthStatusParams(includeToken: true, refreshToken: false),
+                responseType: GetAuthStatusResponse.self
+            )
+            return (resp.authMethod, resp.authToken)
+        } catch {
+            return (nil, nil)
+        }
+    }
+
     func loginWithChatGPT() async {
         do {
             let resp: LoginStartResponse = try await client.sendRequest(

--- a/apps/ios/Sources/Litter/Models/VoiceTranscriptionManager.swift
+++ b/apps/ios/Sources/Litter/Models/VoiceTranscriptionManager.swift
@@ -1,0 +1,241 @@
+import AVFoundation
+
+@MainActor
+final class VoiceTranscriptionManager: ObservableObject {
+    @Published var isRecording = false
+    @Published var isTranscribing = false
+    @Published var audioLevel: Float = 0
+    @Published var error: String?
+
+    private var audioEngine: AVAudioEngine?
+    private let bufferCollector = AudioBufferCollector()
+    private nonisolated(unsafe) var lastLevelUpdate: CFAbsoluteTime = 0
+
+    private static let targetSampleRate: Double = 24000
+    private static let transcribeModel = "gpt-4o-mini-transcribe"
+
+    func requestMicPermission() async -> Bool {
+        await AVAudioApplication.requestRecordPermission()
+    }
+
+    func startRecording() {
+        bufferCollector.reset()
+        error = nil
+
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(.playAndRecord, options: .defaultToSpeaker)
+            try session.setActive(true)
+        } catch {
+            self.error = "Failed to configure audio session."
+            return
+        }
+
+        let engine = AVAudioEngine()
+        let inputNode = engine.inputNode
+        let format = inputNode.outputFormat(forBus: 0)
+        let collector = bufferCollector
+
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: format) { [weak self] buffer, _ in
+            collector.append(buffer)
+            guard let self else { return }
+            let now = CFAbsoluteTimeGetCurrent()
+            guard now - self.lastLevelUpdate > 0.05 else { return }
+            self.lastLevelUpdate = now
+            let level = Self.rms(buffer: buffer)
+            Task { @MainActor in self.audioLevel = level }
+        }
+
+        do {
+            try engine.start()
+        } catch {
+            self.error = "Failed to start audio engine."
+            return
+        }
+
+        audioEngine = engine
+        isRecording = true
+    }
+
+    func stopAndTranscribe(authMethod: String?, authToken: String?) async -> String? {
+        guard isRecording else { return nil }
+        teardownEngine()
+
+        guard let wav = encodeWAV() else {
+            error = "Failed to encode audio."
+            return nil
+        }
+
+        guard let authToken, !authToken.isEmpty else {
+            error = "Not logged in."
+            return nil
+        }
+
+        isTranscribing = true
+        defer { isTranscribing = false }
+
+        do {
+            return try await transcribe(wav: wav, authMethod: authMethod, token: authToken)
+        } catch let err {
+            self.error = err.localizedDescription
+            return nil
+        }
+    }
+
+    func cancelRecording() {
+        teardownEngine()
+    }
+
+    // MARK: - Private
+
+    private func teardownEngine() {
+        audioEngine?.inputNode.removeTap(onBus: 0)
+        audioEngine?.stop()
+        audioEngine = nil
+        isRecording = false
+        audioLevel = 0
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+
+    private func encodeWAV() -> Data? {
+        let buffers = bufferCollector.drain()
+        guard let first = buffers.first else { return nil }
+
+        let srcRate = first.format.sampleRate
+        let targetRate = Self.targetSampleRate
+
+        var allSamples = [Float]()
+        for buf in buffers {
+            guard let data = buf.floatChannelData?[0] else { continue }
+            allSamples.append(contentsOf: UnsafeBufferPointer(start: data, count: Int(buf.frameLength)))
+        }
+        guard !allSamples.isEmpty else { return nil }
+
+        let resampled: [Int16]
+        if abs(srcRate - targetRate) < 1.0 {
+            resampled = allSamples.map { Self.floatToInt16($0) }
+        } else {
+            let ratio = targetRate / srcRate
+            let outCount = Int(Double(allSamples.count) * ratio)
+            var out = [Int16](repeating: 0, count: outCount)
+            for i in 0..<outCount {
+                let srcIdx = Double(i) / ratio
+                let idx = Int(srcIdx)
+                let frac = Float(srcIdx - Double(idx))
+                let s0 = allSamples[min(idx, allSamples.count - 1)]
+                let s1 = allSamples[min(idx + 1, allSamples.count - 1)]
+                out[i] = Self.floatToInt16(s0 + frac * (s1 - s0))
+            }
+            resampled = out
+        }
+
+        guard Float(resampled.count) / Float(targetRate) >= 0.5 else { return nil }
+
+        let dataSize = resampled.count * 2
+        var wav = Data(capacity: 44 + dataSize)
+        wav.append(contentsOf: "RIFF".utf8)
+        wav.appendLE(UInt32(36 + dataSize))
+        wav.append(contentsOf: "WAVE".utf8)
+        wav.append(contentsOf: "fmt ".utf8)
+        wav.appendLE(UInt32(16))
+        wav.appendLE(UInt16(1)) // PCM
+        wav.appendLE(UInt16(1)) // mono
+        wav.appendLE(UInt32(UInt32(targetRate)))
+        wav.appendLE(UInt32(UInt32(targetRate) * 2)) // byte rate
+        wav.appendLE(UInt16(2)) // block align
+        wav.appendLE(UInt16(16)) // bits per sample
+        wav.append(contentsOf: "data".utf8)
+        wav.appendLE(UInt32(dataSize))
+        resampled.withUnsafeBufferPointer { ptr in
+            wav.append(contentsOf: UnsafeRawBufferPointer(ptr))
+        }
+        return wav
+    }
+
+    private func transcribe(wav: Data, authMethod: String?, token: String) async throws -> String {
+        let isChatGPT = authMethod == "chatgpt" || authMethod == "chatgptAuthTokens"
+
+        let url: URL
+        if isChatGPT {
+            url = URL(string: "https://chatgpt.com/backend-api/transcribe")!
+        } else {
+            url = URL(string: "https://api.openai.com/v1/audio/transcriptions")!
+        }
+
+        let boundary = UUID().uuidString
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+        var body = Data()
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: audio/wav\r\n\r\n".data(using: .utf8)!)
+        body.append(wav)
+        body.append("\r\n".data(using: .utf8)!)
+        if !isChatGPT {
+            body.append("--\(boundary)\r\n".data(using: .utf8)!)
+            body.append("Content-Disposition: form-data; name=\"model\"\r\n\r\n".data(using: .utf8)!)
+            body.append("\(Self.transcribeModel)\r\n".data(using: .utf8)!)
+        }
+        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+        request.httpBody = body
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+            throw NSError(domain: "Transcription", code: status, userInfo: [
+                NSLocalizedDescriptionKey: "Transcription failed (\(status))"
+            ])
+        }
+
+        struct TranscriptionResponse: Decodable { let text: String }
+        return try JSONDecoder().decode(TranscriptionResponse.self, from: data).text
+    }
+
+    private static func floatToInt16(_ v: Float) -> Int16 {
+        Int16(max(-1, min(1, v)) * Float(Int16.max))
+    }
+
+    private static func rms(buffer: AVAudioPCMBuffer) -> Float {
+        guard let data = buffer.floatChannelData?[0] else { return 0 }
+        let count = Int(buffer.frameLength)
+        guard count > 0 else { return 0 }
+        var sum: Float = 0
+        for i in 0..<count { sum += data[i] * data[i] }
+        return min(sqrtf(sum / Float(count)) * 3, 1.0)
+    }
+}
+
+private final class AudioBufferCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var buffers: [AVAudioPCMBuffer] = []
+
+    func append(_ buffer: AVAudioPCMBuffer) {
+        lock.lock()
+        buffers.append(buffer)
+        lock.unlock()
+    }
+
+    func drain() -> [AVAudioPCMBuffer] {
+        lock.lock()
+        let result = buffers
+        buffers = []
+        lock.unlock()
+        return result
+    }
+
+    func reset() {
+        lock.lock()
+        buffers = []
+        lock.unlock()
+    }
+}
+
+private extension Data {
+    mutating func appendLE<T: FixedWidthInteger>(_ value: T) {
+        var le = value.littleEndian
+        Swift.withUnsafeBytes(of: &le) { append(contentsOf: $0) }
+    }
+}

--- a/apps/ios/Sources/Litter/Views/AudioWaveformView.swift
+++ b/apps/ios/Sources/Litter/Views/AudioWaveformView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct AudioWaveformView: View {
+    let level: Float
+
+    private static let barCount = 24
+
+    @State private var smoothedLevel: CGFloat = 0
+    @State private var ring = [CGFloat](repeating: 0, count: AudioWaveformView.barCount)
+    @State private var head = 0
+
+    var body: some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 30)) { timeline in
+            Canvas { ctx, size in
+                let _ = timeline.date
+                let midY = size.height / 2
+                let barWidth: CGFloat = 2
+                let gap = (size.width - barWidth * CGFloat(Self.barCount)) / CGFloat(Self.barCount - 1)
+
+                for i in 0..<Self.barCount {
+                    let ri = (head + i) % Self.barCount
+                    let h = ring[ri]
+                    let barHeight = max(2, h * size.height * 0.9)
+                    let x = CGFloat(i) * (barWidth + gap)
+                    let rect = CGRect(x: x, y: midY - barHeight / 2, width: barWidth, height: barHeight)
+                    ctx.fill(
+                        Path(roundedRect: rect, cornerRadius: 1),
+                        with: .color(LitterTheme.accentStrong.opacity(0.4 + 0.6 * h))
+                    )
+                }
+            }
+            .onChange(of: timeline.date) { _, _ in pushLevel() }
+        }
+        .onAppear { pushLevel() }
+    }
+
+    private func pushLevel() {
+        smoothedLevel += (CGFloat(level) - smoothedLevel) * 0.3
+        ring[head] = smoothedLevel
+        head = (head + 1) % Self.barCount
+    }
+}

--- a/apps/ios/Sources/Litter/Views/ConversationView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationView.swift
@@ -608,6 +608,8 @@ private struct ConversationInputBar: View {
     @State private var skillsLoading = false
     @State private var mentionSkillPathsByName: [String: String] = [:]
     @State private var hasAttemptedSkillMentionLoad = false
+    @StateObject private var voiceManager = VoiceTranscriptionManager()
+    @State private var showMicPermissionAlert = false
 
     private var hasText: Bool {
         !inputText.trimmingCharacters(in: .whitespaces).isEmpty
@@ -677,7 +679,18 @@ private struct ConversationInputBar: View {
             hideComposerPopups()
             inputFocused.wrappedValue = true
         }
+        .alert("Microphone Access", isPresented: $showMicPermissionAlert) {
+            Button("Open Settings") {
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(url)
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Microphone permission is required for voice input. Enable it in Settings.")
+        }
         .onDisappear {
+            if voiceManager.isRecording { voiceManager.cancelRecording() }
             popupRefreshTask?.cancel()
             popupRefreshTask = nil
             fileSearchTask?.cancel()
@@ -887,12 +900,15 @@ private struct ConversationInputBar: View {
 
     private var composerRow: some View {
         HStack(alignment: .center, spacing: 8) {
-            Button { showAttachMenu = true } label: {
-                Image(systemName: "plus")
-                    .font(.system(.subheadline, weight: .semibold))
-                    .foregroundColor(LitterTheme.textPrimary)
-                    .frame(width: 32, height: 32)
-                    .modifier(GlassCircleModifier())
+            if !voiceManager.isRecording && !voiceManager.isTranscribing && !isTurnActive {
+                Button { showAttachMenu = true } label: {
+                    Image(systemName: "plus")
+                        .font(.system(.body, weight: .semibold))
+                        .foregroundColor(LitterTheme.textPrimary)
+                        .frame(width: 36, height: 36)
+                        .modifier(GlassCircleModifier())
+                }
+                .transition(.scale.combined(with: .opacity))
             }
 
             HStack(spacing: 0) {
@@ -903,19 +919,10 @@ private struct ConversationInputBar: View {
                     .focused(inputFocused)
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled(true)
-                    .padding(.leading, 14)
-                    .padding(.vertical, 8)
+                    .padding(.leading, 16)
+                    .padding(.vertical, 10)
 
-                if isTurnActive {
-                    Button {
-                        Task { await serverManager.interrupt() }
-                    } label: {
-                        Image(systemName: "stop.circle.fill")
-                            .font(.system(.title2))
-                            .foregroundColor(LitterTheme.danger)
-                    }
-                    .padding(.trailing, 4)
-                } else if hasText {
+                if hasText {
                     Button {
                         let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
                         guard !text.isEmpty else { return }
@@ -940,11 +947,68 @@ private struct ConversationInputBar: View {
                             .foregroundColor(LitterTheme.accent)
                     }
                     .padding(.trailing, 4)
+                } else if voiceManager.isRecording {
+                    AudioWaveformView(level: voiceManager.audioLevel)
+                        .frame(width: 48, height: 20)
+                    Button {
+                        Task {
+                            let auth = await serverManager.activeConnection?.getAuthToken()
+                            if let text = await voiceManager.stopAndTranscribe(
+                                authMethod: auth?.method, authToken: auth?.token
+                            ), !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                                inputText = text
+                            }
+                        }
+                    } label: {
+                        Image(systemName: "stop.circle.fill")
+                            .font(.system(.title2))
+                            .foregroundColor(LitterTheme.accentStrong)
+                            .frame(width: 32, height: 32)
+                            .contentShape(Rectangle())
+                    }
+                    .padding(.trailing, 4)
+                } else if voiceManager.isTranscribing {
+                    ProgressView()
+                        .tint(LitterTheme.accent)
+                        .padding(.trailing, 8)
+                } else {
+                    Button {
+                        Task {
+                            let granted = await voiceManager.requestMicPermission()
+                            guard granted else {
+                                showMicPermissionAlert = true
+                                return
+                            }
+                            voiceManager.startRecording()
+                        }
+                    } label: {
+                        Image(systemName: "mic.fill")
+                            .font(.system(.subheadline))
+                            .foregroundColor(LitterTheme.textSecondary)
+                            .frame(width: 32, height: 32)
+                            .contentShape(Rectangle())
+                    }
+                    .padding(.trailing, 4)
                 }
             }
-            .frame(minHeight: 32)
-            .modifier(GlassCapsuleModifier())
+            .frame(minHeight: 36)
+            .modifier(GlassRoundedRectModifier(cornerRadius: 20))
+
+            if isTurnActive {
+                Button {
+                    Task { await serverManager.interrupt() }
+                } label: {
+                    Text("Cancel")
+                        .font(.system(.subheadline, weight: .medium))
+                        .foregroundColor(LitterTheme.textPrimary)
+                        .padding(.horizontal, 14)
+                        .frame(height: 36)
+                        .modifier(GlassCapsuleModifier())
+                }
+                .transition(.move(edge: .trailing).combined(with: .opacity))
+            }
         }
+        .animation(.spring(response: 0.3, dampingFraction: 0.86), value: isTurnActive)
         .padding(.horizontal, 12)
         .padding(.top, 6)
         .padding(.bottom, 6)


### PR DESCRIPTION
## Summary
- Add mic button to input bar that records audio and transcribes via OpenAI/ChatGPT transcription API (same flow as TUI voice mode)
- Live waveform visualization (Canvas + TimelineView at 30fps with circular buffer)
- Glass capsule "Cancel" button outside input bar for turn interruption, with spring animation
- Input bar uses RoundedRectangle instead of Capsule to fix multi-line text clipping

## Key changes
- **VoiceTranscriptionManager** — AVAudioEngine recording, WAV encoding (24kHz mono 16-bit), multipart POST to transcription API using auth token from server
- **AudioWaveformView** — Canvas-based waveform with smoothed audio levels and circular buffer
- **ConversationView** — mic/stop/transcribing states in composer, cancel button outside input box
- **ServerConnection.getAuthToken()** — fetches bearer token via `getAuthStatus` RPC
- **GlassRoundedRectModifier** — fixed corner radius glass effect for input bar

## Test plan
- [ ] Build and run on physical device (mic doesn't work on simulator)
- [ ] Verify mic button appears when input is empty and no turn active
- [ ] Tap mic → grant permission → recording starts with waveform
- [ ] Tap stop → transcription spinner → text appears in input field
- [ ] Verify Cancel button appears during active turns with animation
- [ ] Verify multi-line text doesn't clip outside input box corners