### PR TITLE
ios: resolve SSH codex bootstrap via login shell

### DIFF
--- a/apps/ios/Sources/Litter/Models/SSHSessionManager.swift
+++ b/apps/ios/Sources/Litter/Models/SSHSessionManager.swift
@@ -247,14 +247,18 @@ actor SSHSessionManager {
         return ports
     }
 
+    private func loginShell(_ script: String) -> String {
+        let base64 = Data(script.utf8).base64EncodedString()
+        return "$SHELL -l -c \"$(echo \(base64) | base64 -d)\""
+    }
+
     private func resolveServerLaunchCommand(client: SSHClient) async throws -> ServerLaunchCommand? {
         let script = """
-        for f in "$HOME/.profile" "$HOME/.bash_profile" "$HOME/.bashrc" "$HOME/.zprofile" "$HOME/.zshrc"; do
-          [ -f "$f" ] && . "$f" 2>/dev/null
-        done
         codex_path="$(command -v codex 2>/dev/null || true)"
         if [ -n "$codex_path" ] && [ -f "$codex_path" ] && [ -x "$codex_path" ]; then
           printf 'codex:%s' "$codex_path"
+        elif [ -x "$HOME/.bun/bin/codex" ]; then
+          printf 'codex:%s' "$HOME/.bun/bin/codex"
         elif [ -x "$HOME/.volta/bin/codex" ]; then
           printf 'codex:%s' "$HOME/.volta/bin/codex"
         elif [ -x "$HOME/.cargo/bin/codex" ]; then
@@ -268,7 +272,7 @@ actor SSHSessionManager {
           fi
         fi
         """
-        let output = String(buffer: try await client.executeCommand(script))
+        let output = String(buffer: try await client.executeCommand(loginShell(script)))
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard !output.isEmpty else { return nil }
         let parts = output.split(separator: ":", maxSplits: 1).map(String.init)
@@ -338,7 +342,7 @@ actor SSHSessionManager {
             helpCommand = "\(shellQuote(executable)) --help 2>&1 || true"
         }
 
-        let helpText = String(buffer: try await client.executeCommand(helpCommand))
+        let helpText = String(buffer: try await client.executeCommand(loginShell(helpCommand)))
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard !helpText.isEmpty else { return nil }
 
@@ -353,8 +357,7 @@ actor SSHSessionManager {
     }
 
     private func backgroundedLaunch(_ launch: String, logPath: String) -> String {
-        let profileInit = "for f in \"$HOME/.profile\" \"$HOME/.bash_profile\" \"$HOME/.bashrc\" \"$HOME/.zprofile\" \"$HOME/.zshrc\"; do [ -f \"$f\" ] && . \"$f\" 2>/dev/null; done;"
-        return "\(profileInit) nohup \(launch) </dev/null >\(shellQuote(logPath)) 2>&1 & echo $!"
+        loginShell("nohup \(launch) </dev/null >\(shellQuote(logPath)) 2>&1 & echo $!")
     }
 
     private func isPortListening(client: SSHClient, port: UInt16) async throws -> Bool {

--- a/docs/releases/testflight-whats-new.md
+++ b/docs/releases/testflight-whats-new.md
@@ -1,5 +1,25 @@
-- iOS: Reapplied and stabilized conversation UX after PR merge, including pinch-to-zoom text sizing, animated "Latest" jump-to-bottom, improved scroll behavior, and more reliable network discovery scanning. (@dnakov)
-- Cross-platform UI: Bundled Berkeley Mono on iOS and Android and wired it into app styling. (@dnakov)
-- Android: Added bundled Codex server + node proxy flow for on-device usage, plus settings-sheet regression fix and CI archive-tool fallback (`ar` vs `bsdtar`). (@Dixith-dev)
-- App polish and integration cleanups across iOS/Android in the PR-11 merge train (state/UI refinements, identifier cleanup, and follow-up fixes). (@makyinmars)
-- Release process: Enforced non-empty TestFlight changelog notes in upload tooling/checklist. (@dnakov)
+Summary
+
+- SSH bootstrap now resolves `codex` through a real login shell and explicitly supports Bun-installed Codex binaries.
+- Big iOS UI refresh with liquid glass styling and a full-screen conversation layout.
+- Discovery, auth, and local Codex server flows are more reliable and easier to recover from.
+- New personalization controls for theme, font family, and code block scaling.
+- Added rate-limit visibility and voice transcription in the composer.
+
+What to test
+
+- Verify SSH startup on Macs where `codex` is only available after shell init or installed under `~/.bun/bin`.
+- Try the new mic button and confirm voice transcription inserts cleanly into the composer.
+- Check rate-limit indicators and the updated context placement around the input area.
+- Switch theme/font settings and verify light mode, typography, and code blocks render correctly.
+- Exercise discovery, login, local server startup, and stop/error handling flows.
+
+Merged PRs in the last 24 hours
+
+- PR #21: iOS voice transcription with mic button and waveform.
+- PR #20: Rate-limit indicators and updated context badge placement.
+- PR #19: Light mode, font family setting, and code block scaling.
+- PR #18: Keyboard fix, OAuth callback forwarding, and auth UX improvements.
+- PR #17: Local Codex server fixes and bundled TLS root certificates.
+- PR #16: Auth-gated discovery, stop button, clearer errors, and local directory picker.
+- PR #15: Liquid glass UI and full-screen conversation refresh.


### PR DESCRIPTION
## Purpose
Ensure SSH bootstrap can find Codex when it is only available from a real login shell, and persist the TestFlight notes used for the latest build.

## Key changes
- run SSH command discovery, help checks, and background launch through `$SHELL -l -c`
- explicitly detect Bun-installed Codex at `~/.bun/bin/codex`
- update the TestFlight summary, test focus, and last-24h PR rollup in `docs/releases/testflight-whats-new.md`

## Verification
- `./apps/ios/scripts/testflight-upload.sh`
- TestFlight build `1.0.1 (20260226153226)`
- Build record `07f7ad88-2b37-438c-b233-10d863845335`
- Internal state `READY_FOR_BETA_TESTING`
- External state `IN_BETA_TESTING`
- Beta review `APPROVED`
