### PR TITLE
android: add OpenCode mobile shell support

### DIFF
--- a/apps/android/app/src/debug/AndroidManifest.xml
+++ b/apps/android/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application android:usesCleartextTraffic="true" />
+</manifest>

--- a/apps/android/app/src/main/java/com/litter/android/state/OpenCodeClient.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/OpenCodeClient.kt
@@ -1,0 +1,436 @@
+package com.litter.android.state
+
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.BufferedReader
+import java.io.Closeable
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URL
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal class OpenCodeClient(
+    private val server: ServerConfig,
+) : Closeable {
+    private val closed = AtomicBoolean(false)
+    private var eventThread: Thread? = null
+    private var eventConnection: HttpURLConnection? = null
+
+    fun connect() {
+        val response = request("GET", "/global/health")
+        if (!response.optBoolean("healthy", false)) {
+            throw IllegalStateException("OpenCode server is not healthy")
+        }
+    }
+
+    fun currentDirectory(): String? =
+        runCatching { request("GET", "/path").optString("directory").trim().ifBlank { null } }.getOrNull()
+
+    fun listSessions(): JSONArray {
+        val directory = scopedDirectory()
+        val query = if (directory != null) "?directory=${urlEncode(directory)}" else ""
+        return requestArray("GET", "/session$query")
+    }
+
+    fun listStatuses(): JSONObject =
+        request("GET", "/session/status")
+
+    fun loadMessages(sessionId: String): JSONArray =
+        requestArray("GET", "/session/$sessionId/message")
+
+    fun createSession(): JSONObject =
+        request("POST", "/session", JSONObject())
+
+    fun listSlashes(): JSONArray =
+        runCatching { requestArray("GET", "/slash") }
+            .getOrElse {
+                val commands = requestArray("GET", "/command")
+                JSONArray().also { items ->
+                    for (index in 0 until commands.length()) {
+                        val item = commands.optJSONObject(index) ?: continue
+                        val source = item.optString("source").trim().ifBlank { null }
+                        if (source == "skill") {
+                            continue
+                        }
+                        val name = item.optString("name").trim()
+                        if (name.isEmpty()) {
+                            continue
+                        }
+                        items.put(
+                            JSONObject()
+                                .put("id", "command:$name")
+                                .put("kind", "command")
+                                .put("name", name)
+                                .put("aliases", JSONArray())
+                                .put("description", item.optString("description").trim())
+                                .put("category", if (source == "mcp") "MCP" else "Prompt")
+                                .put("source", source ?: JSONObject.NULL)
+                                .put("displayName", "/$name${if (source == "mcp") ":mcp" else ""}"),
+                        )
+                    }
+                }
+            }
+
+    fun listSkills(): JSONArray =
+        requestArray("GET", "/skill")
+
+    fun listAgents(): JSONArray =
+        requestArray("GET", "/agent")
+
+    fun listMcpStatus(): JSONObject =
+        request("GET", "/mcp")
+
+    fun listProviders(): JSONObject =
+        request("GET", "/provider")
+
+    fun listConfigProviders(): JSONObject =
+        request("GET", "/config/providers")
+
+    fun pathInfo(): JSONObject =
+        request("GET", "/path")
+
+    fun vcsInfo(): JSONObject =
+        request("GET", "/vcs")
+
+    fun lspStatus(): JSONArray =
+        requestArray("GET", "/lsp")
+
+    fun formatterStatus(): JSONArray =
+        requestArray("GET", "/formatter")
+
+    fun sendPrompt(
+        sessionId: String,
+        text: String,
+        model: JSONObject? = null,
+        agent: String? = null,
+    ) {
+        val parts =
+            JSONArray().put(
+                JSONObject()
+                    .put("type", "text")
+                    .put("text", text),
+            )
+        val body =
+            JSONObject()
+                .put("parts", parts)
+                .apply {
+                    putOpt("model", model)
+                    putOpt("agent", agent?.trim()?.ifEmpty { null })
+                }
+        requestEmpty(
+            "POST",
+            "/session/$sessionId/prompt_async",
+            body,
+            expectedStatus = 204,
+        )
+    }
+
+    fun executeCommand(
+        sessionId: String,
+        command: String,
+        arguments: String,
+        model: String? = null,
+        agent: String? = null,
+        parts: JSONArray? = null,
+    ): JSONObject =
+        request(
+            "POST",
+            "/session/$sessionId/command",
+            JSONObject()
+                .put("command", command)
+                .put("arguments", arguments)
+                .apply {
+                    putOpt("model", model?.trim()?.ifEmpty { null })
+                    putOpt("agent", agent?.trim()?.ifEmpty { null })
+                    putOpt("parts", parts)
+                },
+        )
+
+    fun abort(sessionId: String) {
+        request("POST", "/session/$sessionId/abort", JSONObject())
+    }
+
+    fun shareSession(sessionId: String): JSONObject =
+        request("POST", "/session/$sessionId/share", JSONObject())
+
+    fun unshareSession(sessionId: String): JSONObject =
+        request("DELETE", "/session/$sessionId/share")
+
+    fun summarizeSession(
+        sessionId: String,
+        providerId: String,
+        modelId: String,
+    ): JSONObject =
+        request(
+            "POST",
+            "/session/$sessionId/summarize",
+            JSONObject()
+                .put("providerID", providerId)
+                .put("modelID", modelId),
+        )
+
+    fun revertSession(
+        sessionId: String,
+        messageId: String,
+    ): JSONObject =
+        request(
+            "POST",
+            "/session/$sessionId/revert",
+            JSONObject().put("messageID", messageId),
+        )
+
+    fun unrevertSession(sessionId: String): JSONObject =
+        request("POST", "/session/$sessionId/unrevert", JSONObject())
+
+    fun renameSession(
+        sessionId: String,
+        title: String,
+    ) {
+        request("PATCH", "/session/$sessionId", JSONObject().put("title", title))
+    }
+
+    fun archiveSession(
+        sessionId: String,
+        archived: Boolean,
+    ) {
+        val time = if (archived) System.currentTimeMillis() else JSONObject.NULL
+        request("PATCH", "/session/$sessionId", JSONObject().put("time", JSONObject().put("archived", time)))
+    }
+
+    fun forkSession(sessionId: String): JSONObject =
+        request("POST", "/session/$sessionId/fork", JSONObject())
+
+    fun listPermissions(): JSONArray =
+        requestArray("GET", "/permission")
+
+    fun replyPermission(
+        requestId: String,
+        reply: String,
+    ) {
+        request("POST", "/permission/$requestId/reply", JSONObject().put("reply", reply))
+    }
+
+    fun listQuestions(): JSONArray =
+        requestArray("GET", "/question")
+
+    fun replyQuestion(
+        requestId: String,
+        answers: List<List<String>>,
+    ) {
+        val encodedAnswers = JSONArray()
+        answers.forEach { answer ->
+            val values = JSONArray()
+            answer.forEach(values::put)
+            encodedAnswers.put(values)
+        }
+        request("POST", "/question/$requestId/reply", JSONObject().put("answers", encodedAnswers))
+    }
+
+    fun rejectQuestion(requestId: String) {
+        request("POST", "/question/$requestId/reject", JSONObject())
+    }
+
+    fun subscribeEvents(onEvent: (JSONObject) -> Unit) {
+        closeEventStream()
+        eventThread =
+            Thread {
+                while (!closed.get()) {
+                    var connection: HttpURLConnection? = null
+                    try {
+                        connection = openConnection("/event", "GET")
+                        connection.setRequestProperty("Accept", "text/event-stream")
+                        connection.connect()
+                        if (connection.responseCode !in 200..299) {
+                            throw IllegalStateException("OpenCode event stream failed with HTTP ${connection.responseCode}")
+                        }
+                        eventConnection = connection
+                        val reader =
+                            BufferedReader(
+                                InputStreamReader(connection.inputStream, StandardCharsets.UTF_8),
+                            )
+                        val data = StringBuilder()
+                        while (!closed.get()) {
+                            val line = reader.readLine() ?: break
+                            if (line.isEmpty()) {
+                                if (data.isNotEmpty()) {
+                                    val payload = data.toString().trim()
+                                    if (payload.isNotEmpty()) {
+                                        onEvent(JSONObject(payload))
+                                    }
+                                    data.setLength(0)
+                                }
+                                continue
+                            }
+                            if (line.startsWith("data:")) {
+                                data.append(line.removePrefix("data:").trim()).append('\n')
+                            }
+                        }
+                    } catch (_: Throwable) {
+                        if (closed.get()) {
+                            return@Thread
+                        }
+                        Thread.sleep(500L)
+                    } finally {
+                        connection?.disconnect()
+                        eventConnection = null
+                    }
+                }
+            }.apply {
+                name = "Litter-OpenCode-Events-${server.id}"
+                isDaemon = true
+                start()
+            }
+    }
+
+    override fun close() {
+        closed.set(true)
+        closeEventStream()
+        eventThread?.interrupt()
+        eventThread = null
+    }
+
+    private fun closeEventStream() {
+        eventConnection?.disconnect()
+        eventConnection = null
+    }
+
+    private fun scopedDirectory(): String? =
+        server.directory?.trim()?.ifBlank { null }
+
+    private fun request(
+        method: String,
+        path: String,
+        body: JSONObject? = null,
+    ): JSONObject {
+        val response = requestRaw(method, path, body, expectedStatus = null)
+        return if (response.isBlank()) JSONObject() else JSONObject(response)
+    }
+
+    private fun requestArray(
+        method: String,
+        path: String,
+    ): JSONArray {
+        val response = requestRaw(method, path, null, expectedStatus = null)
+        return if (response.isBlank()) JSONArray() else JSONArray(response)
+    }
+
+    private fun requestEmpty(
+        method: String,
+        path: String,
+        body: JSONObject? = null,
+        expectedStatus: Int,
+    ) {
+        requestRaw(method, path, body, expectedStatus = expectedStatus)
+    }
+
+    private fun requestRaw(
+        method: String,
+        path: String,
+        body: JSONObject?,
+        expectedStatus: Int?,
+    ): String {
+        val connection = openConnection(path, method)
+        return try {
+            if (body != null) {
+                connection.doOutput = true
+                OutputStreamWriter(connection.outputStream, StandardCharsets.UTF_8).use { writer ->
+                    writer.write(body.toString())
+                }
+            }
+            val status = connection.responseCode
+            if (expectedStatus != null) {
+                if (status != expectedStatus) {
+                    throw IllegalStateException(readError(connection, status))
+                }
+            } else if (status !in 200..299) {
+                throw IllegalStateException(readError(connection, status))
+            }
+            BufferedReader(InputStreamReader(connection.inputStream, StandardCharsets.UTF_8)).use { reader ->
+                reader.readText()
+            }
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    private fun readError(
+        connection: HttpURLConnection,
+        status: Int,
+    ): String {
+        val text =
+            runCatching {
+                connection.errorStream?.bufferedReader(StandardCharsets.UTF_8)?.use { it.readText() }
+            }.getOrNull()
+        return "OpenCode request failed with HTTP $status${if (text.isNullOrBlank()) "" else ": $text"}"
+    }
+
+    private fun openConnection(
+        path: String,
+        method: String,
+    ): HttpURLConnection {
+        val baseUrl =
+            if (server.host.contains("://")) {
+                val parsed = URL(server.host)
+                val port = if (parsed.port > 0) parsed.port else server.port
+                URL(parsed.protocol, parsed.host, port, openCodePath(parsed.path, path))
+            } else {
+                val normalizedHost =
+                    if (server.host.contains(':') && !server.host.startsWith("[") && !server.host.endsWith("]")) {
+                        "[${server.host}]"
+                    } else {
+                        server.host
+                    }
+                URL("http://$normalizedHost:${server.port}$path")
+            }
+        return (baseUrl.openConnection() as HttpURLConnection).apply {
+            requestMethod = method
+            connectTimeout = 8_000
+            readTimeout = 0
+            setRequestProperty("Accept", "application/json")
+            setRequestProperty("Content-Type", "application/json")
+            server.username
+                ?.takeIf { server.password != null }
+                ?.let { username ->
+                    setRequestProperty("Authorization", basicAuth(username, server.password.orEmpty()))
+                }
+                ?: server.password?.let { password ->
+                    setRequestProperty("Authorization", basicAuth("opencode", password))
+                }
+            scopedDirectory()?.let { directory ->
+                setRequestProperty("x-opencode-directory", urlEncode(directory))
+            }
+        }
+    }
+
+    private fun basicAuth(
+        username: String,
+        password: String,
+    ): String {
+        val raw = "$username:$password".toByteArray(StandardCharsets.UTF_8)
+        return "Basic ${Base64.getEncoder().encodeToString(raw)}"
+    }
+
+    private fun urlEncode(value: String): String =
+        java.net.URLEncoder.encode(value, StandardCharsets.UTF_8.toString())
+}
+
+internal fun openCodePath(
+    base: String?,
+    path: String,
+): String {
+    val prefix = base?.trim().orEmpty().trimEnd('/').ifEmpty { "/" }
+    val suffix = path.trim().ifEmpty { "/" }
+    if (prefix == "/") {
+        return if (suffix.startsWith("/")) suffix else "/$suffix"
+    }
+    return buildString {
+        append(prefix)
+        if (!suffix.startsWith("/")) {
+            append('/')
+        }
+        append(suffix)
+    }
+}

--- a/apps/android/app/src/main/java/com/litter/android/state/ServerManager.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/ServerManager.kt
@@ -54,13 +54,21 @@ class ServerManager(
     private val mainHandler = Handler(Looper.getMainLooper())
     private val threadsByKey = LinkedHashMap<ThreadKey, ThreadState>()
     private val transportsByServerId = LinkedHashMap<String, BridgeRpcTransport>()
+    private val openCodeClientsByServerId = LinkedHashMap<String, OpenCodeClient>()
     private val serversById = LinkedHashMap<String, ServerConfig>()
     private val accountByServerId = LinkedHashMap<String, AccountState>()
+    private val capabilitiesByServerId = LinkedHashMap<String, BackendCapabilities>()
+    private val availableModelsByServerId = LinkedHashMap<String, List<ModelOption>>()
+    private val selectedModelByServerId = LinkedHashMap<String, ModelSelection>()
+    private val slashByServerId = LinkedHashMap<String, List<SlashEntry>>()
+    private val agentOptionsByServerId = LinkedHashMap<String, List<OpenCodeAgentOption>>()
+    private val selectedAgentByServerId = LinkedHashMap<String, String?>()
     private val liveItemMessageIndices = LinkedHashMap<ThreadKey, MutableMap<String, Int>>()
     private val liveTurnDiffMessageIndices = LinkedHashMap<ThreadKey, MutableMap<String, Int>>()
     private val serversUsingItemNotifications = HashSet<String>()
     private val threadTurnCounts = LinkedHashMap<ThreadKey, Int>()
     private val pendingApprovalsById = LinkedHashMap<String, PendingApproval>()
+    private val pendingQuestionsById = LinkedHashMap<String, PendingQuestion>()
     private val agentDirectory = AgentDirectory()
 
     private val appContext = context?.applicationContext
@@ -104,6 +112,7 @@ class ServerManager(
             val result = runCatching {
                 val server = connectLocalDefaultServerInternal()
                 refreshSessionsInternal(server.id)
+                refreshOpenCodeMetadataInternal(server.id)
                 loadModelsInternal(server.id)
                 refreshAccountStateInternal(server.id)
                 server
@@ -136,6 +145,7 @@ class ServerManager(
             val result = runCatching {
                 val connected = connectServerInternal(server)
                 refreshSessionsInternal(connected.id)
+                refreshOpenCodeMetadataInternal(connected.id)
                 loadModelsInternal(connected.id)
                 refreshAccountStateInternal(connected.id)
                 connected
@@ -158,17 +168,27 @@ class ServerManager(
             val result = runCatching {
                 val saved = loadSavedServersInternal()
                 val connected = mutableListOf<ServerConfig>()
+                val errors = mutableListOf<Throwable>()
                 for (savedServer in saved) {
                     runCatching {
                         val cfg = savedServer.toServerConfig()
                         val connectedServer = connectServerInternal(cfg)
                         refreshSessionsInternal(connectedServer.id)
+                        refreshOpenCodeMetadataInternal(connectedServer.id)
                         refreshAccountStateInternal(connectedServer.id)
                         connected += connectedServer
-                    }
+                    }.onFailure { errors += it }
                 }
                 if (connected.isNotEmpty()) {
                     loadModelsInternal(connected.first().id)
+                } else if (saved.isNotEmpty() && errors.isNotEmpty()) {
+                    // Had saved servers but none connected — mark as error so UI shows offline state
+                    updateState {
+                        it.copy(
+                            connectionStatus = ServerConnectionStatus.ERROR,
+                            connectionError = errors.firstOrNull()?.message ?: "Server unreachable",
+                        )
+                    }
                 }
                 connected
             }
@@ -184,6 +204,24 @@ class ServerManager(
 
     fun removeServer(serverId: String) {
         disconnect(serverId)
+    }
+
+    fun removeSavedServer(serverId: String) {
+        submit {
+            // Remove from in-memory maps if present
+            runCatching { transportsByServerId.remove(serverId)?.close() }
+            runCatching { openCodeClientsByServerId.remove(serverId)?.close() }
+            serversById.remove(serverId)
+            accountByServerId.remove(serverId)
+            capabilitiesByServerId.remove(serverId)
+            slashByServerId.remove(serverId)
+            agentOptionsByServerId.remove(serverId)
+            selectedAgentByServerId.remove(serverId)
+            threadsByKey.entries.removeAll { it.key.serverId == serverId }
+            // Persist the updated list (explicitly removing this server ID)
+            persistSavedServersInternal(removedServerIds = setOf(serverId))
+            updateState { it }
+        }
     }
 
     fun refreshSessions(onComplete: ((Result<List<ThreadState>>) -> Unit)? = null) {
@@ -314,10 +352,14 @@ class ServerManager(
     ) {
         submit {
             updateState { current ->
+                val serverId = current.activeServerId
                 val next = current.selectedModel.copy(
                     modelId = modelId ?: current.selectedModel.modelId,
                     reasoningEffort = reasoningEffort ?: current.selectedModel.reasoningEffort,
                 )
+                if (serverId != null) {
+                    selectedModelByServerId[serverId] = next
+                }
                 current.copy(selectedModel = next)
             }
         }
@@ -339,6 +381,18 @@ class ServerManager(
     ) {
         submit {
             val pending = pendingApprovalsById.remove(approvalId) ?: return@submit
+            val server = serversById[pending.serverId]
+            if (server?.backendKind == BackendKind.OPENCODE) {
+                val reply =
+                    when (decision) {
+                        ApprovalDecision.ACCEPT -> "once"
+                        ApprovalDecision.ACCEPT_FOR_SESSION -> "always"
+                        ApprovalDecision.DECLINE, ApprovalDecision.CANCEL -> "reject"
+                    }
+                requireOpenCodeClient(pending.serverId).replyPermission(pending.requestId, reply)
+                commitState(state.copy(connectionError = null))
+                return@submit
+            }
             val decisionValue = approvalDecisionValue(method = pending.method, decision = decision)
             val transport = transportsByServerId[pending.serverId]
             if (transport != null) {
@@ -347,6 +401,25 @@ class ServerManager(
                     result = JSONObject().put("decision", decisionValue),
                 )
             }
+            updateState { it.copy(connectionError = null) }
+        }
+    }
+
+    fun respondToPendingQuestion(
+        questionId: String,
+        answers: List<List<String>>,
+    ) {
+        submit {
+            val pending = pendingQuestionsById.remove(questionId) ?: return@submit
+            requireOpenCodeClient(pending.serverId).replyQuestion(pending.requestId, answers)
+            updateState { it.copy(connectionError = null) }
+        }
+    }
+
+    fun rejectPendingQuestion(questionId: String) {
+        submit {
+            val pending = pendingQuestionsById.remove(questionId) ?: return@submit
+            requireOpenCodeClient(pending.serverId).rejectQuestion(pending.requestId)
             updateState { it.copy(connectionError = null) }
         }
     }
@@ -464,6 +537,90 @@ class ServerManager(
         }
     }
 
+    fun selectOpenCodeAgent(
+        name: String?,
+        serverId: String? = null,
+    ) {
+        submit {
+            val resolvedServerId = resolveServerIdForRequestedOperation(serverId)
+            if (serversById[resolvedServerId]?.backendKind != BackendKind.OPENCODE) {
+                return@submit
+            }
+            selectedAgentByServerId[resolvedServerId] = name?.trim()?.takeIf { it.isNotEmpty() }
+            updateState { it }
+        }
+    }
+
+    fun shareActiveThread(onComplete: ((Result<Unit>) -> Unit)? = null) {
+        submit {
+            val result = runCatching { shareActiveThreadInternal() }
+            deliver(onComplete, result)
+        }
+    }
+
+    fun unshareActiveThread(onComplete: ((Result<Unit>) -> Unit)? = null) {
+        submit {
+            val result = runCatching { unshareActiveThreadInternal() }
+            deliver(onComplete, result)
+        }
+    }
+
+    fun compactActiveThread(onComplete: ((Result<Unit>) -> Unit)? = null) {
+        submit {
+            val result = runCatching { compactActiveThreadInternal() }
+            deliver(onComplete, result)
+        }
+    }
+
+    fun undoActiveThread(onComplete: ((Result<Unit>) -> Unit)? = null) {
+        submit {
+            val result = runCatching { undoActiveThreadInternal() }
+            deliver(onComplete, result)
+        }
+    }
+
+    fun redoActiveThread(onComplete: ((Result<Unit>) -> Unit)? = null) {
+        submit {
+            val result = runCatching { redoActiveThreadInternal() }
+            deliver(onComplete, result)
+        }
+    }
+
+    fun executeOpenCodeCommand(
+        command: String,
+        arguments: String,
+        cwd: String? = null,
+        modelSelection: ModelSelection? = null,
+        onComplete: ((Result<Unit>) -> Unit)? = null,
+    ) {
+        submit {
+            val result = runCatching {
+                val resolvedCwd = resolveMessageCwd(cwd)
+                executeOpenCodeCommandInternal(
+                    command = command,
+                    arguments = arguments,
+                    cwd = resolvedCwd,
+                    modelSelection = modelSelection ?: state.selectedModel,
+                )
+            }
+            deliver(onComplete, result)
+        }
+    }
+
+    fun loadOpenCodeMcpStatus(onComplete: ((Result<List<OpenCodeMcpServer>>) -> Unit)? = null) {
+        submit {
+            val result = runCatching { loadOpenCodeMcpStatusInternal() }
+            deliver(onComplete, result)
+        }
+    }
+
+    fun loadOpenCodeStatus(onComplete: ((Result<OpenCodeStatusSnapshot>) -> Unit)? = null) {
+        submit {
+            val result = runCatching { loadOpenCodeStatusInternal() }
+            deliver(onComplete, result)
+        }
+    }
+
     fun renameActiveThread(
         name: String,
         onComplete: ((Result<Unit>) -> Unit)? = null,
@@ -575,6 +732,10 @@ class ServerManager(
             transportsByServerId.values.forEach { it.close() }
             transportsByServerId.clear()
         }
+        runCatching {
+            openCodeClientsByServerId.values.forEach { it.close() }
+            openCodeClientsByServerId.clear()
+        }
         runCatching { codexRpcClient.stop() }
         runCatching { worker.shutdownNow() }
     }
@@ -586,19 +747,6 @@ class ServerManager(
     }
 
     private fun connectServerInternal(server: ServerConfig): ServerConfig {
-        val existingServer = serversById[server.id]
-        val existingTransport = transportsByServerId[server.id]
-        if (existingServer != null && existingTransport != null) {
-            updateState {
-                it.copy(
-                    activeServerId = server.id,
-                    connectionStatus = ServerConnectionStatus.READY,
-                    connectionError = null,
-                )
-            }
-            return existingServer
-        }
-
         val normalizedServer =
             if (server.source == ServerSource.LOCAL) {
                 // Always resolve the active on-device bridge port instead of trusting discovery defaults.
@@ -607,73 +755,157 @@ class ServerManager(
                 ensureBundledServiceReady()
                 ServerConfig.bundled(BundledCodexService.PORT)
             } else {
-                server.copy(host = normalizeServerHost(server.host))
-            }
-
-        val transport = BridgeRpcTransport(
-            url = websocketUrl(normalizedServer),
-            onNotification = { method, params ->
-                submit {
-                    handleNotification(normalizedServer.id, method, params)
-                }
-            },
-            onServerRequest = { requestId, method, params ->
-                handleServerRequestInternal(
-                    serverId = normalizedServer.id,
-                    requestId = requestId,
-                    method = method,
-                    params = params,
+                server.copy(
+                    host =
+                        normalizeServerHost(
+                            server.host,
+                            preserveScheme = server.backendKind == BackendKind.OPENCODE,
+                        ),
                 )
-            },
-        )
-
-        try {
-            transport.connect(timeoutSeconds = 15)
-            sendInitialize(transport)
-            if (normalizedServer.source == ServerSource.BUNDLED) {
-                restoreBundledAuthIfAvailableInternal(serverId = normalizedServer.id, transport = transport)
             }
-        } catch (error: Throwable) {
-            transport.close()
-            throw error
+        val existingServer = serversById[normalizedServer.id]
+        val isConnected =
+            when (normalizedServer.backendKind) {
+                BackendKind.CODEX -> transportsByServerId[normalizedServer.id] != null
+                BackendKind.OPENCODE -> openCodeClientsByServerId[normalizedServer.id] != null
+            }
+        val reset = existingServer != null && isConnected && !sameServer(existingServer, normalizedServer)
+        if (existingServer != null && isConnected && !reset) {
+            updateState {
+                it.copy(
+                    activeServerId = normalizedServer.id,
+                    connectionStatus = ServerConnectionStatus.READY,
+                    connectionError = null,
+                )
+            }
+            return existingServer
+        }
+        if (reset) {
+            clearServer(normalizedServer.id)
         }
 
-        transportsByServerId[normalizedServer.id]?.close()
-        transportsByServerId[normalizedServer.id] = transport
-        serversById[normalizedServer.id] = normalizedServer
-        accountByServerId.putIfAbsent(normalizedServer.id, AccountState())
+        val connectedServer =
+            when (normalizedServer.backendKind) {
+                BackendKind.CODEX -> {
+                    val transport = BridgeRpcTransport(
+                        url = websocketUrl(normalizedServer),
+                        onNotification = { method, params ->
+                            submit {
+                                handleNotification(normalizedServer.id, method, params)
+                            }
+                        },
+                        onServerRequest = { requestId, method, params ->
+                            handleServerRequestInternal(
+                                serverId = normalizedServer.id,
+                                requestId = requestId,
+                                method = method,
+                                params = params,
+                            )
+                        },
+                    )
+
+                    try {
+                        transport.connect(timeoutSeconds = 15)
+                        sendInitialize(transport)
+                        if (normalizedServer.source == ServerSource.BUNDLED) {
+                            restoreBundledAuthIfAvailableInternal(serverId = normalizedServer.id, transport = transport)
+                        }
+                    } catch (error: Throwable) {
+                        transport.close()
+                        throw error
+                    }
+
+                    transportsByServerId[normalizedServer.id]?.close()
+                    transportsByServerId[normalizedServer.id] = transport
+                    capabilitiesByServerId[normalizedServer.id] =
+                        BackendCapabilities(
+                            supportsAuthManagement = true,
+                            supportsExperimentalFeatures = true,
+                            supportsSkillListing = true,
+                            supportsDirectoryBrowser = true,
+                            supportsQuestions = false,
+                        )
+                    normalizedServer
+                }
+
+                BackendKind.OPENCODE -> {
+                    val initialClient = OpenCodeClient(normalizedServer)
+                    initialClient.connect()
+                    val directory = normalizedServer.directory ?: initialClient.currentDirectory()
+                    initialClient.close()
+                    val scopedServer = normalizedServer.copy(directory = directory)
+                    val client = OpenCodeClient(scopedServer)
+                    client.connect()
+                    client.subscribeEvents { event ->
+                        submit {
+                            handleOpenCodeEvent(scopedServer.id, event)
+                        }
+                    }
+                    openCodeClientsByServerId[scopedServer.id]?.close()
+                    openCodeClientsByServerId[scopedServer.id] = client
+                    capabilitiesByServerId[scopedServer.id] =
+                        BackendCapabilities(
+                            supportsAuthManagement = false,
+                            supportsExperimentalFeatures = false,
+                            supportsSkillListing = true,
+                            supportsDirectoryBrowser = false,
+                            supportsQuestions = true,
+                        )
+                    scopedServer
+                }
+            }
+
+        serversById[connectedServer.id] = connectedServer
+        accountByServerId.putIfAbsent(connectedServer.id, AccountState())
         persistSavedServersInternal()
 
         updateState {
             val preferredCwd =
-                if (normalizedServer.source == ServerSource.BUNDLED) {
-                    preferredDirectoryRootForServer(normalizedServer.id)
+                if (connectedServer.source == ServerSource.BUNDLED) {
+                    preferredDirectoryRootForServer(connectedServer.id)
+                } else if (connectedServer.backendKind == BackendKind.OPENCODE) {
+                    connectedServer.directory ?: it.currentCwd
                 } else {
                     it.currentCwd
                 }
             it.copy(
                 connectionStatus = ServerConnectionStatus.READY,
                 connectionError = null,
-                activeServerId = normalizedServer.id,
+                activeServerId = connectedServer.id,
+                activeThreadKey =
+                    if (reset) {
+                        null
+                    } else {
+                        it.activeThreadKey?.takeIf { key -> key.serverId == connectedServer.id }
+                    },
                 currentCwd = preferredCwd,
             )
         }
 
-        return normalizedServer
+        return connectedServer
     }
 
     private fun disconnectInternal(serverId: String?) {
         if (serverId == null) {
             transportsByServerId.values.forEach { runCatching { it.close() } }
             transportsByServerId.clear()
+            openCodeClientsByServerId.values.forEach { runCatching { it.close() } }
+            openCodeClientsByServerId.clear()
             serversById.clear()
             accountByServerId.clear()
+            capabilitiesByServerId.clear()
+            availableModelsByServerId.clear()
+            selectedModelByServerId.clear()
+            slashByServerId.clear()
+            agentOptionsByServerId.clear()
+            selectedAgentByServerId.clear()
             threadsByKey.clear()
             liveItemMessageIndices.clear()
             liveTurnDiffMessageIndices.clear()
             serversUsingItemNotifications.clear()
             threadTurnCounts.clear()
             pendingApprovalsById.clear()
+            pendingQuestionsById.clear()
             agentDirectory.clear()
             runCatching { codexRpcClient.stop() }
             runCatching { appContext?.stopService(android.content.Intent(appContext, BundledCodexService::class.java)) }
@@ -692,14 +924,22 @@ class ServerManager(
         }
 
         runCatching { transportsByServerId.remove(serverId)?.close() }
+        runCatching { openCodeClientsByServerId.remove(serverId)?.close() }
         val removedServer = serversById.remove(serverId)
         accountByServerId.remove(serverId)
+        capabilitiesByServerId.remove(serverId)
+        availableModelsByServerId.remove(serverId)
+        selectedModelByServerId.remove(serverId)
+        slashByServerId.remove(serverId)
+        agentOptionsByServerId.remove(serverId)
+        selectedAgentByServerId.remove(serverId)
         threadsByKey.entries.removeAll { it.key.serverId == serverId }
         liveItemMessageIndices.keys.removeAll { it.serverId == serverId }
         liveTurnDiffMessageIndices.keys.removeAll { it.serverId == serverId }
         serversUsingItemNotifications.remove(serverId)
         threadTurnCounts.keys.removeAll { it.serverId == serverId }
         pendingApprovalsById.values.removeAll { it.serverId == serverId }
+        pendingQuestionsById.values.removeAll { it.serverId == serverId }
         agentDirectory.removeServer(serverId)
 
         if (removedServer?.source == ServerSource.LOCAL && serversById.values.none { it.source == ServerSource.LOCAL }) {
@@ -739,7 +979,43 @@ class ServerManager(
                 accountByServerId = LinkedHashMap(accountByServerId),
             ),
         )
-        persistSavedServersInternal()
+        persistSavedServersInternal(removedServerIds = setOf(serverId))
+    }
+
+    private fun clearServer(serverId: String): ServerConfig? {
+        runCatching { transportsByServerId.remove(serverId)?.close() }
+        runCatching { openCodeClientsByServerId.remove(serverId)?.close() }
+        val removed = serversById.remove(serverId)
+        accountByServerId.remove(serverId)
+        capabilitiesByServerId.remove(serverId)
+        availableModelsByServerId.remove(serverId)
+        selectedModelByServerId.remove(serverId)
+        slashByServerId.remove(serverId)
+        agentOptionsByServerId.remove(serverId)
+        selectedAgentByServerId.remove(serverId)
+        threadsByKey.entries.removeAll { it.key.serverId == serverId }
+        liveItemMessageIndices.keys.removeAll { it.serverId == serverId }
+        liveTurnDiffMessageIndices.keys.removeAll { it.serverId == serverId }
+        serversUsingItemNotifications.remove(serverId)
+        threadTurnCounts.keys.removeAll { it.serverId == serverId }
+        pendingApprovalsById.values.removeAll { it.serverId == serverId }
+        pendingQuestionsById.values.removeAll { it.serverId == serverId }
+        agentDirectory.removeServer(serverId)
+        return removed
+    }
+
+    private fun sameServer(
+        left: ServerConfig,
+        right: ServerConfig,
+    ): Boolean {
+        return left.host == right.host &&
+            left.port == right.port &&
+            left.source == right.source &&
+            left.backendKind == right.backendKind &&
+            left.hasCodexServer == right.hasCodexServer &&
+            left.username == right.username &&
+            left.password == right.password &&
+            left.directory == right.directory
     }
 
     private fun websocketUrl(server: ServerConfig): String {
@@ -753,18 +1029,49 @@ class ServerManager(
         return "ws://$normalizedHost:${server.port}"
     }
 
-    private fun normalizeServerHost(rawHost: String): String {
+    private fun normalizeServerHost(
+        rawHost: String,
+        preserveScheme: Boolean = false,
+    ): String {
         var host = rawHost.trim()
         if (host.isEmpty()) {
             return "127.0.0.1"
+        }
+
+        if (preserveScheme && host.contains("://")) {
+            return runCatching {
+                val uri = URI(host)
+                val scheme = uri.scheme?.trim()?.lowercase().orEmpty().ifEmpty { "http" }
+                val authority =
+                    uri.rawAuthority?.trim()?.takeIf { it.isNotEmpty() }
+                        ?: uri.host?.trim()
+                        ?: host.substringAfter("://", host).substringBefore('/').trim()
+                val path =
+                    uri.rawPath
+                        ?.trim()
+                        ?.trimEnd('/')
+                        ?.takeIf { it.isNotEmpty() && it != "/" }
+                        .orEmpty()
+                if (authority.isEmpty()) {
+                    host.trimEnd('/')
+                } else {
+                    "$scheme://$authority$path"
+                }
+            }.getOrDefault(host.trimEnd('/'))
         }
 
         if (host.contains("://")) {
             host =
                 runCatching {
                     val parsed = URI(host)
-                    parsed.host?.trim()
-                        ?: parsed.path?.trim()?.trimStart('/')
+                    val parsedHost = parsed.host?.trim()
+                    val port = parsed.port.takeIf { it > 0 }?.let { ":$it" }.orEmpty()
+                    val authority =
+                        when {
+                            !parsedHost.isNullOrEmpty() -> parsedHost + port
+                            else -> parsed.path?.trim()?.trimStart('/')
+                        }
+                    authority
                         ?: host
                 }.getOrDefault(host)
         }
@@ -799,6 +1106,10 @@ class ServerManager(
             }
 
         for (server in targetServers) {
+            if (server.backendKind == BackendKind.OPENCODE) {
+                refreshOpenCodeSessions(server)
+                continue
+            }
             val transport = requireTransport(server.id)
             val authoritativeKeys = LinkedHashSet<ThreadKey>()
             val missingRemoteCwdKeys = LinkedHashSet<ThreadKey>()
@@ -943,6 +1254,20 @@ class ServerManager(
 
     private fun loadModelsInternal(serverId: String? = null): List<ModelOption> {
         val targetServerId = serverId ?: resolveServerIdForActiveOperations()
+        if (serversById[targetServerId]?.backendKind == BackendKind.OPENCODE) {
+            val parsed = loadOpenCodeModelsInternal(targetServerId)
+            updateState { current ->
+                val selectedModel = chooseModelSelection(selectedModelByServerId[targetServerId] ?: current.selectedModel, parsed)
+                availableModelsByServerId[targetServerId] = parsed
+                selectedModelByServerId[targetServerId] = selectedModel
+                current.copy(
+                    availableModels = parsed,
+                    selectedModel = selectedModel,
+                    activeServerId = targetServerId,
+                )
+            }
+            return parsed
+        }
         val transport = requireTransport(targetServerId)
         val response = transport.request(
             method = "model/list",
@@ -990,7 +1315,9 @@ class ServerManager(
         }
 
         updateState { current ->
-            val selectedModel = chooseModelSelection(current.selectedModel, parsed)
+            val selectedModel = chooseModelSelection(selectedModelByServerId[targetServerId] ?: current.selectedModel, parsed)
+            availableModelsByServerId[targetServerId] = parsed
+            selectedModelByServerId[targetServerId] = selectedModel
             current.copy(
                 availableModels = parsed,
                 selectedModel = selectedModel,
@@ -1001,6 +1328,17 @@ class ServerManager(
     }
 
     private fun refreshAccountStateInternal(serverId: String): AccountState {
+        if (serversById[serverId]?.backendKind == BackendKind.OPENCODE) {
+            val accountState = AccountState(status = AuthStatus.NOT_LOGGED_IN)
+            accountByServerId[serverId] = accountState
+            updateState {
+                it.copy(
+                    accountByServerId = LinkedHashMap(accountByServerId),
+                    activeServerId = serverId,
+                )
+            }
+            return accountState
+        }
         val response =
             requireTransport(serverId).request(
                 method = "account/read",
@@ -1690,10 +2028,15 @@ class ServerManager(
     }
 
     private fun resolveHomeDirectoryInternal(serverId: String? = null): String {
-        if (transportsByServerId.isEmpty()) {
+        if (transportsByServerId.isEmpty() && openCodeClientsByServerId.isEmpty()) {
             connectLocalDefaultServerInternal()
         }
         val targetServerId = resolveServerIdForRequestedOperation(serverId)
+        val targetServer = ensureConnectedServer(targetServerId)
+        if (targetServer.backendKind == BackendKind.OPENCODE) {
+            return targetServer.directory?.trim()?.ifBlank { null }
+                ?: state.currentCwd.ifBlank { "/" }
+        }
         if (serversById[targetServerId]?.source == ServerSource.BUNDLED) {
             return preferredDirectoryRootForServer(targetServerId)
         }
@@ -1726,10 +2069,14 @@ class ServerManager(
         path: String,
         serverId: String? = null,
     ): List<String> {
-        if (transportsByServerId.isEmpty()) {
+        if (transportsByServerId.isEmpty() && openCodeClientsByServerId.isEmpty()) {
             connectLocalDefaultServerInternal()
         }
         val targetServerId = resolveServerIdForRequestedOperation(serverId)
+        val targetServer = ensureConnectedServer(targetServerId)
+        if (targetServer.backendKind == BackendKind.OPENCODE) {
+            throw IllegalStateException("Directory browsing is not supported for OpenCode servers")
+        }
         val fallbackRoot = preferredDirectoryRootForServer(targetServerId)
         if (serversById[targetServerId]?.source == ServerSource.BUNDLED) {
             return listLocalDirectoriesInternal(path = path, fallbackRoot = fallbackRoot)
@@ -1780,10 +2127,13 @@ class ServerManager(
         roots: List<String>,
         cancellationToken: String?,
     ): List<FuzzyFileSearchResult> {
-        if (transportsByServerId.isEmpty()) {
+        if (transportsByServerId.isEmpty() && openCodeClientsByServerId.isEmpty()) {
             connectLocalDefaultServerInternal()
         }
         val serverId = resolveServerIdForActiveOperations()
+        if (ensureConnectedServer(serverId).backendKind == BackendKind.OPENCODE) {
+            throw IllegalStateException("File search is not supported for OpenCode servers")
+        }
         val normalizedRoots =
             roots
                 .map { it.trim() }
@@ -1865,11 +2215,46 @@ class ServerManager(
         modelSelection: ModelSelection?,
         serverId: String? = null,
     ): ThreadKey {
-        if (transportsByServerId.isEmpty()) {
+        if (transportsByServerId.isEmpty() && openCodeClientsByServerId.isEmpty()) {
             connectLocalDefaultServerInternal()
         }
         val targetServerId = resolveServerIdForRequestedOperation(serverId)
         val server = ensureConnectedServer(targetServerId)
+        if (server.backendKind == BackendKind.OPENCODE) {
+            val created = requireOpenCodeClient(targetServerId).createSession()
+            val threadId = created.optString("id").trim()
+            if (threadId.isEmpty()) {
+                throw IllegalStateException("OpenCode session/create returned no session id")
+            }
+            val key = ThreadKey(server.id, threadId)
+            threadsByKey[key] =
+                ThreadState(
+                    key = key,
+                    serverName = server.name,
+                    serverSource = server.source,
+                    status = ThreadStatus.READY,
+                    messages = emptyList(),
+                    preview = created.optString("title").trim(),
+                    cwd = server.directory ?: cwd,
+                    modelProvider = "",
+                    parentThreadId = created.optString("parentID").trim().ifBlank { null },
+                    rootThreadId = null,
+                    updatedAtEpochMillis = parseOpenCodeUpdatedAt(created),
+                    activeTurnId = null,
+                    lastError = null,
+                )
+            threadTurnCounts[key] = 0
+            updateState {
+                it.copy(
+                    activeThreadKey = key,
+                    activeServerId = server.id,
+                    currentCwd = server.directory ?: cwd,
+                    connectionStatus = ServerConnectionStatus.READY,
+                    connectionError = null,
+                )
+            }
+            return key
+        }
         val model = modelSelection?.modelId ?: state.selectedModel.modelId
         val response = startThreadWithFallback(serverId = targetServerId, cwd = cwd, model = model)
         val threadId =
@@ -1971,12 +2356,41 @@ class ServerManager(
         threadId: String,
         cwd: String,
     ): ThreadKey {
-        if (transportsByServerId.isEmpty()) {
+        if (transportsByServerId.isEmpty() && openCodeClientsByServerId.isEmpty()) {
             connectLocalDefaultServerInternal()
         }
         val server = ensureConnectedServer(serverId)
         val key = ThreadKey(server.id, threadId)
         val existing = threadsByKey[key]
+        if (server.backendKind == BackendKind.OPENCODE) {
+            val messages = mapOpenCodeMessages(requireOpenCodeClient(serverId).loadMessages(threadId))
+            val now = System.currentTimeMillis()
+            threadsByKey[key] =
+                ThreadState(
+                    key = key,
+                    serverName = server.name,
+                    serverSource = server.source,
+                    status = ThreadStatus.READY,
+                    messages = messages,
+                    preview = derivePreview(messages, existing?.preview),
+                    cwd = server.directory ?: cwd,
+                    modelProvider = existing?.modelProvider.orEmpty(),
+                    parentThreadId = existing?.parentThreadId,
+                    rootThreadId = existing?.rootThreadId,
+                    updatedAtEpochMillis = now,
+                    activeTurnId = null,
+                    lastError = null,
+                )
+            threadTurnCounts[key] = inferredTurnCountFromMessages(messages)
+            updateState {
+                it.copy(
+                    activeThreadKey = key,
+                    activeServerId = server.id,
+                    currentCwd = server.directory ?: cwd,
+                )
+            }
+            return key
+        }
         threadsByKey[key] =
             ThreadState(
                 key = key,
@@ -2100,6 +2514,9 @@ class ServerManager(
 
     private fun startReviewOnActiveThreadInternal() {
         val key = state.activeThreadKey ?: throw IllegalStateException("No active thread")
+        if (serversById[key.serverId]?.backendKind == BackendKind.OPENCODE) {
+            throw IllegalStateException("Review is not supported for OpenCode servers")
+        }
         requireTransport(key.serverId).request(
             method = "review/start",
             params = JSONObject()
@@ -2107,6 +2524,149 @@ class ServerManager(
                 .put("target", JSONObject().put("type", "uncommittedChanges"))
                 .put("delivery", "inline"),
         )
+    }
+
+    private fun shareActiveThreadInternal() {
+        val key = state.activeThreadKey ?: throw IllegalStateException("No active thread")
+        val server = ensureConnectedServer(key.serverId)
+        if (server.backendKind != BackendKind.OPENCODE) {
+            throw IllegalStateException("Share is only supported for OpenCode servers")
+        }
+        requireOpenCodeClient(key.serverId).shareSession(key.threadId)
+        refreshSessionsInternal(key.serverId)
+    }
+
+    private fun unshareActiveThreadInternal() {
+        val key = state.activeThreadKey ?: throw IllegalStateException("No active thread")
+        val server = ensureConnectedServer(key.serverId)
+        if (server.backendKind != BackendKind.OPENCODE) {
+            throw IllegalStateException("Unshare is only supported for OpenCode servers")
+        }
+        requireOpenCodeClient(key.serverId).unshareSession(key.threadId)
+        refreshSessionsInternal(key.serverId)
+    }
+
+    private fun compactActiveThreadInternal() {
+        val key = state.activeThreadKey ?: throw IllegalStateException("No active thread")
+        val server = ensureConnectedServer(key.serverId)
+        if (server.backendKind != BackendKind.OPENCODE) {
+            throw IllegalStateException("Compact is only supported for OpenCode servers")
+        }
+        val model = parseOpenCodeModel(state.selectedModel.modelId)
+            ?: throw IllegalStateException("Select an OpenCode model before compacting the session")
+        requireOpenCodeClient(key.serverId).summarizeSession(
+            sessionId = key.threadId,
+            providerId = model.first,
+            modelId = model.second,
+        )
+        refreshSessionsInternal(key.serverId)
+    }
+
+    private fun undoActiveThreadInternal() {
+        val key = state.activeThreadKey ?: throw IllegalStateException("No active thread")
+        val server = ensureConnectedServer(key.serverId)
+        if (server.backendKind != BackendKind.OPENCODE) {
+            throw IllegalStateException("Undo is only supported for OpenCode servers")
+        }
+        val messages = requireOpenCodeClient(key.serverId).loadMessages(key.threadId)
+        var targetId: String? = null
+        for (index in messages.length() - 1 downTo 0) {
+            val item = messages.optJSONObject(index) ?: continue
+            val info = item.optJSONObject("info") ?: continue
+            if (info.optString("role").trim() != "user") {
+                continue
+            }
+            targetId = info.optString("id").trim().ifEmpty { null }
+            if (targetId != null) {
+                break
+            }
+        }
+        val messageId = targetId ?: throw IllegalStateException("No user message available to undo")
+        requireOpenCodeClient(key.serverId).revertSession(key.threadId, messageId)
+        val existing = threadsByKey[key]
+        if (existing != null) {
+            threadsByKey[key] =
+                existing.copy(
+                    status = ThreadStatus.READY,
+                    activeTurnId = null,
+                    updatedAtEpochMillis = System.currentTimeMillis(),
+                )
+        }
+        syncActiveThreadFromServerInternal()
+    }
+
+    private fun redoActiveThreadInternal() {
+        val key = state.activeThreadKey ?: throw IllegalStateException("No active thread")
+        val server = ensureConnectedServer(key.serverId)
+        if (server.backendKind != BackendKind.OPENCODE) {
+            throw IllegalStateException("Redo is only supported for OpenCode servers")
+        }
+        requireOpenCodeClient(key.serverId).unrevertSession(key.threadId)
+        syncActiveThreadFromServerInternal()
+    }
+
+    private fun executeOpenCodeCommandInternal(
+        command: String,
+        arguments: String,
+        cwd: String,
+        modelSelection: ModelSelection,
+    ) {
+        if (openCodeClientsByServerId.isEmpty() && transportsByServerId.isEmpty()) {
+            connectLocalDefaultServerInternal()
+        }
+        val key = state.activeThreadKey ?: startThreadInternal(cwd, modelSelection)
+        val server = ensureConnectedServer(key.serverId)
+        if (server.backendKind != BackendKind.OPENCODE) {
+            throw IllegalStateException("OpenCode slash commands require an OpenCode server")
+        }
+        val cleanCommand = command.trim().removePrefix("/")
+        if (cleanCommand.isEmpty()) {
+            throw IllegalArgumentException("Command name is required")
+        }
+        val cleanArguments = arguments.trim()
+        val preview = buildString {
+            append('/')
+            append(cleanCommand)
+            if (cleanArguments.isNotEmpty()) {
+                append(' ')
+                append(cleanArguments)
+            }
+        }
+        val existing = threadsByKey[key] ?: throw IllegalStateException("Unable to resolve active thread")
+        threadsByKey[key] =
+            existing.copy(
+                status = ThreadStatus.THINKING,
+                messages = existing.messages + ChatMessage(role = MessageRole.USER, text = preview, isFromUserTurnBoundary = true),
+                preview = preview.take(120),
+                cwd = cwd,
+                updatedAtEpochMillis = System.currentTimeMillis(),
+                lastError = null,
+            )
+        updateState { it.copy(activeThreadKey = key, activeServerId = key.serverId, currentCwd = cwd, connectionError = null) }
+        val model = modelSelection.modelId ?: state.selectedModel.modelId
+        val agent = selectedAgentByServerId[key.serverId]?.trim()?.takeIf { it.isNotEmpty() }
+        try {
+            requireOpenCodeClient(key.serverId).executeCommand(
+                sessionId = key.threadId,
+                command = cleanCommand,
+                arguments = cleanArguments,
+                model = model,
+                agent = agent,
+            )
+            refreshOpenCodeInteractions(key.serverId)
+        } catch (error: Throwable) {
+            val latest = threadsByKey[key]
+            if (latest != null) {
+                threadsByKey[key] =
+                    latest.copy(
+                        status = ThreadStatus.ERROR,
+                        lastError = error.message ?: "Failed to run slash command",
+                        updatedAtEpochMillis = System.currentTimeMillis(),
+                    )
+            }
+            updateState { it.copy(connectionError = error.message ?: "Failed to run slash command") }
+            throw error
+        }
     }
 
     private fun renameActiveThreadInternal(name: String) {
@@ -2126,10 +2686,14 @@ class ServerManager(
         if (trimmed.isEmpty()) {
             throw IllegalArgumentException("Thread name is required")
         }
-        requireTransport(key.serverId).request(
-            method = "thread/name/set",
-            params = JSONObject().put("threadId", key.threadId).put("name", trimmed),
-        )
+        if (serversById[key.serverId]?.backendKind == BackendKind.OPENCODE) {
+            requireOpenCodeClient(key.serverId).renameSession(key.threadId, trimmed)
+        } else {
+            requireTransport(key.serverId).request(
+                method = "thread/name/set",
+                params = JSONObject().put("threadId", key.threadId).put("name", trimmed),
+            )
+        }
 
         val existing = threadsByKey[key] ?: return
         threadsByKey[key] =
@@ -2200,6 +2764,40 @@ class ServerManager(
         sourceThread: ThreadState,
     ): ThreadKey {
         val server = ensureConnectedServer(sourceKey.serverId)
+        if (server.backendKind == BackendKind.OPENCODE) {
+            val forked = requireOpenCodeClient(server.id).forkSession(sourceKey.threadId)
+            val forkedThreadId = forked.optString("id").trim()
+            if (forkedThreadId.isEmpty()) {
+                throw IllegalStateException("OpenCode session/fork returned no session id")
+            }
+            val forkedKey = ThreadKey(server.id, forkedThreadId)
+            threadsByKey[forkedKey] =
+                ThreadState(
+                    key = forkedKey,
+                    serverName = server.name,
+                    serverSource = server.source,
+                    status = ThreadStatus.READY,
+                    messages = emptyList(),
+                    preview = forked.optString("title").trim().ifBlank { sourceThread.preview },
+                    cwd = server.directory ?: sourceThread.cwd,
+                    modelProvider = sourceThread.modelProvider,
+                    parentThreadId = forked.optString("parentID").trim().ifBlank { sourceKey.threadId },
+                    rootThreadId = sourceThread.rootThreadId ?: sourceThread.parentThreadId ?: sourceKey.threadId,
+                    updatedAtEpochMillis = parseOpenCodeUpdatedAt(forked),
+                    activeTurnId = null,
+                    lastError = null,
+                )
+            threadTurnCounts[forkedKey] = 0
+            updateState {
+                it.copy(
+                    activeThreadKey = forkedKey,
+                    activeServerId = server.id,
+                    currentCwd = server.directory ?: sourceThread.cwd,
+                    connectionError = null,
+                )
+            }
+            return forkedKey
+        }
         val sourceCwd = sourceThread.cwd.ifBlank { defaultWorkingDirectory() }
         val response = forkThreadWithFallback(server.id, sourceKey.threadId, sourceCwd)
         val threadObj = response.optJSONObject("thread") ?: JSONObject()
@@ -2263,10 +2861,14 @@ class ServerManager(
     }
 
     private fun archiveThreadInternal(threadKey: ThreadKey) {
-        requireTransport(threadKey.serverId).request(
-            method = "thread/archive",
-            params = JSONObject().put("threadId", threadKey.threadId),
-        )
+        if (serversById[threadKey.serverId]?.backendKind == BackendKind.OPENCODE) {
+            requireOpenCodeClient(threadKey.serverId).archiveSession(threadKey.threadId, archived = true)
+        } else {
+            requireTransport(threadKey.serverId).request(
+                method = "thread/archive",
+                params = JSONObject().put("threadId", threadKey.threadId),
+            )
+        }
         threadsByKey.remove(threadKey)
         threadTurnCounts.remove(threadKey)
         liveItemMessageIndices.remove(threadKey)
@@ -2395,6 +2997,9 @@ class ServerManager(
 
     private fun listExperimentalFeaturesInternal(limit: Int): List<ExperimentalFeature> {
         val serverId = resolveServerIdForActiveOperations()
+        if (serversById[serverId]?.backendKind == BackendKind.OPENCODE) {
+            throw IllegalStateException("Experimental features are not supported for OpenCode servers")
+        }
         val response =
             requireTransport(serverId).request(
                 method = "experimentalFeature/list",
@@ -2439,6 +3044,9 @@ class ServerManager(
             throw IllegalArgumentException("Feature name is required")
         }
         val serverId = resolveServerIdForActiveOperations()
+        if (serversById[serverId]?.backendKind == BackendKind.OPENCODE) {
+            throw IllegalStateException("Experimental features are not supported for OpenCode servers")
+        }
         requireTransport(serverId).request(
             method = "config/value/write",
             params =
@@ -2456,6 +3064,27 @@ class ServerManager(
         forceReload: Boolean,
     ): List<SkillMetadata> {
         val serverId = resolveServerIdForActiveOperations()
+        if (serversById[serverId]?.backendKind == BackendKind.OPENCODE) {
+            val items = requireOpenCodeClient(serverId).listSkills()
+            val parsed = ArrayList<SkillMetadata>(items.length())
+            for (index in 0 until items.length()) {
+                val item = items.optJSONObject(index) ?: continue
+                val name = item.optString("name").trim()
+                val path = item.optString("location").trim()
+                if (name.isEmpty() || path.isEmpty()) {
+                    continue
+                }
+                parsed +=
+                    SkillMetadata(
+                        name = name,
+                        description = item.optString("description").trim(),
+                        path = path,
+                        scope = "opencode",
+                        enabled = true,
+                    )
+            }
+            return parsed
+        }
         val params = JSONObject().put("forceReload", forceReload)
         val normalizedCwds =
             cwds
@@ -2510,15 +3139,6 @@ class ServerManager(
             return
         }
 
-        if (transportsByServerId.isEmpty()) {
-            connectLocalDefaultServerInternal()
-        }
-
-        val key = state.activeThreadKey ?: startThreadInternal(cwd, modelSelection)
-        val serverId = key.serverId
-        ensureAuthenticatedForTurns(serverId)
-        val existing = threadsByKey[key] ?: throw IllegalStateException("Unable to resolve active thread")
-        val now = System.currentTimeMillis()
         val localImageName = normalizedLocalImagePath?.let { File(it).name }.orEmpty()
         val userVisibleText =
             when {
@@ -2531,6 +3151,26 @@ class ServerManager(
 
                 else -> ""
             }
+
+        if (transportsByServerId.isEmpty() && openCodeClientsByServerId.isEmpty()) {
+            connectLocalDefaultServerInternal()
+        }
+
+        val key = state.activeThreadKey ?: startThreadInternal(cwd, modelSelection)
+        val serverId = key.serverId
+        if (serversById[serverId]?.backendKind == BackendKind.OPENCODE) {
+            sendOpenCodeMessageInternal(
+                key = key,
+                text = trimmed,
+                cwd = cwd,
+                userVisibleText = userVisibleText,
+                modelSelection = modelSelection,
+            )
+            return
+        }
+        ensureAuthenticatedForTurns(serverId)
+        val existing = threadsByKey[key] ?: throw IllegalStateException("Unable to resolve active thread")
+        val now = System.currentTimeMillis()
 
         val withUserMessage =
             existing.copy(
@@ -2702,6 +3342,19 @@ class ServerManager(
 
     private fun interruptInternal() {
         val key = state.activeThreadKey ?: return
+        if (serversById[key.serverId]?.backendKind == BackendKind.OPENCODE) {
+            requireOpenCodeClient(key.serverId).abort(key.threadId)
+            val existing = threadsByKey[key] ?: return
+            threadsByKey[key] =
+                existing.copy(
+                    status = ThreadStatus.READY,
+                    activeTurnId = null,
+                    updatedAtEpochMillis = System.currentTimeMillis(),
+                    messages = finalizeStreaming(existing.messages),
+                )
+            updateState { it }
+            return
+        }
         val activeTurnId = threadsByKey[key]?.activeTurnId?.trim().takeIf { !it.isNullOrEmpty() }
         val params =
             JSONObject()
@@ -3832,6 +4485,77 @@ class ServerManager(
         ).orEmpty()
     }
 
+    private fun parseOpenCodeModel(value: String?): Pair<String, String>? {
+        val model = value?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+        val providerId = model.substringBefore('/').trim()
+        val modelId = model.substringAfter('/', "").trim()
+        if (providerId.isEmpty() || modelId.isEmpty()) {
+            return null
+        }
+        return providerId to modelId
+    }
+
+    private fun openCodePromptModel(value: String?): JSONObject? {
+        val model = parseOpenCodeModel(value) ?: return null
+        return JSONObject()
+            .put("providerID", model.first)
+            .put("modelID", model.second)
+    }
+
+    private fun JSONArray.jsonStrings(): List<String> {
+        val values = ArrayList<String>(length())
+        for (index in 0 until length()) {
+            val value = optString(index).trim()
+            if (value.isNotEmpty()) {
+                values += value
+            }
+        }
+        return values
+    }
+
+    private fun summarizeJson(value: Any?): String {
+        return when (value) {
+            null, JSONObject.NULL -> ""
+            is JSONObject -> {
+                val lines = jsonLines(value)
+                if (lines.isEmpty()) "" else lines.joinToString(" • ")
+            }
+            is JSONArray -> {
+                val lines = jsonLines(value)
+                if (lines.isEmpty()) "" else lines.joinToString(" • ")
+            }
+            else -> value.toString().trim()
+        }
+    }
+
+    private fun jsonLines(value: Any?): List<String> {
+        return when (value) {
+            null, JSONObject.NULL -> emptyList()
+            is JSONObject -> {
+                val keys = value.keys()
+                val lines = ArrayList<String>()
+                while (keys.hasNext()) {
+                    val key = keys.next()
+                    val item = value.opt(key)
+                    val summary = summarizeJson(item)
+                    lines += if (summary.isNotEmpty()) "$key: $summary" else key
+                }
+                lines
+            }
+            is JSONArray -> {
+                val lines = ArrayList<String>(value.length())
+                for (index in 0 until value.length()) {
+                    val summary = summarizeJson(value.opt(index))
+                    if (summary.isNotEmpty()) {
+                        lines += summary
+                    }
+                }
+                lines
+            }
+            else -> listOf(value.toString())
+        }
+    }
+
     private fun normalizeCwd(cwd: String?): String? = cwd?.trim()?.takeIf { it.isNotEmpty() }
 
     private fun parseThreadCwd(obj: JSONObject?): String? {
@@ -4427,6 +5151,23 @@ class ServerManager(
         val thread = threadsByKey[key] ?: return false
         if (thread.hasTurnActive) {
             return false
+        }
+        if (serversById[key.serverId]?.backendKind == BackendKind.OPENCODE) {
+            val restoredMessages = mapOpenCodeMessages(requireOpenCodeClient(key.serverId).loadMessages(key.threadId))
+            if (messagesEquivalent(thread.messages, restoredMessages)) {
+                return false
+            }
+            threadsByKey[key] =
+                thread.copy(
+                    status = thread.status,
+                    activeTurnId = null,
+                    messages = restoredMessages,
+                    preview = derivePreview(restoredMessages, thread.preview),
+                    updatedAtEpochMillis = System.currentTimeMillis(),
+                    lastError = null,
+                )
+            threadTurnCounts[key] = inferredTurnCountFromMessages(restoredMessages)
+            return true
         }
 
         val cwd = thread.cwd.ifBlank { defaultWorkingDirectory() }
@@ -5285,6 +6026,431 @@ class ServerManager(
         }
     }
 
+    private fun handleOpenCodeEvent(
+        serverId: String,
+        event: JSONObject,
+    ) {
+        val payload = event.optJSONObject("payload") ?: event
+        val type = payload.optString("type")
+        if (type == "server.connected" || type == "server.heartbeat") {
+            return
+        }
+        if (type == "session.status") {
+            val props = payload.optJSONObject("properties")
+            val threadId = props?.optString("sessionID")?.trim().orEmpty()
+            val status = props?.optJSONObject("status")
+            if (threadId.isNotEmpty()) {
+                val key = ThreadKey(serverId, threadId)
+                val thread = threadsByKey[key]
+                if (thread != null) {
+                    threadsByKey[key] =
+                        thread.copy(
+                            status = mapOpenCodeThreadStatus(status),
+                            updatedAtEpochMillis = System.currentTimeMillis(),
+                        )
+                    updateState { it }
+                }
+            }
+        }
+        refreshSessionsInternal(serverId)
+        syncActiveThreadFromServerInternal()
+    }
+
+    private fun refreshOpenCodeSessions(server: ServerConfig) {
+        val client = requireOpenCodeClient(server.id)
+        val sessions = client.listSessions()
+        val statuses = client.listStatuses()
+        val authoritativeKeys = LinkedHashSet<ThreadKey>()
+        for (index in 0 until sessions.length()) {
+            val item = sessions.optJSONObject(index) ?: continue
+            val threadId = item.optString("id").trim()
+            if (threadId.isEmpty()) continue
+            val key = ThreadKey(server.id, threadId)
+            authoritativeKeys += key
+            val existing = threadsByKey[key]
+            threadsByKey[key] =
+                ThreadState(
+                    key = key,
+                    serverName = server.name,
+                    serverSource = server.source,
+                    status = mapOpenCodeThreadStatus(statuses.optJSONObject(threadId)),
+                    messages = existing?.messages ?: emptyList(),
+                    preview = item.optString("title").trim().ifBlank { existing?.preview.orEmpty() },
+                    cwd = server.directory ?: existing?.cwd.orEmpty(),
+                    modelProvider = existing?.modelProvider.orEmpty(),
+                    parentThreadId = item.optString("parentID").trim().ifBlank { null },
+                    rootThreadId = existing?.rootThreadId,
+                    updatedAtEpochMillis = parseOpenCodeUpdatedAt(item),
+                    activeTurnId = null,
+                    lastError = null,
+                )
+        }
+        refreshOpenCodeMetadataInternal(server.id)
+        refreshOpenCodeInteractions(server.id)
+        computePlaceholderKeysToPrune(server.id, authoritativeKeys, state.activeThreadKey, threadsByKey).forEach { key ->
+            threadsByKey.remove(key)
+        }
+    }
+
+    private fun refreshOpenCodeInteractions(serverId: String) {
+        val client = requireOpenCodeClient(serverId)
+        pendingApprovalsById.entries.removeAll { it.value.serverId == serverId }
+        pendingQuestionsById.entries.removeAll { it.value.serverId == serverId }
+
+        val permissions = client.listPermissions()
+        for (index in 0 until permissions.length()) {
+            val item = permissions.optJSONObject(index) ?: continue
+            val requestId = item.optString("id").trim()
+            if (requestId.isEmpty()) continue
+            pendingApprovalsById[requestId] =
+                PendingApproval(
+                    id = requestId,
+                    requestId = requestId,
+                    serverId = serverId,
+                    method = "permission.reply",
+                    kind = ApprovalKind.COMMAND_EXECUTION,
+                    threadId = item.optString("sessionID").trim().ifBlank { null },
+                    turnId = null,
+                    itemId = item.optJSONObject("tool")?.optString("callID")?.trim(),
+                    command = item.optJSONArray("patterns")?.join(" ")?.trim(),
+                    cwd = null,
+                    reason = item.optString("permission").trim().ifBlank { "Permission requested" },
+                    grantRoot = null,
+                )
+        }
+
+        val questions = client.listQuestions()
+        for (index in 0 until questions.length()) {
+            val item = questions.optJSONObject(index) ?: continue
+            val requestId = item.optString("id").trim()
+            if (requestId.isEmpty()) continue
+            val prompts = ArrayList<PendingQuestionPrompt>()
+            val questionItems = item.optJSONArray("questions") ?: JSONArray()
+            for (questionIndex in 0 until questionItems.length()) {
+                val prompt = questionItems.optJSONObject(questionIndex) ?: continue
+                val options = ArrayList<PendingQuestionOption>()
+                val optionItems = prompt.optJSONArray("options") ?: JSONArray()
+                for (optionIndex in 0 until optionItems.length()) {
+                    val option = optionItems.optJSONObject(optionIndex) ?: continue
+                    options += PendingQuestionOption(label = option.optString("label"), description = option.optString("description"))
+                }
+                prompts +=
+                    PendingQuestionPrompt(
+                        header = prompt.optString("header"),
+                        question = prompt.optString("question"),
+                        options = options,
+                        multiple = prompt.optBoolean("multiple", false),
+                        custom = !prompt.has("custom") || prompt.optBoolean("custom", true),
+                    )
+            }
+            pendingQuestionsById[requestId] =
+                PendingQuestion(
+                    id = requestId,
+                    requestId = requestId,
+                    serverId = serverId,
+                    threadId = item.optString("sessionID").trim().ifBlank { null },
+                    prompts = prompts,
+                )
+        }
+    }
+
+    private fun refreshOpenCodeMetadataInternal(serverId: String) {
+        val server = serversById[serverId] ?: return
+        if (server.backendKind != BackendKind.OPENCODE) {
+            return
+        }
+        slashByServerId[serverId] = loadOpenCodeSlashEntriesInternal(serverId)
+        val agents = loadOpenCodeAgentOptionsInternal(serverId)
+        agentOptionsByServerId[serverId] = agents
+        val selected = selectedAgentByServerId[serverId]?.trim()?.takeIf { it.isNotEmpty() }
+        if (selected != null && agents.none { it.name == selected && !it.hidden }) {
+            selectedAgentByServerId[serverId] = null
+        }
+    }
+
+    private fun loadOpenCodeSlashEntriesInternal(serverId: String): List<SlashEntry> {
+        val items = requireOpenCodeClient(serverId).listSlashes()
+        val parsed = ArrayList<SlashEntry>(items.length())
+        for (index in 0 until items.length()) {
+            val item = items.optJSONObject(index) ?: continue
+            val id = item.optString("id").trim()
+            val name = item.optString("name").trim()
+            if (id.isEmpty() || name.isEmpty()) {
+                continue
+            }
+            val rawKind = item.optString("kind").trim().lowercase(Locale.ROOT)
+            val kind =
+                if (rawKind == "action") {
+                    SlashKind.ACTION
+                } else if (rawKind == "command") {
+                    SlashKind.COMMAND
+                } else {
+                    continue
+                }
+            parsed +=
+                SlashEntry(
+                    id = id,
+                    kind = kind,
+                    name = name,
+                    aliases = item.optJSONArray("aliases")?.jsonStrings().orEmpty(),
+                    description = item.optString("description").trim(),
+                    category = item.optString("category").trim(),
+                    displayName = item.optString("displayName").trim().ifBlank { "/$name" },
+                    actionId = item.optString("actionID").trim().ifBlank { null },
+                    source = item.optString("source").trim().ifBlank { null },
+                )
+        }
+        return mergeOpenCodeSlashEntries(parsed)
+    }
+
+    private fun loadOpenCodeAgentOptionsInternal(serverId: String): List<OpenCodeAgentOption> {
+        val items = requireOpenCodeClient(serverId).listAgents()
+        val parsed = ArrayList<OpenCodeAgentOption>(items.length())
+        for (index in 0 until items.length()) {
+            val item = items.optJSONObject(index) ?: continue
+            val name = item.optString("name").trim()
+            if (name.isEmpty()) {
+                continue
+            }
+            parsed +=
+                OpenCodeAgentOption(
+                    name = name,
+                    description = item.optString("description").trim(),
+                    mode = item.optString("mode").trim(),
+                    hidden = item.optBoolean("hidden", false),
+                )
+        }
+        return parsed
+            .filterNot { it.hidden }
+            .sortedBy { it.name.lowercase(Locale.ROOT) }
+    }
+
+    private fun loadOpenCodeModelsInternal(serverId: String): List<ModelOption> {
+        val client = requireOpenCodeClient(serverId)
+        val config = runCatching { client.listConfigProviders() }.getOrNull()
+        val providers = config?.optJSONArray("providers")
+        if (providers != null && providers.length() > 0) {
+            return parseOpenCodeModels(
+                providers = providers,
+                defaults = config.optJSONObject("default") ?: JSONObject(),
+            )
+        }
+        val fallback = client.listProviders()
+        return parseOpenCodeModels(
+            providers = fallback.optJSONArray("all") ?: JSONArray(),
+            defaults = fallback.optJSONObject("default") ?: JSONObject(),
+        )
+    }
+
+    private fun parseOpenCodeModels(
+        providers: JSONArray,
+        defaults: JSONObject,
+    ): List<ModelOption> {
+        val parsed = ArrayList<ModelOption>()
+        for (providerIndex in 0 until providers.length()) {
+            val provider = providers.optJSONObject(providerIndex) ?: continue
+            val providerId = provider.optString("id").trim()
+            if (providerId.isEmpty()) {
+                continue
+            }
+            val providerName = provider.optString("name").trim().ifBlank { providerId }
+            val models = provider.optJSONObject("models") ?: continue
+            val defaultModel = defaults.optString(providerId).trim()
+            val keys = models.keys()
+            while (keys.hasNext()) {
+                val modelId = keys.next().trim()
+                if (modelId.isEmpty()) {
+                    continue
+                }
+                val info = models.optJSONObject(modelId) ?: JSONObject()
+                val displayName = info.optString("name").trim().ifBlank { modelId }
+                val description =
+                    buildString {
+                        append(providerName)
+                        val family = info.optString("family").trim()
+                        if (family.isNotEmpty()) {
+                            append(" • ")
+                            append(family)
+                        }
+                    }
+                parsed +=
+                    ModelOption(
+                        id = "$providerId/$modelId",
+                        displayName = displayName,
+                        description = description,
+                        defaultReasoningEffort = null,
+                        supportedReasoningEfforts = emptyList(),
+                        isDefault = modelId == defaultModel,
+                    )
+            }
+        }
+        return parsed.sortedWith(compareByDescending<ModelOption> { it.isDefault }.thenBy { it.id.lowercase(Locale.ROOT) })
+    }
+
+    private fun loadOpenCodeMcpStatusInternal(): List<OpenCodeMcpServer> {
+        val serverId = resolveServerIdForActiveOperations()
+        val server = ensureConnectedServer(serverId)
+        if (server.backendKind != BackendKind.OPENCODE) {
+            throw IllegalStateException("MCP status is only available for OpenCode servers")
+        }
+        val items = requireOpenCodeClient(serverId).listMcpStatus()
+        val parsed = ArrayList<OpenCodeMcpServer>()
+        val keys = items.keys()
+        while (keys.hasNext()) {
+            val name = keys.next()
+            val value = items.optJSONObject(name) ?: JSONObject()
+            parsed +=
+                OpenCodeMcpServer(
+                    name = name,
+                    status = extractString(value, "status", "state", "connection").orEmpty().ifBlank { "unknown" },
+                    summary = summarizeJson(value),
+                )
+        }
+        return parsed.sortedBy { it.name.lowercase(Locale.ROOT) }
+    }
+
+    private fun loadOpenCodeStatusInternal(): OpenCodeStatusSnapshot {
+        val serverId = resolveServerIdForActiveOperations()
+        val server = ensureConnectedServer(serverId)
+        if (server.backendKind != BackendKind.OPENCODE) {
+            throw IllegalStateException("Status is only available for OpenCode servers")
+        }
+        val client = requireOpenCodeClient(serverId)
+        val path = client.pathInfo()
+        val vcs = client.vcsInfo()
+        val mcp = client.listMcpStatus()
+        val lsp = client.lspStatus()
+        val formatter = client.formatterStatus()
+        return OpenCodeStatusSnapshot(
+            sections =
+                listOf(
+                    OpenCodeStatusSection(
+                        title = "Paths",
+                        lines =
+                            listOfNotNull(
+                                path.optString("directory").trim().takeIf { it.isNotEmpty() }?.let { "Directory: $it" },
+                                path.optString("worktree").trim().takeIf { it.isNotEmpty() }?.let { "Worktree: $it" },
+                                path.optString("config").trim().takeIf { it.isNotEmpty() }?.let { "Config: $it" },
+                            ),
+                    ),
+                    OpenCodeStatusSection(
+                        title = "VCS",
+                        lines = jsonLines(vcs),
+                    ),
+                    OpenCodeStatusSection(
+                        title = "MCP",
+                        lines = jsonLines(mcp),
+                    ),
+                    OpenCodeStatusSection(
+                        title = "LSP",
+                        lines = jsonLines(lsp),
+                    ),
+                    OpenCodeStatusSection(
+                        title = "Formatter",
+                        lines = jsonLines(formatter),
+                    ),
+                ).filter { it.lines.isNotEmpty() },
+        )
+    }
+
+    private fun mapOpenCodeMessages(messages: JSONArray): List<ChatMessage> {
+        val parsed = mutableListOf<ChatMessage>()
+        var turnIndex = 0
+        for (index in 0 until messages.length()) {
+            val item = messages.optJSONObject(index) ?: continue
+            val info = item.optJSONObject("info") ?: continue
+            val messageId = info.optString("id").trim().ifBlank { UUID.randomUUID().toString() }
+            val createdAt = info.optJSONObject("time")?.optLong("created") ?: System.currentTimeMillis()
+            val role = info.optString("role")
+            val parts = item.optJSONArray("parts") ?: JSONArray()
+            if (role == "user") {
+                val text = buildString {
+                    for (partIndex in 0 until parts.length()) {
+                        val part = parts.optJSONObject(partIndex) ?: continue
+                        when (part.optString("type")) {
+                            "text" -> appendLine(part.optString("text"))
+                            "file" -> appendLine("[Attachment] ${part.optString("filename").ifBlank { part.optString("mime") }}")
+                        }
+                    }
+                }.trim()
+                parsed += ChatMessage(id = messageId, role = MessageRole.USER, text = text, timestampEpochMillis = createdAt, isFromUserTurnBoundary = true, sourceTurnIndex = turnIndex)
+                turnIndex += 1
+                continue
+            }
+            val text = StringBuilder()
+            val reasoning = StringBuilder()
+            for (partIndex in 0 until parts.length()) {
+                val part = parts.optJSONObject(partIndex) ?: continue
+                when (part.optString("type")) {
+                    "text" -> text.append(part.optString("text"))
+                    "reasoning" -> reasoning.append(part.optString("text"))
+                    "file" -> {
+                        if (text.isNotEmpty()) {
+                            text.append('\n')
+                        }
+                        text.append("[Attachment] ").append(part.optString("filename").ifBlank { part.optString("mime") })
+                    }
+                    "tool" -> {
+                        if (text.isNotEmpty()) {
+                            text.append('\n')
+                        }
+                        text.append("[").append(part.optString("tool")).append(": ").append(part.optJSONObject("state")?.optString("status")).append("]")
+                    }
+                    "step-start", "step-finish" -> Unit
+                    else -> Unit
+                }
+            }
+            if (reasoning.isNotBlank()) {
+                parsed += ChatMessage(id = "$messageId-reasoning", role = MessageRole.REASONING, text = reasoning.toString().trim(), timestampEpochMillis = createdAt, sourceTurnIndex = maxOf(turnIndex - 1, 0))
+            }
+            val fallbackError = info.optJSONObject("error")?.optString("message").orEmpty()
+            val assistantText = text.toString().trim().ifBlank { fallbackError }
+            if (assistantText.isNotBlank()) {
+                parsed += ChatMessage(id = messageId, role = MessageRole.ASSISTANT, text = assistantText, timestampEpochMillis = createdAt, sourceTurnIndex = maxOf(turnIndex - 1, 0))
+            }
+        }
+        return parsed
+    }
+
+    private fun sendOpenCodeMessageInternal(
+        key: ThreadKey,
+        text: String,
+        cwd: String,
+        userVisibleText: String,
+        modelSelection: ModelSelection,
+    ) {
+        val existing = threadsByKey[key] ?: throw IllegalStateException("Unable to resolve active thread")
+        threadsByKey[key] =
+            existing.copy(
+                status = ThreadStatus.THINKING,
+                messages = existing.messages + ChatMessage(role = MessageRole.USER, text = userVisibleText, isFromUserTurnBoundary = true),
+                preview = userVisibleText.take(120),
+                cwd = cwd,
+                updatedAtEpochMillis = System.currentTimeMillis(),
+                lastError = null,
+            )
+        updateState { it.copy(activeThreadKey = key, activeServerId = key.serverId, currentCwd = cwd, connectionError = null) }
+        val model = openCodePromptModel(modelSelection.modelId ?: state.selectedModel.modelId)
+        val agent = selectedAgentByServerId[key.serverId]?.trim()?.takeIf { it.isNotEmpty() }
+        requireOpenCodeClient(key.serverId).sendPrompt(key.threadId, text, model = model, agent = agent)
+        refreshOpenCodeInteractions(key.serverId)
+    }
+
+    private fun parseOpenCodeUpdatedAt(item: JSONObject): Long {
+        val time = item.optJSONObject("time")
+        return time?.optLong("updated")
+            ?: time?.optLong("created")
+            ?: System.currentTimeMillis()
+    }
+
+    private fun mapOpenCodeThreadStatus(status: JSONObject?): ThreadStatus {
+        return when (status?.optString("type")?.lowercase(Locale.ROOT)) {
+            "busy", "running", "pending" -> ThreadStatus.THINKING
+            "error", "failed" -> ThreadStatus.ERROR
+            else -> ThreadStatus.READY
+        }
+    }
+
     private fun shouldRetryWithoutLinuxSandbox(error: Throwable): Boolean {
         val lower = error.message?.lowercase().orEmpty()
         return lower.contains("codex-linux-sandbox was required but not provided") ||
@@ -5435,6 +6601,10 @@ class ServerManager(
         transportsByServerId[serverId]
             ?: throw IllegalStateException("Codex bridge transport is not connected for server '$serverId'")
 
+    private fun requireOpenCodeClient(serverId: String): OpenCodeClient =
+        openCodeClientsByServerId[serverId]
+            ?: throw IllegalStateException("OpenCode client is not connected for server '$serverId'")
+
     private fun ensureConnectedServer(serverId: String): ServerConfig =
         serversById[serverId] ?: throw IllegalStateException("No connected server '$serverId'")
 
@@ -5512,16 +6682,19 @@ class ServerManager(
 
     private fun commitState(base: AppState) {
         val sortedThreads = threadsByKey.values.sortedByDescending { it.updatedAtEpochMillis }
+        val preferredServerId =
+            base.activeServerId?.takeIf { serversById.containsKey(it) }
         val activeKey =
             when {
                 base.activeThreadKey != null && threadsByKey.containsKey(base.activeThreadKey) -> base.activeThreadKey
+                preferredServerId != null -> sortedThreads.firstOrNull { it.key.serverId == preferredServerId }?.key
                 sortedThreads.isNotEmpty() -> sortedThreads.first().key
                 else -> null
             }
         val activeServerId =
             when {
-                base.activeServerId != null && serversById.containsKey(base.activeServerId) -> base.activeServerId
                 activeKey != null -> activeKey.serverId
+                preferredServerId != null -> preferredServerId
                 serversById.isNotEmpty() -> serversById.keys.first()
                 else -> null
             }
@@ -5537,6 +6710,8 @@ class ServerManager(
                 base.connectionStatus == ServerConnectionStatus.ERROR -> ServerConnectionStatus.ERROR
                 else -> ServerConnectionStatus.READY
             }
+        val availableModels = activeServerId?.let { availableModelsByServerId[it] }.orEmpty()
+        val selectedModel = activeServerId?.let { selectedModelByServerId[it] } ?: base.selectedModel
 
         val next =
             base.copy(
@@ -5544,10 +6719,33 @@ class ServerManager(
                 servers = serversById.values.toList(),
                 savedServers = loadSavedServersInternal(),
                 accountByServerId = LinkedHashMap(accountByServerId),
+                capabilitiesByServerId = LinkedHashMap(capabilitiesByServerId),
+                slashByServerId = LinkedHashMap(slashByServerId),
+                agentOptionsByServerId = LinkedHashMap(agentOptionsByServerId),
+                selectedAgentByServerId = LinkedHashMap(selectedAgentByServerId),
                 activeServerId = activeServerId,
+                availableModels = availableModels,
+                selectedModel = selectedModel,
                 threads = sortedThreads,
                 activeThreadKey = activeKey,
-                pendingApprovals = pendingApprovalsById.values.toList(),
+                pendingInteractions =
+                    (pendingApprovalsById.values.map { approval ->
+                        PendingInteraction(
+                            id = approval.id,
+                            serverId = approval.serverId,
+                            kind = PendingInteractionKind.APPROVAL,
+                            approval = approval,
+                            createdAtEpochMillis = approval.createdAtEpochMillis,
+                        )
+                    } + pendingQuestionsById.values.map { question ->
+                        PendingInteraction(
+                            id = question.id,
+                            serverId = question.serverId,
+                            kind = PendingInteractionKind.QUESTION,
+                            question = question,
+                            createdAtEpochMillis = question.createdAtEpochMillis,
+                        )
+                    }).sortedBy { it.createdAtEpochMillis },
                 toolTargetLabelsById = toolTargetLabelsById,
             )
         state = next
@@ -5582,10 +6780,18 @@ class ServerManager(
         }
     }
 
-    private fun persistSavedServersInternal() {
-        val payload = JSONArray()
+    private fun persistSavedServersInternal(removedServerIds: Set<String> = emptySet()) {
+        // Merge: start with existing saved servers (preserving offline ones), then overlay connected servers
+        val existing = loadSavedServersInternal().associateBy { it.id }.toMutableMap()
+        // Remove explicitly deleted servers
+        removedServerIds.forEach { existing.remove(it) }
+        // Overlay currently connected servers (they may have updated fields like directory)
         for (server in serversById.values) {
             val saved = SavedServer.from(server)
+            existing[saved.id] = saved
+        }
+        val payload = JSONArray()
+        for (saved in existing.values) {
             payload.put(
                 JSONObject()
                     .put("id", saved.id)
@@ -5593,7 +6799,11 @@ class ServerManager(
                     .put("host", saved.host)
                     .put("port", saved.port)
                     .put("source", saved.source)
-                    .put("hasCodexServer", saved.hasCodexServer),
+                    .put("backendKind", saved.backendKind)
+                    .put("hasCodexServer", saved.hasCodexServer)
+                    .put("username", saved.username ?: JSONObject.NULL)
+                    .put("password", saved.password ?: JSONObject.NULL)
+                    .put("directory", saved.directory ?: JSONObject.NULL),
             )
         }
         savedServersPreferences
@@ -5605,30 +6815,60 @@ class ServerManager(
     private fun loadSavedServersInternal(): List<SavedServer> {
         val raw = savedServersPreferences?.getString(savedServersKey, null) ?: return emptyList()
         val parsed = runCatching { JSONArray(raw) }.getOrNull() ?: return emptyList()
-        val out = mutableListOf<SavedServer>()
+        val out = LinkedHashMap<String, SavedServer>()
         for (index in 0 until parsed.length()) {
             val item = parsed.optJSONObject(index) ?: continue
-            val id = item.optString("id").trim()
             val name = item.optString("name").trim()
-            val host = normalizeServerHost(item.optString("host"))
+            val backendKind = item.optString("backendKind").trim()
+            val kind = BackendKind.from(backendKind)
+            val host =
+                normalizeServerHost(
+                    item.optString("host"),
+                    preserveScheme = kind == BackendKind.OPENCODE,
+                )
             val port = item.optInt("port", 0)
             val source = item.optString("source").trim()
             val hasCodexServer = item.optBoolean("hasCodexServer", true)
+            val id =
+                if (ServerSource.from(source) == ServerSource.MANUAL) {
+                    manualServerId(kind, host, port)
+                } else {
+                    item.optString("id").trim()
+                }
             if (id.isEmpty() || host.isEmpty() || port <= 0) {
                 continue
             }
-            out +=
+            out.remove(id)
+            out[id] =
                 SavedServer(
                     id = id,
                     name = if (name.isEmpty()) host else name,
                     host = host,
                     port = port,
                     source = source,
+                    backendKind = backendKind,
                     hasCodexServer = hasCodexServer,
+                    username = nullableString(item, "username"),
+                    password = nullableString(item, "password"),
+                    directory = nullableString(item, "directory"),
                 )
         }
-        return out
+        return out.values.toList()
     }
+}
+
+private fun nullableString(
+    item: JSONObject,
+    key: String,
+): String? {
+    if (item.isNull(key)) {
+        return null
+    }
+    val value = item.optString(key).trim()
+    if (value.isEmpty() || value.equals("null", ignoreCase = true)) {
+        return null
+    }
+    return value
 }
 
 internal fun computePlaceholderKeysToPrune(

--- a/apps/android/app/src/main/java/com/litter/android/state/StateModels.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/StateModels.kt
@@ -1,5 +1,7 @@
 package com.litter.android.state
 
+import java.net.URI
+import java.util.Locale
 import java.util.UUID
 
 enum class MessageRole {
@@ -60,6 +62,26 @@ enum class ServerSource {
     }
 }
 
+enum class BackendKind {
+    CODEX,
+    OPENCODE,
+    ;
+
+    fun rawValue(): String =
+        when (this) {
+            CODEX -> "codex"
+            OPENCODE -> "opencode"
+        }
+
+    companion object {
+        fun from(raw: String?): BackendKind =
+            when (raw?.trim()?.lowercase()) {
+                "opencode" -> OPENCODE
+                else -> CODEX
+            }
+    }
+}
+
 enum class AuthStatus {
     UNKNOWN,
     NOT_LOGGED_IN,
@@ -90,7 +112,11 @@ data class ServerConfig(
     val host: String,
     val port: Int,
     val source: ServerSource,
+    val backendKind: BackendKind = BackendKind.CODEX,
     val hasCodexServer: Boolean = true,
+    val username: String? = null,
+    val password: String? = null,
+    val directory: String? = null,
 ) {
     companion object {
         fun local(port: Int): ServerConfig =
@@ -100,6 +126,7 @@ data class ServerConfig(
                 host = "127.0.0.1",
                 port = port,
                 source = ServerSource.LOCAL,
+                backendKind = BackendKind.CODEX,
                 hasCodexServer = true,
             )
 
@@ -110,6 +137,7 @@ data class ServerConfig(
                 host = "127.0.0.1",
                 port = port,
                 source = ServerSource.BUNDLED,
+                backendKind = BackendKind.CODEX,
                 hasCodexServer = true,
             )
     }
@@ -121,7 +149,11 @@ data class SavedServer(
     val host: String,
     val port: Int,
     val source: String,
+    val backendKind: String = BackendKind.CODEX.rawValue(),
     val hasCodexServer: Boolean,
+    val username: String? = null,
+    val password: String? = null,
+    val directory: String? = null,
 ) {
     fun toServerConfig(): ServerConfig =
         ServerConfig(
@@ -130,7 +162,11 @@ data class SavedServer(
             host = host,
             port = port,
             source = ServerSource.from(source),
+            backendKind = BackendKind.from(backendKind),
             hasCodexServer = hasCodexServer,
+            username = username,
+            password = password,
+            directory = directory,
         )
 
     companion object {
@@ -141,10 +177,22 @@ data class SavedServer(
                 host = server.host,
                 port = server.port,
                 source = server.source.rawValue(),
+                backendKind = server.backendKind.rawValue(),
                 hasCodexServer = server.hasCodexServer,
+                username = server.username,
+                password = server.password,
+                directory = server.directory,
             )
     }
 }
+
+data class BackendCapabilities(
+    val supportsAuthManagement: Boolean = true,
+    val supportsExperimentalFeatures: Boolean = true,
+    val supportsSkillListing: Boolean = true,
+    val supportsDirectoryBrowser: Boolean = true,
+    val supportsQuestions: Boolean = false,
+)
 
 data class AccountState(
     val status: AuthStatus = AuthStatus.UNKNOWN,
@@ -213,6 +261,45 @@ data class SkillMentionInput(
     val path: String,
 )
 
+enum class SlashKind {
+    ACTION,
+    COMMAND,
+}
+
+data class SlashEntry(
+    val id: String,
+    val kind: SlashKind,
+    val name: String,
+    val aliases: List<String> = emptyList(),
+    val description: String = "",
+    val category: String = "",
+    val displayName: String = "",
+    val actionId: String? = null,
+    val source: String? = null,
+)
+
+data class OpenCodeAgentOption(
+    val name: String,
+    val description: String = "",
+    val mode: String = "",
+    val hidden: Boolean = false,
+)
+
+data class OpenCodeMcpServer(
+    val name: String,
+    val status: String,
+    val summary: String = "",
+)
+
+data class OpenCodeStatusSection(
+    val title: String,
+    val lines: List<String>,
+)
+
+data class OpenCodeStatusSnapshot(
+    val sections: List<OpenCodeStatusSection>,
+)
+
 data class ChatMessage(
     val id: String = UUID.randomUUID().toString(),
     val role: MessageRole,
@@ -241,6 +328,42 @@ data class PendingApproval(
     val grantRoot: String?,
     val requesterAgentNickname: String? = null,
     val requesterAgentRole: String? = null,
+    val createdAtEpochMillis: Long = System.currentTimeMillis(),
+)
+
+enum class PendingInteractionKind {
+    APPROVAL,
+    QUESTION,
+}
+
+data class PendingQuestionOption(
+    val label: String,
+    val description: String,
+)
+
+data class PendingQuestionPrompt(
+    val header: String,
+    val question: String,
+    val options: List<PendingQuestionOption>,
+    val multiple: Boolean = false,
+    val custom: Boolean = true,
+)
+
+data class PendingQuestion(
+    val id: String,
+    val requestId: String,
+    val serverId: String,
+    val threadId: String?,
+    val prompts: List<PendingQuestionPrompt>,
+    val createdAtEpochMillis: Long = System.currentTimeMillis(),
+)
+
+data class PendingInteraction(
+    val id: String,
+    val serverId: String,
+    val kind: PendingInteractionKind,
+    val approval: PendingApproval? = null,
+    val question: PendingQuestion? = null,
     val createdAtEpochMillis: Long = System.currentTimeMillis(),
 )
 
@@ -279,9 +402,13 @@ data class AppState(
     val activeThreadKey: ThreadKey? = null,
     val selectedModel: ModelSelection = ModelSelection(),
     val availableModels: List<ModelOption> = emptyList(),
+    val slashByServerId: Map<String, List<SlashEntry>> = emptyMap(),
+    val agentOptionsByServerId: Map<String, List<OpenCodeAgentOption>> = emptyMap(),
+    val selectedAgentByServerId: Map<String, String?> = emptyMap(),
     val accountByServerId: Map<String, AccountState> = emptyMap(),
+    val capabilitiesByServerId: Map<String, BackendCapabilities> = emptyMap(),
     val currentCwd: String = defaultWorkingDirectory(),
-    val pendingApprovals: List<PendingApproval> = emptyList(),
+    val pendingInteractions: List<PendingInteraction> = emptyList(),
     val toolTargetLabelsById: Map<String, String> = emptyMap(),
 ) {
     val activeThread: ThreadState?
@@ -295,9 +422,238 @@ data class AppState(
                 ?.let { accountByServerId[it] }
                 ?: AccountState()
 
+    val activeCapabilities: BackendCapabilities
+        get() =
+            activeServerId
+                ?.let { capabilitiesByServerId[it] }
+                ?: BackendCapabilities()
+
+    val activeSlashEntries: List<SlashEntry>
+        get() =
+            activeServerId
+                ?.let { slashByServerId[it] }
+                .orEmpty()
+
+    val activeAgentOptions: List<OpenCodeAgentOption>
+        get() =
+            activeServerId
+                ?.let { agentOptionsByServerId[it] }
+                .orEmpty()
+
+    val activeAgentName: String?
+        get() =
+            activeServerId
+                ?.let { selectedAgentByServerId[it] }
+
     val activePendingApproval: PendingApproval?
-        get() = pendingApprovals.firstOrNull()
+        get() = pendingInteractions.firstOrNull()?.approval
+
+    val activePendingInteraction: PendingInteraction?
+        get() = pendingInteractions.firstOrNull()
 }
 
 internal fun defaultWorkingDirectory(): String =
     (System.getProperty("java.io.tmpdir") ?: "/data/local/tmp").trim().ifEmpty { "/data/local/tmp" }
+
+internal fun openCodeMobileSlashEntries(): List<SlashEntry> =
+    listOf(
+        SlashEntry(
+            id = "action:session.new",
+            kind = SlashKind.ACTION,
+            name = "new",
+            aliases = listOf("clear"),
+            description = "Start a new session",
+            category = "Session",
+            displayName = "/new",
+            actionId = "session.new",
+        ),
+        SlashEntry(
+            id = "action:session.list",
+            kind = SlashKind.ACTION,
+            name = "sessions",
+            aliases = listOf("resume", "continue"),
+            description = "Switch sessions",
+            category = "Session",
+            displayName = "/sessions",
+            actionId = "session.list",
+        ),
+        SlashEntry(
+            id = "action:session.fork",
+            kind = SlashKind.ACTION,
+            name = "fork",
+            description = "Fork the current session",
+            category = "Session",
+            displayName = "/fork",
+            actionId = "session.fork",
+        ),
+        SlashEntry(
+            id = "action:session.rename",
+            kind = SlashKind.ACTION,
+            name = "rename",
+            description = "Rename the current session",
+            category = "Session",
+            displayName = "/rename",
+            actionId = "session.rename",
+        ),
+        SlashEntry(
+            id = "action:session.share",
+            kind = SlashKind.ACTION,
+            name = "share",
+            description = "Share the current session",
+            category = "Session",
+            displayName = "/share",
+            actionId = "session.share",
+        ),
+        SlashEntry(
+            id = "action:session.unshare",
+            kind = SlashKind.ACTION,
+            name = "unshare",
+            description = "Stop sharing the current session",
+            category = "Session",
+            displayName = "/unshare",
+            actionId = "session.unshare",
+        ),
+        SlashEntry(
+            id = "action:session.compact",
+            kind = SlashKind.ACTION,
+            name = "compact",
+            aliases = listOf("summarize"),
+            description = "Summarize the current session",
+            category = "Session",
+            displayName = "/compact",
+            actionId = "session.compact",
+        ),
+        SlashEntry(
+            id = "action:session.undo",
+            kind = SlashKind.ACTION,
+            name = "undo",
+            description = "Undo the last change",
+            category = "Session",
+            displayName = "/undo",
+            actionId = "session.undo",
+        ),
+        SlashEntry(
+            id = "action:session.redo",
+            kind = SlashKind.ACTION,
+            name = "redo",
+            description = "Redo the last reverted change",
+            category = "Session",
+            displayName = "/redo",
+            actionId = "session.redo",
+        ),
+        SlashEntry(
+            id = "action:model.list",
+            kind = SlashKind.ACTION,
+            name = "models",
+            description = "Choose a model",
+            category = "Agent",
+            displayName = "/models",
+            actionId = "model.list",
+        ),
+        SlashEntry(
+            id = "action:prompt.skills",
+            kind = SlashKind.ACTION,
+            name = "skills",
+            description = "Browse skills",
+            category = "Prompt",
+            displayName = "/skills",
+            actionId = "prompt.skills",
+        ),
+        SlashEntry(
+            id = "action:agent.list",
+            kind = SlashKind.ACTION,
+            name = "agents",
+            description = "Choose an agent",
+            category = "Agent",
+            displayName = "/agents",
+            actionId = "agent.list",
+        ),
+        SlashEntry(
+            id = "action:mcp.list",
+            kind = SlashKind.ACTION,
+            name = "mcps",
+            description = "Inspect MCP servers",
+            category = "Agent",
+            displayName = "/mcps",
+            actionId = "mcp.list",
+        ),
+        SlashEntry(
+            id = "action:opencode.status",
+            kind = SlashKind.ACTION,
+            name = "status",
+            description = "View OpenCode status",
+            category = "System",
+            displayName = "/status",
+            actionId = "opencode.status",
+        ),
+        SlashEntry(
+            id = "action:help.show",
+            kind = SlashKind.ACTION,
+            name = "help",
+            description = "List slash commands",
+            category = "System",
+            displayName = "/help",
+            actionId = "help.show",
+        ),
+    )
+
+internal fun mergeOpenCodeSlashEntries(
+    remote: List<SlashEntry>,
+    local: List<SlashEntry> = openCodeMobileSlashEntries(),
+): List<SlashEntry> {
+    val merged = ArrayList<SlashEntry>(remote.size + local.size)
+    val names = HashSet<String>()
+    val actions = HashSet<String>()
+
+    fun add(entry: SlashEntry) {
+        val key = entry.name.trim().lowercase(Locale.ROOT)
+        if (key.isEmpty()) {
+            return
+        }
+        if (!names.add(key)) {
+            return
+        }
+        if (entry.kind == SlashKind.ACTION) {
+            val action = entry.actionId?.trim().orEmpty()
+            if (action.isEmpty() || !actions.add(action)) {
+                names.remove(key)
+                return
+            }
+        }
+        merged += entry
+    }
+
+    remote.forEach(::add)
+    local.forEach(::add)
+    return merged.sortedBy { it.displayName.lowercase(Locale.ROOT) }
+}
+
+internal fun manualServerId(
+    kind: BackendKind,
+    host: String,
+    port: Int,
+): String {
+    val raw = host.trim().trimEnd('/')
+    val key =
+        if (kind != BackendKind.OPENCODE) {
+            raw.substringAfter("://", raw).trimStart('/')
+        } else {
+            runCatching {
+                val uri = if (raw.contains("://")) URI(raw) else null
+                val scheme = uri?.scheme?.trim()?.lowercase()
+                val path =
+                    uri?.rawPath
+                        ?.trim()
+                        ?.trimEnd('/')
+                        ?.takeIf { it.isNotEmpty() && it != "/" }
+                        .orEmpty()
+                val value =
+                    (uri?.rawAuthority?.trim()?.takeIf { it.isNotEmpty() }
+                        ?: uri?.host?.trim()
+                        ?: uri?.authority?.substringBefore('@')?.trim())
+                        ?: raw.substringAfter("://", raw).trimStart('/')
+                if (scheme.isNullOrBlank() || scheme == "http") "$value$path" else "$scheme://$value$path"
+            }.getOrDefault(raw)
+        }.ifEmpty { "127.0.0.1" }
+    return "manual-${kind.rawValue()}-$key:$port"
+}

--- a/apps/android/app/src/main/java/com/litter/android/ui/LitterAppShell.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/LitterAppShell.kt
@@ -113,6 +113,7 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
@@ -163,16 +164,25 @@ import com.litter.android.core.network.DiscoverySource
 import com.litter.android.state.AccountState
 import com.litter.android.state.ApprovalDecision
 import com.litter.android.state.ApprovalKind
+import com.litter.android.state.BackendKind
 import com.litter.android.state.AuthStatus
 import com.litter.android.state.ChatMessage
 import com.litter.android.state.ExperimentalFeature
 import com.litter.android.state.FuzzyFileSearchResult
 import com.litter.android.state.MessageRole
 import com.litter.android.state.ModelOption
+import com.litter.android.state.OpenCodeAgentOption
+import com.litter.android.state.OpenCodeMcpServer
+import com.litter.android.state.OpenCodeStatusSnapshot
 import com.litter.android.state.PendingApproval
+import com.litter.android.state.PendingInteractionKind
+import com.litter.android.state.PendingQuestion
+import com.litter.android.state.SavedServer
 import com.litter.android.state.ServerConfig
 import com.litter.android.state.ServerConnectionStatus
 import com.litter.android.state.ServerSource
+import com.litter.android.state.SlashEntry
+import com.litter.android.state.SlashKind
 import com.litter.android.state.SkillMentionInput
 import com.litter.android.state.SkillMetadata
 import com.litter.android.state.ThreadKey
@@ -229,6 +239,7 @@ fun LitterAppShell(
             modifier = Modifier.fillMaxSize().statusBarsPadding().navigationBarsPadding(),
         ) {
             HeaderBar(
+                backendKind = uiState.activeBackendKind,
                 models = uiState.models,
                 selectedModelId = uiState.selectedModelId,
                 selectedReasoningEffort = uiState.selectedReasoningEffort,
@@ -243,7 +254,10 @@ fun LitterAppShell(
                 EmptyState(
                     connectionStatus = uiState.connectionStatus,
                     connectedServers = uiState.connectedServers,
+                    savedServers = uiState.savedServers,
                     onOpenDiscovery = appState::openDiscovery,
+                    onReconnectSavedServer = appState::reconnectSavedServer,
+                    onReconfigureSavedServer = appState::reconfigureSavedServer,
                 )
             } else {
                 ConversationPanel(
@@ -256,6 +270,10 @@ fun LitterAppShell(
                     models = uiState.models,
                     selectedModelId = uiState.selectedModelId,
                     selectedReasoningEffort = uiState.selectedReasoningEffort,
+                    activeBackendKind = uiState.activeBackendKind,
+                    activeSlashEntries = uiState.activeSlashEntries,
+                    activeOpenCodeAgents = uiState.activeOpenCodeAgents,
+                    selectedAgentName = uiState.selectedAgentName,
                     approvalPolicy = uiState.approvalPolicy,
                     sandboxMode = uiState.sandboxMode,
                     currentCwd = uiState.currentCwd,
@@ -265,6 +283,7 @@ fun LitterAppShell(
                     onFileSearch = appState::searchComposerFiles,
                     onSelectModel = appState::selectModel,
                     onSelectReasoningEffort = appState::selectReasoningEffort,
+                    onSelectAgent = appState::selectAgent,
                     onUpdateComposerPermissions = appState::updateComposerPermissions,
                     onOpenNewSessionPicker = appState::openNewSessionPicker,
                     onOpenSidebar = appState::openSidebar,
@@ -273,6 +292,14 @@ fun LitterAppShell(
                     onListExperimentalFeatures = appState::listExperimentalFeatures,
                     onSetExperimentalFeatureEnabled = appState::setExperimentalFeatureEnabled,
                     onListSkills = appState::listSkills,
+                    onShareActiveThread = appState::shareActiveThread,
+                    onUnshareActiveThread = appState::unshareActiveThread,
+                    onCompactActiveThread = appState::compactActiveThread,
+                    onUndoActiveThread = appState::undoActiveThread,
+                    onRedoActiveThread = appState::redoActiveThread,
+                    onExecuteOpenCodeCommand = appState::executeOpenCodeCommand,
+                    onLoadOpenCodeMcpStatus = appState::loadOpenCodeMcpStatus,
+                    onLoadOpenCodeStatus = appState::loadOpenCodeStatus,
                     onForkConversation = appState::forkConversation,
                     onEditMessage = appState::editMessage,
                     onForkFromMessage = appState::forkConversationFromMessage,
@@ -376,8 +403,12 @@ fun LitterAppShell(
                 onDismiss = appState::dismissDiscovery,
                 onRefresh = appState::refreshDiscovery,
                 onConnectDiscovered = appState::connectDiscoveredServer,
+                onManualBackendKindChanged = appState::updateManualBackendKind,
                 onManualHostChanged = appState::updateManualHost,
                 onManualPortChanged = appState::updateManualPort,
+                onManualUsernameChanged = appState::updateManualUsername,
+                onManualPasswordChanged = appState::updateManualPassword,
+                onManualDirectoryChanged = appState::updateManualDirectory,
                 onConnectManual = appState::connectManualServer,
             )
         }
@@ -397,7 +428,7 @@ fun LitterAppShell(
             )
         }
 
-        if (uiState.showSettings) {
+        if (uiState.showSettings && uiState.activeCapabilities.supportsAuthManagement) {
             SettingsSheet(
                 accountState = uiState.accountState,
                 connectedServers = uiState.connectedServers,
@@ -409,7 +440,7 @@ fun LitterAppShell(
             )
         }
 
-        if (uiState.showAccount) {
+        if (uiState.showAccount && uiState.activeCapabilities.supportsAuthManagement) {
             val activeServer = uiState.connectedServers.firstOrNull { it.id == uiState.activeServerId }
             AccountSheet(
                 accountState = uiState.accountState,
@@ -426,34 +457,53 @@ fun LitterAppShell(
             )
         }
 
-        uiState.activePendingApproval?.let { approval ->
-            PendingApprovalDialog(
-                approval = approval,
-                onAllowOnce = {
-                    appState.respondToPendingApproval(
-                        approvalId = approval.id,
-                        decision = ApprovalDecision.ACCEPT,
+        val interaction = uiState.activePendingInteraction
+        when (interaction?.kind) {
+            PendingInteractionKind.APPROVAL -> {
+                val approval = interaction.approval
+                if (approval != null) {
+                    PendingApprovalDialog(
+                        approval = approval,
+                        onAllowOnce = {
+                            appState.respondToPendingApproval(
+                                approvalId = approval.id,
+                                decision = ApprovalDecision.ACCEPT,
+                            )
+                        },
+                        onAllowForSession = {
+                            appState.respondToPendingApproval(
+                                approvalId = approval.id,
+                                decision = ApprovalDecision.ACCEPT_FOR_SESSION,
+                            )
+                        },
+                        onDeny = {
+                            appState.respondToPendingApproval(
+                                approvalId = approval.id,
+                                decision = ApprovalDecision.DECLINE,
+                            )
+                        },
+                        onAbort = {
+                            appState.respondToPendingApproval(
+                                approvalId = approval.id,
+                                decision = ApprovalDecision.CANCEL,
+                            )
+                        },
                     )
-                },
-                onAllowForSession = {
-                    appState.respondToPendingApproval(
-                        approvalId = approval.id,
-                        decision = ApprovalDecision.ACCEPT_FOR_SESSION,
+                }
+            }
+
+            PendingInteractionKind.QUESTION -> {
+                val question = interaction.question
+                if (question != null) {
+                    PendingQuestionDialog(
+                        question = question,
+                        onSubmit = { answers -> appState.respondToPendingQuestion(question.id, answers) },
+                        onReject = { appState.rejectPendingQuestion(question.id) },
                     )
-                },
-                onDeny = {
-                    appState.respondToPendingApproval(
-                        approvalId = approval.id,
-                        decision = ApprovalDecision.DECLINE,
-                    )
-                },
-                onAbort = {
-                    appState.respondToPendingApproval(
-                        approvalId = approval.id,
-                        decision = ApprovalDecision.CANCEL,
-                    )
-                },
-            )
+                }
+            }
+
+            null -> Unit
         }
 
         if (uiState.uiError != null) {
@@ -601,7 +651,107 @@ private fun PendingApprovalDialog(
 }
 
 @Composable
+private fun PendingQuestionDialog(
+    question: PendingQuestion,
+    onSubmit: (List<List<String>>) -> Unit,
+    onReject: () -> Unit,
+) {
+    val answerState =
+        remember(question.id) {
+            question.prompts.map { prompt ->
+                mutableStateListOf<String>().apply {
+                    if (!prompt.multiple && prompt.options.isNotEmpty()) {
+                        add(prompt.options.first().label)
+                    }
+                }
+            }
+        }
+    val customAnswers =
+        remember(question.id) {
+            question.prompts.map { mutableStateOf("") }
+        }
+
+    Dialog(
+        onDismissRequest = {},
+        properties = DialogProperties(dismissOnBackPress = false, dismissOnClickOutside = false),
+    ) {
+        Surface(
+            shape = RoundedCornerShape(16.dp),
+            color = LitterTheme.surface,
+            border = androidx.compose.foundation.BorderStroke(1.dp, LitterTheme.border),
+        ) {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(18.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Text("OpenCode Question", style = MaterialTheme.typography.titleLarge, color = LitterTheme.textPrimary)
+                question.prompts.forEachIndexed { index, prompt ->
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text(prompt.header.ifBlank { "Question ${index + 1}" }, color = LitterTheme.textSecondary, style = MaterialTheme.typography.labelLarge)
+                        Text(prompt.question, color = LitterTheme.textPrimary, style = MaterialTheme.typography.bodyMedium)
+                        prompt.options.forEach { option ->
+                            val selected = answerState[index].contains(option.label)
+                            OutlinedButton(
+                                onClick = {
+                                    if (prompt.multiple) {
+                                        if (selected) answerState[index].remove(option.label) else answerState[index].add(option.label)
+                                    } else {
+                                        answerState[index].clear()
+                                        answerState[index].add(option.label)
+                                    }
+                                },
+                                modifier = Modifier.fillMaxWidth(),
+                                border = androidx.compose.foundation.BorderStroke(1.dp, if (selected) LitterTheme.accent else LitterTheme.border),
+                            ) {
+                                Column(modifier = Modifier.fillMaxWidth()) {
+                                    Text(option.label, color = LitterTheme.textPrimary)
+                                    if (option.description.isNotBlank()) {
+                                        Text(option.description, color = LitterTheme.textSecondary, style = MaterialTheme.typography.labelLarge)
+                                    }
+                                }
+                            }
+                        }
+                        if (prompt.custom) {
+                            OutlinedTextField(
+                                value = customAnswers[index].value,
+                                onValueChange = { customAnswers[index].value = it },
+                                label = { Text("Custom answer") },
+                                modifier = Modifier.fillMaxWidth(),
+                                singleLine = true,
+                            )
+                        }
+                    }
+                }
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedButton(onClick = onReject, modifier = Modifier.weight(1f)) {
+                        Text("Reject")
+                    }
+                    Button(
+                        onClick = {
+                            onSubmit(
+                                answerState.mapIndexed { index, answers ->
+                                    val custom = customAnswers[index].value.trim()
+                                    if (custom.isEmpty()) {
+                                        answers.toList()
+                                    } else {
+                                        (answers.toList() + custom).distinct()
+                                    }
+                                },
+                            )
+                        },
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        Text("Submit")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
 private fun HeaderBar(
+    backendKind: BackendKind,
     models: List<ModelOption>,
     selectedModelId: String?,
     selectedReasoningEffort: String?,
@@ -624,13 +774,24 @@ private fun HeaderBar(
                 Icon(Icons.Default.Menu, contentDescription = "Toggle sidebar", tint = LitterTheme.textSecondary)
             }
 
-            ModelSelector(
-                models = models,
-                selectedModelId = selectedModelId,
-                selectedReasoningEffort = selectedReasoningEffort,
-                onSelectModel = onSelectModel,
-                onSelectReasoningEffort = onSelectReasoningEffort,
-            )
+            if (backendKind == BackendKind.OPENCODE) {
+                OutlinedButton(
+                    onClick = {},
+                    enabled = false,
+                    border = androidx.compose.foundation.BorderStroke(1.dp, LitterTheme.border),
+                    shape = RoundedCornerShape(22.dp),
+                ) {
+                    Text("OpenCode", color = LitterTheme.textSecondary)
+                }
+            } else {
+                ModelSelector(
+                    models = models,
+                    selectedModelId = selectedModelId,
+                    selectedReasoningEffort = selectedReasoningEffort,
+                    onSelectModel = onSelectModel,
+                    onSelectReasoningEffort = onSelectReasoningEffort,
+                )
+            }
 
             Spacer(modifier = Modifier.weight(1f))
 
@@ -742,11 +903,15 @@ private fun StatusDot(connectionStatus: ServerConnectionStatus) {
 private fun EmptyState(
     connectionStatus: ServerConnectionStatus,
     connectedServers: List<ServerConfig>,
+    savedServers: List<SavedServer> = emptyList(),
     onOpenDiscovery: () -> Unit,
+    onReconnectSavedServer: (String) -> Unit = {},
+    onReconfigureSavedServer: (String) -> Unit = {},
 ) {
     val canConnect =
         connectionStatus == ServerConnectionStatus.DISCONNECTED ||
             connectionStatus == ServerConnectionStatus.ERROR
+    val connectedServerIds = remember(connectedServers) { connectedServers.map { it.id }.toSet() }
     val connectedServerLabels =
         remember(connectedServers) {
             connectedServers
@@ -755,6 +920,11 @@ private fun EmptyState(
                     val name = server.name.ifBlank { "server" }
                     "$name * ${serverSourceLabel(server.source)}"
                 }
+        }
+    // Saved servers that are not currently connected (offline/unreachable)
+    val offlineSavedServers =
+        remember(savedServers, connectedServerIds) {
+            savedServers.filter { !connectedServerIds.contains(it.id) }
         }
     Box(
         modifier = Modifier.fillMaxSize(),
@@ -789,6 +959,81 @@ private fun EmptyState(
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
                         )
+                    }
+                }
+            }
+            // Show offline saved servers with reconnect / reconfigure options
+            if (offlineSavedServers.isNotEmpty()) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(
+                        text = if (connectedServerLabels.isEmpty()) "Saved Servers" else "Offline Servers",
+                        style = MaterialTheme.typography.labelLarge,
+                        color = LitterTheme.textSecondary,
+                    )
+                    offlineSavedServers.forEach { saved ->
+                        val kindLabel = if (saved.backendKind.lowercase() == "opencode") "OpenCode" else "Codex"
+                        val hostLabel = "${saved.host}:${saved.port}"
+                        Surface(
+                            modifier = Modifier.fillMaxWidth(),
+                            shape = RoundedCornerShape(10.dp),
+                            color = LitterTheme.surface,
+                            border = androidx.compose.foundation.BorderStroke(1.dp, LitterTheme.border),
+                        ) {
+                            Column(
+                                modifier = Modifier.fillMaxWidth().padding(12.dp),
+                                verticalArrangement = Arrangement.spacedBy(6.dp),
+                            ) {
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    Column(modifier = Modifier.weight(1f)) {
+                                        Text(
+                                            text = saved.name.ifBlank { hostLabel },
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            color = LitterTheme.textPrimary,
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis,
+                                        )
+                                        Text(
+                                            text = "$kindLabel · $hostLabel",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = LitterTheme.textMuted,
+                                        )
+                                    }
+                                    // Offline indicator
+                                    Text(
+                                        text = "offline",
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = LitterTheme.statusError,
+                                    )
+                                }
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                ) {
+                                    OutlinedButton(
+                                        onClick = { onReconnectSavedServer(saved.id) },
+                                        modifier = Modifier.weight(1f),
+                                        border = androidx.compose.foundation.BorderStroke(1.dp, LitterTheme.accent),
+                                    ) {
+                                        Text("Reconnect", color = LitterTheme.accent)
+                                    }
+                                    OutlinedButton(
+                                        onClick = { onReconfigureSavedServer(saved.id) },
+                                        modifier = Modifier.weight(1f),
+                                        border = androidx.compose.foundation.BorderStroke(1.dp, LitterTheme.border),
+                                    ) {
+                                        Text("Reconfigure", color = LitterTheme.textSecondary)
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -2148,6 +2393,10 @@ private fun ConversationPanel(
     models: List<ModelOption>,
     selectedModelId: String?,
     selectedReasoningEffort: String?,
+    activeBackendKind: BackendKind,
+    activeSlashEntries: List<SlashEntry>,
+    activeOpenCodeAgents: List<OpenCodeAgentOption>,
+    selectedAgentName: String?,
     approvalPolicy: String,
     sandboxMode: String,
     currentCwd: String,
@@ -2157,6 +2406,7 @@ private fun ConversationPanel(
     onFileSearch: (String, (Result<List<FuzzyFileSearchResult>>) -> Unit) -> Unit,
     onSelectModel: (String) -> Unit,
     onSelectReasoningEffort: (String) -> Unit,
+    onSelectAgent: (String?) -> Unit,
     onUpdateComposerPermissions: (String, String) -> Unit,
     onOpenNewSessionPicker: () -> Unit,
     onOpenSidebar: () -> Unit,
@@ -2165,6 +2415,14 @@ private fun ConversationPanel(
     onListExperimentalFeatures: ((Result<List<ExperimentalFeature>>) -> Unit) -> Unit,
     onSetExperimentalFeatureEnabled: (String, Boolean, (Result<Unit>) -> Unit) -> Unit,
     onListSkills: (String?, Boolean, (Result<List<SkillMetadata>>) -> Unit) -> Unit,
+    onShareActiveThread: ((Result<Unit>) -> Unit) -> Unit,
+    onUnshareActiveThread: ((Result<Unit>) -> Unit) -> Unit,
+    onCompactActiveThread: ((Result<Unit>) -> Unit) -> Unit,
+    onUndoActiveThread: ((Result<Unit>) -> Unit) -> Unit,
+    onRedoActiveThread: ((Result<Unit>) -> Unit) -> Unit,
+    onExecuteOpenCodeCommand: (String, String, (Result<Unit>) -> Unit) -> Unit,
+    onLoadOpenCodeMcpStatus: ((Result<List<OpenCodeMcpServer>>) -> Unit) -> Unit,
+    onLoadOpenCodeStatus: ((Result<OpenCodeStatusSnapshot>) -> Unit) -> Unit,
     onForkConversation: () -> Unit,
     onEditMessage: (ChatMessage) -> Unit,
     onForkFromMessage: (ChatMessage) -> Unit,
@@ -2352,6 +2610,10 @@ private fun ConversationPanel(
             models = models,
             selectedModelId = selectedModelId,
             selectedReasoningEffort = selectedReasoningEffort,
+            activeBackendKind = activeBackendKind,
+            activeSlashEntries = activeSlashEntries,
+            activeOpenCodeAgents = activeOpenCodeAgents,
+            selectedAgentName = selectedAgentName,
             approvalPolicy = approvalPolicy,
             sandboxMode = sandboxMode,
             currentCwd = currentCwd,
@@ -2360,6 +2622,7 @@ private fun ConversationPanel(
             onFileSearch = onFileSearch,
             onSelectModel = onSelectModel,
             onSelectReasoningEffort = onSelectReasoningEffort,
+            onSelectAgent = onSelectAgent,
             onUpdateComposerPermissions = onUpdateComposerPermissions,
             onOpenNewSessionPicker = onOpenNewSessionPicker,
             onOpenSidebar = onOpenSidebar,
@@ -2368,6 +2631,14 @@ private fun ConversationPanel(
             onListExperimentalFeatures = onListExperimentalFeatures,
             onSetExperimentalFeatureEnabled = onSetExperimentalFeatureEnabled,
             onListSkills = onListSkills,
+            onShareActiveThread = onShareActiveThread,
+            onUnshareActiveThread = onUnshareActiveThread,
+            onCompactActiveThread = onCompactActiveThread,
+            onUndoActiveThread = onUndoActiveThread,
+            onRedoActiveThread = onRedoActiveThread,
+            onExecuteOpenCodeCommand = onExecuteOpenCodeCommand,
+            onLoadOpenCodeMcpStatus = onLoadOpenCodeMcpStatus,
+            onLoadOpenCodeStatus = onLoadOpenCodeStatus,
             onForkConversation = onForkConversation,
             onAttachImage = { attachmentLauncher.launch("image/*") },
             onCaptureImage = { cameraLauncher.launch(null) },
@@ -3248,6 +3519,10 @@ private fun InputBar(
     models: List<ModelOption>,
     selectedModelId: String?,
     selectedReasoningEffort: String?,
+    activeBackendKind: BackendKind,
+    activeSlashEntries: List<SlashEntry>,
+    activeOpenCodeAgents: List<OpenCodeAgentOption>,
+    selectedAgentName: String?,
     approvalPolicy: String,
     sandboxMode: String,
     currentCwd: String,
@@ -3256,6 +3531,7 @@ private fun InputBar(
     onFileSearch: (String, (Result<List<FuzzyFileSearchResult>>) -> Unit) -> Unit,
     onSelectModel: (String) -> Unit,
     onSelectReasoningEffort: (String) -> Unit,
+    onSelectAgent: (String?) -> Unit,
     onUpdateComposerPermissions: (String, String) -> Unit,
     onOpenNewSessionPicker: () -> Unit,
     onOpenSidebar: () -> Unit,
@@ -3264,6 +3540,14 @@ private fun InputBar(
     onListExperimentalFeatures: ((Result<List<ExperimentalFeature>>) -> Unit) -> Unit,
     onSetExperimentalFeatureEnabled: (String, Boolean, (Result<Unit>) -> Unit) -> Unit,
     onListSkills: (String?, Boolean, (Result<List<SkillMetadata>>) -> Unit) -> Unit,
+    onShareActiveThread: ((Result<Unit>) -> Unit) -> Unit,
+    onUnshareActiveThread: ((Result<Unit>) -> Unit) -> Unit,
+    onCompactActiveThread: ((Result<Unit>) -> Unit) -> Unit,
+    onUndoActiveThread: ((Result<Unit>) -> Unit) -> Unit,
+    onRedoActiveThread: ((Result<Unit>) -> Unit) -> Unit,
+    onExecuteOpenCodeCommand: (String, String, (Result<Unit>) -> Unit) -> Unit,
+    onLoadOpenCodeMcpStatus: ((Result<List<OpenCodeMcpServer>>) -> Unit) -> Unit,
+    onLoadOpenCodeStatus: ((Result<OpenCodeStatusSnapshot>) -> Unit) -> Unit,
     onForkConversation: () -> Unit,
     onAttachImage: () -> Unit,
     onCaptureImage: () -> Unit,
@@ -3284,7 +3568,8 @@ private fun InputBar(
     var lastCommittedDraft by remember { mutableStateOf(draft) }
     var showSlashPopup by remember { mutableStateOf(false) }
     var activeSlashToken by remember { mutableStateOf<ComposerSlashQueryContext?>(null) }
-    var slashSuggestions by remember { mutableStateOf<List<ComposerSlashCommand>>(emptyList()) }
+    var codexSlashSuggestions by remember { mutableStateOf<List<ComposerSlashCommand>>(emptyList()) }
+    var openCodeSlashSuggestions by remember { mutableStateOf<List<SlashEntry>>(emptyList()) }
 
     var showFilePopup by remember { mutableStateOf(false) }
     var activeAtToken by remember { mutableStateOf<ComposerTokenContext?>(null) }
@@ -3300,6 +3585,10 @@ private fun InputBar(
     var showPermissionsSheet by remember { mutableStateOf(false) }
     var showExperimentalSheet by remember { mutableStateOf(false) }
     var showSkillsSheet by remember { mutableStateOf(false) }
+    var showAgentsSheet by remember { mutableStateOf(false) }
+    var showMcpsSheet by remember { mutableStateOf(false) }
+    var showStatusSheet by remember { mutableStateOf(false) }
+    var showHelpSheet by remember { mutableStateOf(false) }
     var showRenameDialog by remember { mutableStateOf(false) }
     var renameCurrentTitle by remember { mutableStateOf("") }
     var renameDraft by remember { mutableStateOf("") }
@@ -3308,6 +3597,10 @@ private fun InputBar(
     var experimentalFeaturesLoading by remember { mutableStateOf(false) }
     var skills by remember { mutableStateOf<List<SkillMetadata>>(emptyList()) }
     var skillsLoading by remember { mutableStateOf(false) }
+    var mcps by remember { mutableStateOf<List<OpenCodeMcpServer>>(emptyList()) }
+    var mcpsLoading by remember { mutableStateOf(false) }
+    var statusSnapshot by remember { mutableStateOf<OpenCodeStatusSnapshot?>(null) }
+    var statusLoading by remember { mutableStateOf(false) }
     var showAttachmentMenu by remember { mutableStateOf(false) }
     var mentionSkillPathsByName by remember { mutableStateOf<Map<String, String>>(emptyMap()) }
     var hasAttemptedSkillMentionLoad by remember { mutableStateOf(false) }
@@ -3336,7 +3629,8 @@ private fun InputBar(
     fun hideComposerPopups() {
         showSlashPopup = false
         activeSlashToken = null
-        slashSuggestions = emptyList()
+        codexSlashSuggestions = emptyList()
+        openCodeSlashSuggestions = emptyList()
         showFilePopup = false
         activeAtToken = null
         showSkillPopup = false
@@ -3400,7 +3694,8 @@ private fun InputBar(
         if (atToken != null) {
             showSlashPopup = false
             activeSlashToken = null
-            slashSuggestions = emptyList()
+            codexSlashSuggestions = emptyList()
+            openCodeSlashSuggestions = emptyList()
             showSkillPopup = false
             activeDollarToken = null
             showFilePopup = true
@@ -3425,7 +3720,8 @@ private fun InputBar(
         if (dollarToken != null && isMentionQueryValid(dollarToken.value)) {
             showSlashPopup = false
             activeSlashToken = null
-            slashSuggestions = emptyList()
+            codexSlashSuggestions = emptyList()
+            openCodeSlashSuggestions = emptyList()
             showSkillPopup = true
             if (activeDollarToken != dollarToken) {
                 activeDollarToken = dollarToken
@@ -3448,13 +3744,21 @@ private fun InputBar(
         if (slashToken == null) {
             showSlashPopup = false
             activeSlashToken = null
-            slashSuggestions = emptyList()
+            codexSlashSuggestions = emptyList()
+            openCodeSlashSuggestions = emptyList()
             return
         }
 
         activeSlashToken = slashToken
-        slashSuggestions = filterSlashCommands(slashToken.query)
-        showSlashPopup = slashSuggestions.isNotEmpty()
+        if (activeBackendKind == BackendKind.OPENCODE) {
+            openCodeSlashSuggestions = filterOpenCodeSlashEntries(activeSlashEntries, slashToken.query)
+            codexSlashSuggestions = emptyList()
+            showSlashPopup = openCodeSlashSuggestions.isNotEmpty()
+            return
+        }
+        codexSlashSuggestions = filterSlashCommands(slashToken.query)
+        openCodeSlashSuggestions = emptyList()
+        showSlashPopup = codexSlashSuggestions.isNotEmpty()
     }
 
     fun loadExperimentalFeatures() {
@@ -3488,7 +3792,33 @@ private fun InputBar(
         }
     }
 
-    fun executeSlashCommand(
+    fun loadMcpStatus() {
+        mcpsLoading = true
+        onLoadOpenCodeMcpStatus { result ->
+            mcpsLoading = false
+            result.onFailure { error ->
+                slashErrorMessage = error.message ?: "Failed to load MCP status"
+            }
+            result.onSuccess { loaded ->
+                mcps = loaded.sortedBy { it.name.lowercase(Locale.ROOT) }
+            }
+        }
+    }
+
+    fun loadStatus() {
+        statusLoading = true
+        onLoadOpenCodeStatus { result ->
+            statusLoading = false
+            result.onFailure { error ->
+                slashErrorMessage = error.message ?: "Failed to load status"
+            }
+            result.onSuccess { loaded ->
+                statusSnapshot = loaded
+            }
+        }
+    }
+
+    fun executeCodexSlashCommand(
         command: ComposerSlashCommand,
         args: String?,
     ) {
@@ -3548,11 +3878,152 @@ private fun InputBar(
         }
     }
 
-    fun applySlashSuggestion(command: ComposerSlashCommand) {
+    fun executeOpenCodeAction(
+        actionId: String,
+        args: String?,
+    ) {
+        when (actionId) {
+            "model.list" -> {
+                showModelSheet = true
+            }
+
+            "session.list" -> {
+                onOpenSidebar()
+            }
+
+            "session.new" -> {
+                onOpenNewSessionPicker()
+            }
+
+            "session.fork" -> {
+                onForkConversation()
+            }
+
+            "session.rename" -> {
+                val initialName = args?.trim().orEmpty()
+                if (initialName.isNotEmpty()) {
+                    onRenameActiveThread(initialName) { result ->
+                        result.onFailure { error ->
+                            slashErrorMessage = error.message ?: "Failed to rename thread"
+                        }
+                    }
+                } else {
+                    renameCurrentTitle = activeThreadPreview.ifBlank { "Untitled thread" }
+                    renameDraft = ""
+                    showRenameDialog = true
+                }
+            }
+
+            "prompt.skills" -> {
+                showSkillsSheet = true
+                loadSkills(forceReload = false)
+            }
+
+            "agent.list" -> {
+                showAgentsSheet = true
+            }
+
+            "mcp.list" -> {
+                showMcpsSheet = true
+                loadMcpStatus()
+            }
+
+            "session.share" -> {
+                onShareActiveThread { result ->
+                    result.onFailure { error ->
+                        slashErrorMessage = error.message ?: "Failed to share thread"
+                    }
+                }
+            }
+
+            "session.unshare" -> {
+                onUnshareActiveThread { result ->
+                    result.onFailure { error ->
+                        slashErrorMessage = error.message ?: "Failed to unshare thread"
+                    }
+                }
+            }
+
+            "session.compact" -> {
+                onCompactActiveThread { result ->
+                    result.onFailure { error ->
+                        slashErrorMessage = error.message ?: "Failed to compact thread"
+                    }
+                }
+            }
+
+            "session.undo" -> {
+                onUndoActiveThread { result ->
+                    result.onFailure { error ->
+                        slashErrorMessage = error.message ?: "Failed to undo"
+                    }
+                }
+            }
+
+            "session.redo" -> {
+                onRedoActiveThread { result ->
+                    result.onFailure { error ->
+                        slashErrorMessage = error.message ?: "Failed to redo"
+                    }
+                }
+            }
+
+            "opencode.status" -> {
+                showStatusSheet = true
+                loadStatus()
+            }
+
+            "help.show" -> {
+                showHelpSheet = true
+            }
+
+            else -> {
+                slashErrorMessage = "This slash action is not available on mobile yet"
+            }
+        }
+    }
+
+    fun applyCodexSlashSuggestion(command: ComposerSlashCommand) {
         composerValue = TextFieldValue(text = "", selection = TextRange(0))
         commitDraftIfNeeded("")
         hideComposerPopups()
-        executeSlashCommand(command, args = null)
+        executeCodexSlashCommand(command, args = null)
+    }
+
+    fun insertSlashCommand(name: String) {
+        val token = activeSlashToken
+        val replacement = "/$name "
+        val updatedText =
+            if (token == null) {
+                replacement
+            } else {
+                composerValue.text.replaceRange(
+                    startIndex = token.range.start,
+                    endIndex = token.range.end,
+                    replacement = replacement,
+                )
+            }
+        val nextCursor =
+            if (token == null) {
+                updatedText.length
+            } else {
+                token.range.start + replacement.length
+            }
+        composerValue = TextFieldValue(text = updatedText, selection = TextRange(nextCursor))
+        commitDraftIfNeeded(updatedText)
+        showSlashPopup = false
+        activeSlashToken = null
+        codexSlashSuggestions = emptyList()
+        openCodeSlashSuggestions = emptyList()
+    }
+
+    fun applyOpenCodeSlashSuggestion(entry: SlashEntry) {
+        hideComposerPopups()
+        if (entry.kind == SlashKind.COMMAND) {
+            insertSlashCommand(entry.name)
+            return
+        }
+        executeOpenCodeAction(entry.actionId ?: return, args = null)
     }
 
     fun applyFileSuggestion(match: FuzzyFileSearchResult) {
@@ -3907,8 +4378,17 @@ private fun InputBar(
                             verticalArrangement = Arrangement.spacedBy(6.dp),
                         ) {
                             items(skills, key = { "${it.path}#${it.name}" }) { skill ->
+                                val clickable =
+                                    if (activeBackendKind == BackendKind.OPENCODE) {
+                                        Modifier.clickable {
+                                            insertSlashCommand(skill.name)
+                                            showSkillsSheet = false
+                                        }
+                                    } else {
+                                        Modifier
+                                    }
                                 Surface(
-                                    modifier = Modifier.fillMaxWidth(),
+                                    modifier = Modifier.fillMaxWidth().then(clickable),
                                     color = LitterTheme.surface.copy(alpha = 0.6f),
                                     shape = RoundedCornerShape(8.dp),
                                     border = androidx.compose.foundation.BorderStroke(1.dp, LitterTheme.border),
@@ -3932,6 +4412,239 @@ private fun InputBar(
                                         }
                                         Text(skill.path, color = LitterTheme.textMuted, style = MaterialTheme.typography.labelLarge)
                                     }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showAgentsSheet) {
+        ModalBottomSheet(onDismissRequest = { showAgentsSheet = false }) {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                Text("Agents", style = MaterialTheme.typography.titleMedium)
+                Surface(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                onSelectAgent(null)
+                                showAgentsSheet = false
+                            },
+                    color = LitterTheme.surface.copy(alpha = 0.6f),
+                    shape = RoundedCornerShape(8.dp),
+                    border = androidx.compose.foundation.BorderStroke(1.dp, if (selectedAgentName == null) LitterTheme.accent else LitterTheme.border),
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 9.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                            Text("Default", color = LitterTheme.textPrimary, style = MaterialTheme.typography.bodyMedium)
+                            Text("Use the server default agent", color = LitterTheme.textSecondary, style = MaterialTheme.typography.labelLarge)
+                        }
+                        if (selectedAgentName == null) {
+                            Icon(Icons.Default.Check, contentDescription = null, tint = LitterTheme.accent, modifier = Modifier.size(16.dp))
+                        }
+                    }
+                }
+                if (activeOpenCodeAgents.isEmpty()) {
+                    Text("No agents available", color = LitterTheme.textMuted)
+                } else {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxWidth().fillMaxHeight(0.55f),
+                        verticalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        items(activeOpenCodeAgents, key = { it.name }) { agent ->
+                            Surface(
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .clickable {
+                                            onSelectAgent(agent.name)
+                                            showAgentsSheet = false
+                                        },
+                                color = LitterTheme.surface.copy(alpha = 0.6f),
+                                shape = RoundedCornerShape(8.dp),
+                                border =
+                                    androidx.compose.foundation.BorderStroke(
+                                        1.dp,
+                                        if (agent.name == selectedAgentName) LitterTheme.accent else LitterTheme.border,
+                                    ),
+                            ) {
+                                Row(
+                                    modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 9.dp),
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    Column(
+                                        modifier = Modifier.weight(1f),
+                                        verticalArrangement = Arrangement.spacedBy(2.dp),
+                                    ) {
+                                        Text(agent.name, color = LitterTheme.textPrimary, style = MaterialTheme.typography.bodyMedium)
+                                        Text(
+                                            agent.description.ifBlank { agent.mode.ifBlank { "Agent" } },
+                                            color = LitterTheme.textSecondary,
+                                            style = MaterialTheme.typography.labelLarge,
+                                        )
+                                    }
+                                    if (agent.name == selectedAgentName) {
+                                        Icon(Icons.Default.Check, contentDescription = null, tint = LitterTheme.accent, modifier = Modifier.size(16.dp))
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showMcpsSheet) {
+        ModalBottomSheet(onDismissRequest = { showMcpsSheet = false }) {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text("MCPs", style = MaterialTheme.typography.titleMedium)
+                    TextButton(onClick = { loadMcpStatus() }) { Text("Reload") }
+                }
+                when {
+                    mcpsLoading -> {
+                        Text("Loading...", color = LitterTheme.textMuted)
+                    }
+
+                    mcps.isEmpty() -> {
+                        Text("No MCP servers available", color = LitterTheme.textMuted)
+                    }
+
+                    else -> {
+                        LazyColumn(
+                            modifier = Modifier.fillMaxWidth().fillMaxHeight(0.55f),
+                            verticalArrangement = Arrangement.spacedBy(6.dp),
+                        ) {
+                            items(mcps, key = { it.name }) { item ->
+                                Surface(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    color = LitterTheme.surface.copy(alpha = 0.6f),
+                                    shape = RoundedCornerShape(8.dp),
+                                    border = androidx.compose.foundation.BorderStroke(1.dp, LitterTheme.border),
+                                ) {
+                                    Column(
+                                        modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 9.dp),
+                                        verticalArrangement = Arrangement.spacedBy(2.dp),
+                                    ) {
+                                        Text(item.name, color = LitterTheme.textPrimary, style = MaterialTheme.typography.bodyMedium)
+                                        Text(item.status, color = LitterTheme.accent, style = MaterialTheme.typography.labelLarge)
+                                        if (item.summary.isNotBlank()) {
+                                            Text(item.summary, color = LitterTheme.textSecondary, style = MaterialTheme.typography.labelLarge)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showStatusSheet) {
+        ModalBottomSheet(onDismissRequest = { showStatusSheet = false }) {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text("Status", style = MaterialTheme.typography.titleMedium)
+                    TextButton(onClick = { loadStatus() }) { Text("Reload") }
+                }
+                when {
+                    statusLoading -> {
+                        Text("Loading...", color = LitterTheme.textMuted)
+                    }
+
+                    statusSnapshot == null || statusSnapshot?.sections.isNullOrEmpty() -> {
+                        Text("No status available", color = LitterTheme.textMuted)
+                    }
+
+                    else -> {
+                        LazyColumn(
+                            modifier = Modifier.fillMaxWidth().fillMaxHeight(0.65f),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            items(statusSnapshot?.sections.orEmpty(), key = { it.title }) { section ->
+                                Surface(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    color = LitterTheme.surface.copy(alpha = 0.6f),
+                                    shape = RoundedCornerShape(8.dp),
+                                    border = androidx.compose.foundation.BorderStroke(1.dp, LitterTheme.border),
+                                ) {
+                                    Column(
+                                        modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 9.dp),
+                                        verticalArrangement = Arrangement.spacedBy(4.dp),
+                                    ) {
+                                        Text(section.title, color = LitterTheme.textPrimary, style = MaterialTheme.typography.bodyMedium)
+                                        section.lines.forEach { line ->
+                                            Text(line, color = LitterTheme.textSecondary, style = MaterialTheme.typography.labelLarge)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showHelpSheet) {
+        ModalBottomSheet(onDismissRequest = { showHelpSheet = false }) {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                Text("Slash Commands", style = MaterialTheme.typography.titleMedium)
+                val items = activeSlashEntries.sortedBy { it.displayName.lowercase(Locale.ROOT) }
+                if (items.isEmpty()) {
+                    Text("No slash commands available", color = LitterTheme.textMuted)
+                } else {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxWidth().fillMaxHeight(0.65f),
+                        verticalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        items(items, key = { it.id }) { item ->
+                            Surface(
+                                modifier = Modifier.fillMaxWidth(),
+                                color = LitterTheme.surface.copy(alpha = 0.6f),
+                                shape = RoundedCornerShape(8.dp),
+                                border = androidx.compose.foundation.BorderStroke(1.dp, LitterTheme.border),
+                            ) {
+                                Column(
+                                    modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 9.dp),
+                                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                                ) {
+                                    Text(item.displayName.ifBlank { "/${item.name}" }, color = LitterTheme.textPrimary, style = MaterialTheme.typography.bodyMedium)
+                                    Text(
+                                        item.description.ifBlank { item.category.ifBlank { item.kind.name.lowercase(Locale.ROOT) } },
+                                        color = LitterTheme.textSecondary,
+                                        style = MaterialTheme.typography.labelLarge,
+                                    )
                                 }
                             }
                         }
@@ -4074,32 +4787,63 @@ private fun InputBar(
                     border = androidx.compose.foundation.BorderStroke(1.dp, LitterTheme.border),
                 ) {
                     Column {
-                        slashSuggestions.forEachIndexed { index, command ->
-                            Row(
-                                modifier =
-                                    Modifier
-                                        .fillMaxWidth()
-                                        .clickable { applySlashSuggestion(command) }
-                                        .padding(horizontal = 14.dp, vertical = 10.dp),
-                                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                                verticalAlignment = Alignment.CenterVertically,
-                            ) {
-                                Text(
-                                    text = "/${command.rawValue}",
-                                    color = LitterTheme.success,
-                                    style = MaterialTheme.typography.bodyMedium,
-                                )
-                                Text(
-                                    text = command.description,
-                                    color = LitterTheme.textSecondary,
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                    modifier = Modifier.weight(1f),
-                                )
+                        if (activeBackendKind == BackendKind.OPENCODE) {
+                            openCodeSlashSuggestions.forEachIndexed { index, entry ->
+                                Row(
+                                    modifier =
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .clickable { applyOpenCodeSlashSuggestion(entry) }
+                                            .padding(horizontal = 14.dp, vertical = 10.dp),
+                                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    Text(
+                                        text = entry.displayName.ifBlank { "/${entry.name}" },
+                                        color = LitterTheme.success,
+                                        style = MaterialTheme.typography.bodyMedium,
+                                    )
+                                    Text(
+                                        text = entry.description.ifBlank { entry.category },
+                                        color = LitterTheme.textSecondary,
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                        modifier = Modifier.weight(1f),
+                                    )
+                                }
+                                if (index < openCodeSlashSuggestions.lastIndex) {
+                                    HorizontalDivider(color = LitterTheme.border, thickness = 0.5.dp)
+                                }
                             }
-                            if (index < slashSuggestions.lastIndex) {
-                                HorizontalDivider(color = LitterTheme.border, thickness = 0.5.dp)
+                        } else {
+                            codexSlashSuggestions.forEachIndexed { index, command ->
+                                Row(
+                                    modifier =
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .clickable { applyCodexSlashSuggestion(command) }
+                                            .padding(horizontal = 14.dp, vertical = 10.dp),
+                                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    Text(
+                                        text = "/${command.rawValue}",
+                                        color = LitterTheme.success,
+                                        style = MaterialTheme.typography.bodyMedium,
+                                    )
+                                    Text(
+                                        text = command.description,
+                                        color = LitterTheme.textSecondary,
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                        modifier = Modifier.weight(1f),
+                                    )
+                                }
+                                if (index < codexSlashSuggestions.lastIndex) {
+                                    HorizontalDivider(color = LitterTheme.border, thickness = 0.5.dp)
+                                }
                             }
                         }
                     }
@@ -4351,15 +5095,36 @@ private fun InputBar(
                             .clickable(enabled = canSend) {
                                 val trimmed = composerValue.text.trim()
                                 if (attachedImagePath == null) {
-                                    val invocation = parseSlashCommandInvocation(trimmed)
-                                    if (invocation != null) {
-                                        composerValue = TextFieldValue(text = "", selection = TextRange(0))
-                                        commitDraftIfNeeded("")
-                                        hideComposerPopups()
-                                        focusManager.clearFocus(force = true)
-                                        keyboardController?.hide()
-                                        executeSlashCommand(invocation.command, invocation.args)
-                                        return@clickable
+                                    if (activeBackendKind == BackendKind.OPENCODE) {
+                                        val invocation = parseOpenCodeSlashInvocation(trimmed, activeSlashEntries)
+                                        if (invocation != null) {
+                                            composerValue = TextFieldValue(text = "", selection = TextRange(0))
+                                            commitDraftIfNeeded("")
+                                            hideComposerPopups()
+                                            focusManager.clearFocus(force = true)
+                                            keyboardController?.hide()
+                                            if (invocation.entry.kind == SlashKind.ACTION) {
+                                                executeOpenCodeAction(invocation.entry.actionId ?: "", invocation.args)
+                                            } else {
+                                                onExecuteOpenCodeCommand(invocation.entry.name, invocation.args.orEmpty()) { result ->
+                                                    result.onFailure { error ->
+                                                        slashErrorMessage = error.message ?: "Failed to run slash command"
+                                                    }
+                                                }
+                                            }
+                                            return@clickable
+                                        }
+                                    } else {
+                                        val invocation = parseSlashCommandInvocation(trimmed)
+                                        if (invocation != null) {
+                                            composerValue = TextFieldValue(text = "", selection = TextRange(0))
+                                            commitDraftIfNeeded("")
+                                            hideComposerPopups()
+                                            focusManager.clearFocus(force = true)
+                                            keyboardController?.hide()
+                                            executeCodexSlashCommand(invocation.command, invocation.args)
+                                            return@clickable
+                                        }
                                     }
                                 }
                                 focusManager.clearFocus(force = true)
@@ -4450,6 +5215,30 @@ private data class ComposerSlashInvocation(
     val args: String?,
 )
 
+internal data class OpenCodeSlashInvocation(
+    val entry: SlashEntry,
+    val args: String?,
+)
+
+private val supportedOpenCodeActionIds =
+    setOf(
+        "agent.list",
+        "help.show",
+        "mcp.list",
+        "model.list",
+        "opencode.status",
+        "prompt.skills",
+        "session.compact",
+        "session.fork",
+        "session.list",
+        "session.new",
+        "session.redo",
+        "session.rename",
+        "session.share",
+        "session.undo",
+        "session.unshare",
+    )
+
 private fun filterSlashCommands(query: String): List<ComposerSlashCommand> {
     if (query.isEmpty()) {
         return ComposerSlashCommand.values().toList()
@@ -4462,6 +5251,38 @@ private fun filterSlashCommands(query: String): List<ComposerSlashCommand> {
         .sortedWith(
             compareByDescending<Pair<ComposerSlashCommand, Int>> { it.second }
                 .thenBy { it.first.rawValue },
+        )
+        .map { it.first }
+}
+
+internal fun filterOpenCodeSlashEntries(
+    entries: List<SlashEntry>,
+    query: String,
+): List<SlashEntry> {
+    val visible =
+        entries.filter { entry ->
+            entry.kind != SlashKind.ACTION || supportedOpenCodeActionIds.contains(entry.actionId)
+        }
+    if (query.isBlank()) {
+        return visible.sortedBy { it.displayName.lowercase(Locale.ROOT) }
+    }
+    return visible
+        .mapNotNull { entry ->
+            val candidates = buildList {
+                add(entry.name)
+                addAll(entry.aliases)
+                add(entry.displayName.removePrefix("/"))
+            }
+            val score = candidates.maxOfOrNull { candidate -> fuzzyScore(candidate = candidate, query = query) ?: Int.MIN_VALUE }
+            if (score == null || score == Int.MIN_VALUE) {
+                null
+            } else {
+                entry to score
+            }
+        }
+        .sortedWith(
+            compareByDescending<Pair<SlashEntry, Int>> { it.second }
+                .thenBy { it.first.displayName.lowercase(Locale.ROOT) },
         )
         .map { it.first }
 }
@@ -4578,6 +5399,34 @@ private fun parseSlashCommandInvocation(text: String): ComposerSlashInvocation? 
     val command = ComposerSlashCommand.fromRawCommand(commandName) ?: return null
     val args = body.substringAfter(' ', "").trim().ifEmpty { null }
     return ComposerSlashInvocation(command = command, args = args)
+}
+
+internal fun parseOpenCodeSlashInvocation(
+    text: String,
+    entries: List<SlashEntry>,
+): OpenCodeSlashInvocation? {
+    val firstLine = text.lineSequence().firstOrNull()?.trim().orEmpty()
+    if (!firstLine.startsWith("/")) {
+        return null
+    }
+    val body = firstLine.drop(1)
+    if (body.isEmpty()) {
+        return null
+    }
+    val commandName = body.substringBefore(' ').trim().lowercase(Locale.ROOT)
+    if (commandName.isEmpty()) {
+        return null
+    }
+    val entry =
+        entries.firstOrNull { item ->
+            item.name.lowercase(Locale.ROOT) == commandName ||
+                item.aliases.any { alias -> alias.lowercase(Locale.ROOT) == commandName }
+        } ?: return null
+    if (entry.kind == SlashKind.ACTION && !supportedOpenCodeActionIds.contains(entry.actionId)) {
+        return null
+    }
+    val args = body.substringAfter(' ', "").trim().ifEmpty { null }
+    return OpenCodeSlashInvocation(entry = entry, args = args)
 }
 
 private fun currentPrefixedToken(
@@ -5514,8 +6363,12 @@ private fun DiscoverySheet(
     onDismiss: () -> Unit,
     onRefresh: () -> Unit,
     onConnectDiscovered: (String) -> Unit,
+    onManualBackendKindChanged: (BackendKind) -> Unit,
     onManualHostChanged: (String) -> Unit,
     onManualPortChanged: (String) -> Unit,
+    onManualUsernameChanged: (String) -> Unit,
+    onManualPasswordChanged: (String) -> Unit,
+    onManualDirectoryChanged: (String) -> Unit,
     onConnectManual: () -> Unit,
 ) {
     val configuration = LocalConfiguration.current
@@ -5702,6 +6555,26 @@ private fun DiscoverySheet(
                                         modifier = Modifier.fillMaxWidth().padding(12.dp),
                                         verticalArrangement = Arrangement.spacedBy(10.dp),
                                     ) {
+                                        Row(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                        ) {
+                                            OutlinedButton(
+                                                onClick = { onManualBackendKindChanged(BackendKind.CODEX) },
+                                                modifier = Modifier.weight(1f),
+                                                border = androidx.compose.foundation.BorderStroke(1.dp, if (state.manualBackendKind == BackendKind.CODEX) LitterTheme.accent else LitterTheme.border),
+                                            ) {
+                                                Text("Codex")
+                                            }
+                                            OutlinedButton(
+                                                onClick = { onManualBackendKindChanged(BackendKind.OPENCODE) },
+                                                modifier = Modifier.weight(1f),
+                                                border = androidx.compose.foundation.BorderStroke(1.dp, if (state.manualBackendKind == BackendKind.OPENCODE) LitterTheme.accent else LitterTheme.border),
+                                            ) {
+                                                Text("OpenCode")
+                                            }
+                                        }
+
                                         if (editingField == ManualField.HOST) {
                                             Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
                                                 OutlinedTextField(
@@ -5908,6 +6781,30 @@ private fun DiscoverySheet(
                                                 }
                                             }
                                         }
+
+                                        if (state.manualBackendKind == BackendKind.OPENCODE) {
+                                            OutlinedTextField(
+                                                value = state.manualUsername,
+                                                onValueChange = onManualUsernameChanged,
+                                                label = { Text("Username (optional)") },
+                                                modifier = Modifier.fillMaxWidth(),
+                                                singleLine = true,
+                                            )
+                                            OutlinedTextField(
+                                                value = state.manualPassword,
+                                                onValueChange = onManualPasswordChanged,
+                                                label = { Text("Password (optional)") },
+                                                modifier = Modifier.fillMaxWidth(),
+                                                singleLine = true,
+                                            )
+                                            OutlinedTextField(
+                                                value = state.manualDirectory,
+                                                onValueChange = onManualDirectoryChanged,
+                                                label = { Text("Directory (optional)") },
+                                                modifier = Modifier.fillMaxWidth(),
+                                                singleLine = true,
+                                            )
+                                        }
                                     }
                                 }
                                 Spacer(modifier = Modifier.weight(1f))
@@ -6039,6 +6936,25 @@ private fun DiscoverySheet(
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    OutlinedButton(
+                        onClick = { onManualBackendKindChanged(BackendKind.CODEX) },
+                        modifier = Modifier.weight(1f),
+                        border = androidx.compose.foundation.BorderStroke(1.dp, if (state.manualBackendKind == BackendKind.CODEX) LitterTheme.accent else LitterTheme.border),
+                    ) {
+                        Text("Codex")
+                    }
+                    OutlinedButton(
+                        onClick = { onManualBackendKindChanged(BackendKind.OPENCODE) },
+                        modifier = Modifier.weight(1f),
+                        border = androidx.compose.foundation.BorderStroke(1.dp, if (state.manualBackendKind == BackendKind.OPENCODE) LitterTheme.accent else LitterTheme.border),
+                    ) {
+                        Text("OpenCode")
+                    }
+                }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     OutlinedTextField(
@@ -6054,6 +6970,30 @@ private fun DiscoverySheet(
                         label = { Text("Port") },
                         modifier = Modifier.width(110.dp),
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        singleLine = true,
+                    )
+                }
+
+                if (state.manualBackendKind == BackendKind.OPENCODE) {
+                    OutlinedTextField(
+                        value = state.manualUsername,
+                        onValueChange = onManualUsernameChanged,
+                        label = { Text("Username (optional)") },
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                    )
+                    OutlinedTextField(
+                        value = state.manualPassword,
+                        onValueChange = onManualPasswordChanged,
+                        label = { Text("Password (optional)") },
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                    )
+                    OutlinedTextField(
+                        value = state.manualDirectory,
+                        onValueChange = onManualDirectoryChanged,
+                        label = { Text("Directory (optional)") },
+                        modifier = Modifier.fillMaxWidth(),
                         singleLine = true,
                     )
                 }

--- a/apps/android/app/src/main/java/com/litter/android/ui/LitterAppState.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/LitterAppState.kt
@@ -10,6 +10,8 @@ import com.litter.android.core.network.DiscoveredServer
 import com.litter.android.core.network.DiscoverySource
 import com.litter.android.core.network.ServerDiscoveryService
 import com.litter.android.state.AccountState
+import com.litter.android.state.BackendCapabilities
+import com.litter.android.state.BackendKind
 import com.litter.android.state.ApprovalDecision
 import com.litter.android.state.AppState
 import com.litter.android.state.AuthStatus
@@ -18,12 +20,18 @@ import com.litter.android.state.ExperimentalFeature
 import com.litter.android.state.FuzzyFileSearchResult
 import com.litter.android.state.ModelOption
 import com.litter.android.state.ModelSelection
+import com.litter.android.state.OpenCodeAgentOption
+import com.litter.android.state.OpenCodeMcpServer
+import com.litter.android.state.OpenCodeStatusSnapshot
 import com.litter.android.state.PendingApproval
+import com.litter.android.state.PendingInteraction
+import com.litter.android.state.SavedServer
 import com.litter.android.state.SavedSshCredential
 import com.litter.android.state.ServerConfig
 import com.litter.android.state.ServerConnectionStatus
 import com.litter.android.state.ServerManager
 import com.litter.android.state.ServerSource
+import com.litter.android.state.SlashEntry
 import com.litter.android.state.SkillMentionInput
 import com.litter.android.state.SkillMetadata
 import com.litter.android.state.SshAuthMethod
@@ -33,6 +41,7 @@ import com.litter.android.state.SshSessionManager
 import com.litter.android.state.ThreadKey
 import com.litter.android.state.ThreadState
 import com.litter.android.state.ThreadStatus
+import com.litter.android.state.manualServerId
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -82,8 +91,12 @@ data class DiscoveryUiState(
     val isVisible: Boolean = false,
     val isLoading: Boolean = false,
     val servers: List<UiDiscoveredServer> = emptyList(),
+    val manualBackendKind: BackendKind = BackendKind.CODEX,
     val manualHost: String = "",
     val manualPort: String = "8390",
+    val manualUsername: String = "",
+    val manualPassword: String = "",
+    val manualDirectory: String = "",
     val errorMessage: String? = null,
 )
 
@@ -109,11 +122,16 @@ data class UiShellState(
     val connectionStatus: ServerConnectionStatus = ServerConnectionStatus.DISCONNECTED,
     val connectionError: String? = null,
     val connectedServers: List<ServerConfig> = emptyList(),
+    val savedServers: List<SavedServer> = emptyList(),
     val activeServerId: String? = null,
+    val activeBackendKind: BackendKind = BackendKind.CODEX,
     val serverCount: Int = 0,
     val models: List<ModelOption> = emptyList(),
     val selectedModelId: String? = null,
     val selectedReasoningEffort: String? = "medium",
+    val activeSlashEntries: List<SlashEntry> = emptyList(),
+    val activeOpenCodeAgents: List<OpenCodeAgentOption> = emptyList(),
+    val selectedAgentName: String? = null,
     val approvalPolicy: String = "never",
     val sandboxMode: String = "workspace-write",
     val sessions: List<ThreadState> = emptyList(),
@@ -135,7 +153,9 @@ data class UiShellState(
     val showAccount: Boolean = false,
     val accountOpenedFromSettings: Boolean = false,
     val accountState: AccountState = AccountState(),
+    val activeCapabilities: BackendCapabilities = BackendCapabilities(),
     val activePendingApproval: PendingApproval? = null,
+    val activePendingInteraction: PendingInteraction? = null,
     val apiKeyDraft: String = "",
     val isAuthWorking: Boolean = false,
     val sshLogin: SshLoginUiState = SshLoginUiState(),
@@ -154,6 +174,8 @@ interface LitterAppState : Closeable {
     fun selectModel(modelId: String)
 
     fun selectReasoningEffort(effort: String)
+
+    fun selectAgent(name: String?)
 
     fun selectSession(threadKey: ThreadKey)
 
@@ -215,6 +237,13 @@ interface LitterAppState : Closeable {
         decision: ApprovalDecision,
     )
 
+    fun respondToPendingQuestion(
+        questionId: String,
+        answers: List<List<String>>,
+    )
+
+    fun rejectPendingQuestion(questionId: String)
+
     fun startReview(
         onComplete: (Result<Unit>) -> Unit,
     )
@@ -264,6 +293,40 @@ interface LitterAppState : Closeable {
         onComplete: (Result<List<SkillMetadata>>) -> Unit,
     )
 
+    fun shareActiveThread(
+        onComplete: (Result<Unit>) -> Unit,
+    )
+
+    fun unshareActiveThread(
+        onComplete: (Result<Unit>) -> Unit,
+    )
+
+    fun compactActiveThread(
+        onComplete: (Result<Unit>) -> Unit,
+    )
+
+    fun undoActiveThread(
+        onComplete: (Result<Unit>) -> Unit,
+    )
+
+    fun redoActiveThread(
+        onComplete: (Result<Unit>) -> Unit,
+    )
+
+    fun executeOpenCodeCommand(
+        command: String,
+        arguments: String,
+        onComplete: (Result<Unit>) -> Unit,
+    )
+
+    fun loadOpenCodeMcpStatus(
+        onComplete: (Result<List<OpenCodeMcpServer>>) -> Unit,
+    )
+
+    fun loadOpenCodeStatus(
+        onComplete: (Result<OpenCodeStatusSnapshot>) -> Unit,
+    )
+
     fun openSettings()
 
     fun dismissSettings()
@@ -296,6 +359,14 @@ interface LitterAppState : Closeable {
 
     fun updateManualPort(value: String)
 
+    fun updateManualBackendKind(value: BackendKind)
+
+    fun updateManualUsername(value: String)
+
+    fun updateManualPassword(value: String)
+
+    fun updateManualDirectory(value: String)
+
     fun connectManualServer()
 
     fun dismissSshLogin()
@@ -322,6 +393,10 @@ interface LitterAppState : Closeable {
     )
 
     fun removeServer(serverId: String)
+
+    fun reconnectSavedServer(serverId: String)
+
+    fun reconfigureSavedServer(serverId: String)
 
     fun clearUiError()
 }
@@ -400,6 +475,10 @@ class DefaultLitterAppState(
 
     override fun selectReasoningEffort(effort: String) {
         serverManager.updateModelSelection(reasoningEffort = effort)
+    }
+
+    override fun selectAgent(name: String?) {
+        serverManager.selectOpenCodeAgent(name)
     }
 
     override fun selectSession(threadKey: ThreadKey) {
@@ -819,6 +898,17 @@ class DefaultLitterAppState(
         serverManager.respondToPendingApproval(approvalId = approvalId, decision = decision)
     }
 
+    override fun respondToPendingQuestion(
+        questionId: String,
+        answers: List<List<String>>,
+    ) {
+        serverManager.respondToPendingQuestion(questionId = questionId, answers = answers)
+    }
+
+    override fun rejectPendingQuestion(questionId: String) {
+        serverManager.rejectPendingQuestion(questionId = questionId)
+    }
+
     override fun startReview(onComplete: (Result<Unit>) -> Unit) {
         serverManager.startReviewOnActiveThread { result ->
             result.onFailure { error ->
@@ -903,6 +993,10 @@ class DefaultLitterAppState(
     }
 
     override fun listExperimentalFeatures(onComplete: (Result<List<ExperimentalFeature>>) -> Unit) {
+        if (!_uiState.value.activeCapabilities.supportsExperimentalFeatures) {
+            onComplete(Result.failure(IllegalStateException("Experimental features are not supported for this backend")))
+            return
+        }
         serverManager.listExperimentalFeatures(onComplete = onComplete)
     }
 
@@ -911,6 +1005,10 @@ class DefaultLitterAppState(
         enabled: Boolean,
         onComplete: (Result<Unit>) -> Unit,
     ) {
+        if (!_uiState.value.activeCapabilities.supportsExperimentalFeatures) {
+            onComplete(Result.failure(IllegalStateException("Experimental features are not supported for this backend")))
+            return
+        }
         serverManager.setExperimentalFeatureEnabled(
             featureName = featureName,
             enabled = enabled,
@@ -923,6 +1021,10 @@ class DefaultLitterAppState(
         forceReload: Boolean,
         onComplete: (Result<List<SkillMetadata>>) -> Unit,
     ) {
+        if (!_uiState.value.activeCapabilities.supportsSkillListing) {
+            onComplete(Result.success(emptyList()))
+            return
+        }
         val normalizedCwd = cwd?.trim()?.takeIf { it.isNotEmpty() }
         serverManager.listSkills(
             cwds = normalizedCwd?.let { listOf(it) },
@@ -931,7 +1033,59 @@ class DefaultLitterAppState(
         )
     }
 
+    override fun shareActiveThread(onComplete: (Result<Unit>) -> Unit) {
+        serverManager.shareActiveThread(onComplete = onComplete)
+    }
+
+    override fun unshareActiveThread(onComplete: (Result<Unit>) -> Unit) {
+        serverManager.unshareActiveThread(onComplete = onComplete)
+    }
+
+    override fun compactActiveThread(onComplete: (Result<Unit>) -> Unit) {
+        serverManager.compactActiveThread(onComplete = onComplete)
+    }
+
+    override fun undoActiveThread(onComplete: (Result<Unit>) -> Unit) {
+        serverManager.undoActiveThread(onComplete = onComplete)
+    }
+
+    override fun redoActiveThread(onComplete: (Result<Unit>) -> Unit) {
+        serverManager.redoActiveThread(onComplete = onComplete)
+    }
+
+    override fun executeOpenCodeCommand(
+        command: String,
+        arguments: String,
+        onComplete: (Result<Unit>) -> Unit,
+    ) {
+        val snapshot = _uiState.value
+        val modelSelection =
+            ModelSelection(
+                modelId = snapshot.selectedModelId,
+                reasoningEffort = snapshot.selectedReasoningEffort,
+            )
+        serverManager.executeOpenCodeCommand(
+            command = command,
+            arguments = arguments,
+            cwd = snapshot.currentCwd,
+            modelSelection = modelSelection,
+            onComplete = onComplete,
+        )
+    }
+
+    override fun loadOpenCodeMcpStatus(onComplete: (Result<List<OpenCodeMcpServer>>) -> Unit) {
+        serverManager.loadOpenCodeMcpStatus(onComplete = onComplete)
+    }
+
+    override fun loadOpenCodeStatus(onComplete: (Result<OpenCodeStatusSnapshot>) -> Unit) {
+        serverManager.loadOpenCodeStatus(onComplete = onComplete)
+    }
+
     override fun openSettings() {
+        if (!_uiState.value.activeCapabilities.supportsAuthManagement) {
+            setUiError("Settings are not available for this backend")
+            return
+        }
         _uiState.update {
             it.copy(
                 showSettings = true,
@@ -947,6 +1101,10 @@ class DefaultLitterAppState(
     }
 
     override fun openAccount() {
+        if (!_uiState.value.activeCapabilities.supportsAuthManagement) {
+            setUiError("Account management is not available for this backend")
+            return
+        }
         _uiState.update { it.copy(showSettings = false, showAccount = true, accountOpenedFromSettings = true) }
         serverManager.refreshAccountState { result ->
             result.onFailure { error ->
@@ -970,6 +1128,10 @@ class DefaultLitterAppState(
     }
 
     override fun loginWithChatGpt() {
+        if (!_uiState.value.activeCapabilities.supportsAuthManagement) {
+            setUiError("Account management is not available for this backend")
+            return
+        }
         _uiState.update { it.copy(isAuthWorking = true) }
         serverManager.loginWithChatGpt { result ->
             _uiState.update { it.copy(isAuthWorking = false) }
@@ -980,6 +1142,10 @@ class DefaultLitterAppState(
     }
 
     override fun loginWithApiKey() {
+        if (!_uiState.value.activeCapabilities.supportsAuthManagement) {
+            setUiError("Account management is not available for this backend")
+            return
+        }
         val key = _uiState.value.apiKeyDraft.trim()
         if (key.isEmpty()) {
             return
@@ -997,6 +1163,10 @@ class DefaultLitterAppState(
     }
 
     override fun logoutAccount() {
+        if (!_uiState.value.activeCapabilities.supportsAuthManagement) {
+            setUiError("Account management is not available for this backend")
+            return
+        }
         _uiState.update { it.copy(isAuthWorking = true) }
         serverManager.logoutAccount { result ->
             _uiState.update { it.copy(isAuthWorking = false) }
@@ -1029,8 +1199,21 @@ class DefaultLitterAppState(
 
     override fun openDiscovery() {
         _uiState.update {
+            val server =
+                it.connectedServers.firstOrNull { cfg ->
+                    cfg.id == it.activeServerId && cfg.source == ServerSource.MANUAL
+                }
             it.copy(
-                discovery = it.discovery.copy(isVisible = true),
+                discovery =
+                    it.discovery.copy(
+                        isVisible = true,
+                        manualBackendKind = server?.backendKind ?: it.discovery.manualBackendKind,
+                        manualHost = server?.host ?: it.discovery.manualHost,
+                        manualPort = server?.port?.toString() ?: it.discovery.manualPort,
+                        manualUsername = server?.username ?: it.discovery.manualUsername,
+                        manualPassword = server?.password ?: it.discovery.manualPassword,
+                        manualDirectory = server?.directory ?: it.discovery.manualDirectory,
+                    ),
                 isSidebarOpen = false,
                 sessionSearchQuery = "",
                 showSettings = false,
@@ -1171,6 +1354,47 @@ class DefaultLitterAppState(
         }
     }
 
+    override fun updateManualBackendKind(value: BackendKind) {
+        _uiState.update {
+            it.copy(
+                discovery =
+                    it.discovery.copy(
+                        manualBackendKind = value,
+                        manualPort =
+                            if (value == BackendKind.OPENCODE && it.discovery.manualPort == "8390") {
+                                "4096"
+                            } else {
+                                it.discovery.manualPort
+                            },
+                    ),
+            )
+        }
+    }
+
+    override fun updateManualUsername(value: String) {
+        _uiState.update {
+            it.copy(
+                discovery = it.discovery.copy(manualUsername = value),
+            )
+        }
+    }
+
+    override fun updateManualPassword(value: String) {
+        _uiState.update {
+            it.copy(
+                discovery = it.discovery.copy(manualPassword = value),
+            )
+        }
+    }
+
+    override fun updateManualDirectory(value: String) {
+        _uiState.update {
+            it.copy(
+                discovery = it.discovery.copy(manualDirectory = value),
+            )
+        }
+    }
+
     override fun connectManualServer() {
         val snapshot = _uiState.value.discovery
         val host = snapshot.manualHost.trim()
@@ -1182,12 +1406,16 @@ class DefaultLitterAppState(
 
         val server =
             ServerConfig(
-                id = "manual-$host:$port",
+                id = manualServerId(snapshot.manualBackendKind, host, port),
                 name = host,
                 host = host,
                 port = port,
                 source = ServerSource.MANUAL,
-                hasCodexServer = true,
+                backendKind = snapshot.manualBackendKind,
+                hasCodexServer = snapshot.manualBackendKind == BackendKind.CODEX,
+                username = snapshot.manualUsername.trim().ifBlank { null },
+                password = snapshot.manualPassword.ifBlank { null },
+                directory = snapshot.manualDirectory.trim().ifBlank { null },
             )
 
         serverManager.connectServer(server) { result ->
@@ -1202,7 +1430,10 @@ class DefaultLitterAppState(
                                 isVisible = false,
                                 errorMessage = null,
                                 manualHost = "",
-                                manualPort = "8390",
+                                manualPort = if (snapshot.manualBackendKind == BackendKind.OPENCODE) "4096" else "8390",
+                                manualUsername = "",
+                                manualPassword = "",
+                                manualDirectory = "",
                             ),
                     )
                 }
@@ -1463,8 +1694,51 @@ class DefaultLitterAppState(
         serverManager.removeServer(serverId)
         if (_uiState.value.connectedServers.size <= 1) {
             _uiState.update { it.copy(showAccount = false, showSettings = false) }
-            openDiscovery()
+            // Only open discovery if there are no saved servers to show
+            val hasSaved = serverManager.snapshot().savedServers.isNotEmpty()
+            if (!hasSaved) {
+                openDiscovery()
+            }
         }
+    }
+
+    override fun reconnectSavedServer(serverId: String) {
+        val saved = serverManager.snapshot().savedServers.firstOrNull { it.id == serverId } ?: return
+        val server = saved.toServerConfig()
+        serverManager.connectServer(server) { result ->
+            result.onSuccess {
+                postConnectPrime()
+            }
+            result.onFailure { error ->
+                setUiError(error.message ?: "Failed to reconnect")
+            }
+        }
+    }
+
+    override fun reconfigureSavedServer(serverId: String) {
+        val saved = serverManager.snapshot().savedServers.firstOrNull { it.id == serverId }
+        _uiState.update {
+            it.copy(
+                discovery =
+                    it.discovery.copy(
+                        isVisible = true,
+                        manualBackendKind = if (saved != null) BackendKind.from(saved.backendKind) else it.discovery.manualBackendKind,
+                        manualHost = saved?.host ?: it.discovery.manualHost,
+                        manualPort = saved?.port?.toString() ?: it.discovery.manualPort,
+                        manualUsername = saved?.username.orEmpty(),
+                        manualPassword = saved?.password.orEmpty(),
+                        manualDirectory = saved?.directory.orEmpty(),
+                    ),
+                isSidebarOpen = false,
+                showSettings = false,
+                showAccount = false,
+            )
+        }
+        // Remove the old saved entry so connecting creates a fresh one with updated config
+        if (saved != null) {
+            serverManager.removeSavedServer(serverId)
+        }
+        refreshDiscovery()
     }
 
     override fun clearUiError() {
@@ -1474,11 +1748,21 @@ class DefaultLitterAppState(
     private fun connectAndPrime() {
         serverManager.reconnectSavedServers { result ->
             result.onFailure {
-                openDiscovery()
+                // If reconnect threw entirely (no saved servers at all), open discovery
+                val hasSaved = serverManager.snapshot().savedServers.isNotEmpty()
+                if (!hasSaved) {
+                    openDiscovery()
+                }
+                // Otherwise the saved servers are shown in EmptyState with a Reconnect button
             }
             result.onSuccess { connected ->
                 if (connected.isEmpty()) {
-                    openDiscovery()
+                    // There were saved servers but none connected — show them in EmptyState
+                    // Only open discovery if there are no saved servers at all
+                    val hasSaved = serverManager.snapshot().savedServers.isNotEmpty()
+                    if (!hasSaved) {
+                        openDiscovery()
+                    }
                 } else {
                     postConnectPrime()
                 }
@@ -1638,6 +1922,11 @@ class DefaultLitterAppState(
     private fun mergeBackendState(backend: AppState) {
         val activeThread = backend.activeThread
         val activeServerId = backend.activeServerId ?: backend.activeThreadKey?.serverId ?: backend.servers.firstOrNull()?.id
+        val activeBackendKind =
+            backend.servers
+                .firstOrNull { it.id == activeServerId }
+                ?.backendKind
+                ?: BackendKind.CODEX
         val accountState = backend.activeAccount
         var pickerFallbackServerId: String? = null
         var shouldClosePickerForNoServers = false
@@ -1683,11 +1972,16 @@ class DefaultLitterAppState(
                 connectionStatus = backend.connectionStatus,
                 connectionError = backend.connectionError,
                 connectedServers = backend.servers,
+                savedServers = backend.savedServers,
                 activeServerId = activeServerId,
+                activeBackendKind = activeBackendKind,
                 serverCount = backend.servers.size,
                 models = backend.availableModels,
                 selectedModelId = backend.selectedModel.modelId,
                 selectedReasoningEffort = backend.selectedModel.reasoningEffort,
+                activeSlashEntries = backend.activeSlashEntries,
+                activeOpenCodeAgents = backend.activeAgentOptions,
+                selectedAgentName = backend.activeAgentName,
                 sessions = backend.threads,
                 activeThreadKey = backend.activeThreadKey,
                 messages = activeThread?.messages ?: emptyList(),
@@ -1695,7 +1989,9 @@ class DefaultLitterAppState(
                 isSending = activeThread?.status == ThreadStatus.THINKING,
                 currentCwd = backend.currentCwd,
                 accountState = accountState,
+                activeCapabilities = backend.activeCapabilities,
                 activePendingApproval = backend.activePendingApproval,
+                activePendingInteraction = backend.activePendingInteraction,
                 showSettings = current.showSettings,
                 showAccount = current.showAccount,
                 accountOpenedFromSettings = current.accountOpenedFromSettings,

--- a/apps/android/app/src/test/java/com/litter/android/state/OpenCodeClientPathTest.kt
+++ b/apps/android/app/src/test/java/com/litter/android/state/OpenCodeClientPathTest.kt
@@ -1,0 +1,13 @@
+package com.litter.android.state
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class OpenCodeClientPathTest {
+    @Test
+    fun openCodePathKeepsConfiguredBasePrefix() {
+        assertEquals("/base/slash", openCodePath("/base", "/slash"))
+        assertEquals("/nested/root/skill", openCodePath("/nested/root/", "skill"))
+        assertEquals("/slash", openCodePath("/", "/slash"))
+    }
+}

--- a/apps/android/app/src/test/java/com/litter/android/state/OpenCodeStateModelsTest.kt
+++ b/apps/android/app/src/test/java/com/litter/android/state/OpenCodeStateModelsTest.kt
@@ -1,0 +1,62 @@
+package com.litter.android.state
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OpenCodeStateModelsTest {
+    @Test
+    fun activeOpenCodeMetadataUsesActiveServer() {
+        val slash = SlashEntry(id = "command:review", kind = SlashKind.COMMAND, name = "review", displayName = "/review")
+        val agent = OpenCodeAgentOption(name = "build", description = "Default")
+        val state =
+            AppState(
+                activeServerId = "opencode",
+                slashByServerId = mapOf("opencode" to listOf(slash)),
+                agentOptionsByServerId = mapOf("opencode" to listOf(agent)),
+                selectedAgentByServerId = mapOf("opencode" to "build"),
+            )
+
+        assertEquals(listOf(slash), state.activeSlashEntries)
+        assertEquals(listOf(agent), state.activeAgentOptions)
+        assertEquals("build", state.activeAgentName)
+    }
+
+    @Test
+    fun mergeOpenCodeSlashEntriesAddsMobileActions() {
+        val merged =
+            mergeOpenCodeSlashEntries(
+                listOf(
+                    SlashEntry(id = "command:init", kind = SlashKind.COMMAND, name = "init", displayName = "/init"),
+                    SlashEntry(id = "command:review", kind = SlashKind.COMMAND, name = "review", displayName = "/review"),
+                ),
+            )
+
+        val names = merged.map { it.name }
+
+        assertTrue(names.contains("init"))
+        assertTrue(names.contains("review"))
+        assertTrue(names.contains("new"))
+        assertTrue(names.contains("sessions"))
+        assertTrue(names.contains("models"))
+        assertTrue(names.contains("skills"))
+    }
+
+    @Test
+    fun mergeOpenCodeSlashEntriesPrefersRemoteNameConflicts() {
+        val remote =
+            SlashEntry(
+                id = "command:status",
+                kind = SlashKind.COMMAND,
+                name = "status",
+                description = "Custom status command",
+                displayName = "/status",
+            )
+
+        val merged = mergeOpenCodeSlashEntries(listOf(remote))
+        val status = merged.filter { it.name == "status" }
+
+        assertEquals(1, status.size)
+        assertEquals(SlashKind.COMMAND, status.single().kind)
+    }
+}

--- a/apps/android/app/src/test/java/com/litter/android/state/PendingInteractionStateTest.kt
+++ b/apps/android/app/src/test/java/com/litter/android/state/PendingInteractionStateTest.kt
@@ -1,0 +1,53 @@
+package com.litter.android.state
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PendingInteractionStateTest {
+    @Test
+    fun activePendingApprovalUsesFirstInteractionApproval() {
+        val approval = PendingApproval(id = "approval-1", requestId = "approval-1", serverId = "server", method = "exec", kind = ApprovalKind.COMMAND_EXECUTION, threadId = null, turnId = null, itemId = null, command = null, cwd = null, reason = null, grantRoot = null)
+        val state =
+            AppState(
+                pendingInteractions =
+                    listOf(
+                        PendingInteraction(
+                            id = approval.id,
+                            serverId = approval.serverId,
+                            kind = PendingInteractionKind.APPROVAL,
+                            approval = approval,
+                        ),
+                    ),
+            )
+
+        assertEquals(approval, state.activePendingApproval)
+    }
+
+    @Test
+    fun activePendingApprovalIgnoresQuestionInteraction() {
+        val question =
+            PendingQuestion(
+                id = "question-1",
+                requestId = "question-1",
+                serverId = "server",
+                threadId = null,
+                prompts = listOf(PendingQuestionPrompt(header = "Mode", question = "Choose", options = listOf(PendingQuestionOption("A", "desc")))),
+            )
+        val state =
+            AppState(
+                pendingInteractions =
+                    listOf(
+                        PendingInteraction(
+                            id = question.id,
+                            serverId = question.serverId,
+                            kind = PendingInteractionKind.QUESTION,
+                            question = question,
+                        ),
+                    ),
+            )
+
+        assertNull(state.activePendingApproval)
+        assertEquals(question.id, state.activePendingInteraction?.question?.id)
+    }
+}

--- a/apps/android/app/src/test/java/com/litter/android/state/ServerConfigPersistenceTest.kt
+++ b/apps/android/app/src/test/java/com/litter/android/state/ServerConfigPersistenceTest.kt
@@ -1,0 +1,67 @@
+package com.litter.android.state
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ServerConfigPersistenceTest {
+    @Test
+    fun manualOpenCodeIdCanonicalizesDefaultHttpScheme() {
+        val first = manualServerId(BackendKind.OPENCODE, "127.0.0.1", 4096)
+        val second = manualServerId(BackendKind.OPENCODE, "http://127.0.0.1", 4096)
+
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun savedServerRoundTripsOpenCodeFields() {
+        val server =
+            ServerConfig(
+                id = "opencode-main",
+                name = "OpenCode",
+                host = "192.168.1.10",
+                port = 4096,
+                source = ServerSource.MANUAL,
+                backendKind = BackendKind.OPENCODE,
+                hasCodexServer = false,
+                username = "opencode",
+                password = "secret",
+                directory = "/workspace/demo",
+            )
+
+        val restored = SavedServer.from(server).toServerConfig()
+
+        assertEquals(BackendKind.OPENCODE, restored.backendKind)
+        assertEquals("opencode", restored.username)
+        assertEquals("secret", restored.password)
+        assertEquals("/workspace/demo", restored.directory)
+    }
+
+    @Test
+    fun savedServerDefaultsToCodexWhenBackendKindMissing() {
+        val restored =
+            SavedServer(
+                id = "legacy",
+                name = "Legacy",
+                host = "127.0.0.1",
+                port = 8390,
+                source = "manual",
+                hasCodexServer = true,
+            ).toServerConfig()
+
+        assertEquals(BackendKind.CODEX, restored.backendKind)
+        assertNull(restored.username)
+        assertNull(restored.directory)
+    }
+
+    @Test
+    fun manualOpenCodeIdKeepsPathSegments() {
+        val first = manualServerId(BackendKind.OPENCODE, "https://example.com/base", 443)
+        val second = manualServerId(BackendKind.OPENCODE, "https://example.com/base/", 443)
+        val third = manualServerId(BackendKind.OPENCODE, "https://example.com/other", 443)
+
+        assertEquals(first, second)
+        assertNotEquals(first, third)
+    }
+}

--- a/apps/android/app/src/test/java/com/litter/android/ui/OpenCodeSlashCommandTest.kt
+++ b/apps/android/app/src/test/java/com/litter/android/ui/OpenCodeSlashCommandTest.kt
@@ -1,0 +1,90 @@
+package com.litter.android.ui
+
+import com.litter.android.state.SlashEntry
+import com.litter.android.state.SlashKind
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class OpenCodeSlashCommandTest {
+    @Test
+    fun filterOpenCodeSlashEntriesUsesAliasesAndHidesUnsupportedActions() {
+        val entries =
+            listOf(
+                SlashEntry(
+                    id = "action:session.list",
+                    kind = SlashKind.ACTION,
+                    name = "sessions",
+                    aliases = listOf("resume"),
+                    description = "Switch session",
+                    displayName = "/sessions",
+                    actionId = "session.list",
+                ),
+                SlashEntry(
+                    id = "action:theme.switch",
+                    kind = SlashKind.ACTION,
+                    name = "themes",
+                    description = "Switch theme",
+                    displayName = "/themes",
+                    actionId = "theme.switch",
+                ),
+                SlashEntry(
+                    id = "command:review",
+                    kind = SlashKind.COMMAND,
+                    name = "review",
+                    description = "Review changes",
+                    displayName = "/review",
+                ),
+            )
+
+        val filtered = filterOpenCodeSlashEntries(entries, "res")
+
+        assertEquals(listOf("sessions"), filtered.map { it.name })
+    }
+
+    @Test
+    fun parseOpenCodeSlashInvocationResolvesAliasesAndCommandArguments() {
+        val entries =
+            listOf(
+                SlashEntry(
+                    id = "action:session.list",
+                    kind = SlashKind.ACTION,
+                    name = "sessions",
+                    aliases = listOf("resume"),
+                    displayName = "/sessions",
+                    actionId = "session.list",
+                ),
+                SlashEntry(
+                    id = "command:review",
+                    kind = SlashKind.COMMAND,
+                    name = "review",
+                    displayName = "/review",
+                ),
+            )
+
+        val action = parseOpenCodeSlashInvocation("/resume", entries)
+        val command = parseOpenCodeSlashInvocation("/review staged changes", entries)
+
+        assertEquals("session.list", action?.entry?.actionId)
+        assertEquals("review", command?.entry?.name)
+        assertEquals("staged changes", command?.args)
+    }
+
+    @Test
+    fun parseOpenCodeSlashInvocationRejectsUnsupportedActionIds() {
+        val entries =
+            listOf(
+                SlashEntry(
+                    id = "action:theme.switch",
+                    kind = SlashKind.ACTION,
+                    name = "themes",
+                    displayName = "/themes",
+                    actionId = "theme.switch",
+                ),
+            )
+
+        val invocation = parseOpenCodeSlashInvocation("/themes", entries)
+
+        assertNull(invocation)
+    }
+}

--- a/apps/android/scripts/run-remote-debug.sh
+++ b/apps/android/scripts/run-remote-debug.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ANDROID_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+APP_ID="com.sigkitten.litter.android"
+ACTIVITY="com.litter.android.MainActivity"
+PORT="${OPENCODE_PORT:-4096}"
+
+if ! command -v adb >/dev/null 2>&1; then
+  echo "adb is not installed or not on PATH" >&2
+  exit 1
+fi
+
+adb start-server >/dev/null
+
+DEVICE_LINE="$(adb devices | awk 'NR>1 && $2 != "" {print $0; exit}')"
+if [[ -z "$DEVICE_LINE" ]]; then
+  echo "No Android device detected over adb" >&2
+  exit 1
+fi
+
+DEVICE_STATE="$(printf '%s\n' "$DEVICE_LINE" | awk '{print $2}')"
+if [[ "$DEVICE_STATE" == "unauthorized" ]]; then
+  echo "Android device is connected but unauthorized." >&2
+  echo "Unlock the phone, accept the USB debugging prompt, then rerun this command." >&2
+  exit 1
+fi
+
+if [[ "$DEVICE_STATE" != "device" ]]; then
+  echo "Android device is not ready: $DEVICE_STATE" >&2
+  exit 1
+fi
+
+"$ANDROID_DIR/gradlew" -p "$ANDROID_DIR" :app:installRemoteOnlyDebug
+adb reverse "tcp:${PORT}" "tcp:${PORT}"
+adb shell am force-stop "$APP_ID" >/dev/null 2>&1 || true
+adb shell am start -n "${APP_ID}/${ACTIVITY}" >/dev/null
+
+echo "Installed and launched ${APP_ID}."
+echo "OpenCode endpoint for the app: 127.0.0.1:${PORT}"


### PR DESCRIPTION
## Purpose
Add Android support for connecting to and operating an OpenCode backend from the existing Litter shell.

## Key changes
- add an `OpenCodeClient` and wire `ServerManager` to manage OpenCode connections, metadata, permissions, questions, slash actions, and session lifecycle operations
- extend Android app/ui state for backend-specific capabilities, OpenCode agent selection, mobile slash handling, status/MCP views, and pending question prompts
- add debug cleartext config plus a helper script for running the Android remote-only debug build against a local OpenCode server
- add unit coverage for OpenCode path handling, state model merges, pending interactions, saved server persistence, and slash parsing

## Verification
- `apps/android/gradlew -p apps/android :app:testOnDeviceDebugUnitTest :app:testRemoteOnlyDebugUnitTest`
- `apps/android/gradlew -p apps/android :app:assembleOnDeviceDebug :app:assembleRemoteOnlyDebug`