### PR TITLE
ios: inject state into presented sheets

### DIFF
--- a/apps/ios/Sources/Litter/LitterApp.swift
+++ b/apps/ios/Sources/Litter/LitterApp.swift
@@ -171,9 +171,12 @@ struct ContentView: View {
                     appState.showServerPicker = false
                 })
             }
+            .environment(serverManager)
+            .environment(appState)
         }
         .sheet(isPresented: $bindableAppState.showSettings) {
             SettingsView()
+                .environment(serverManager)
         }
     }
 
@@ -307,6 +310,7 @@ private struct HomeNavigationView: View {
                     }
                 )
             }
+            .environment(serverManager)
         }
         .alert("Home Action Failed", isPresented: Binding(
             get: { actionErrorMessage != nil },

--- a/apps/ios/Sources/Litter/Views/SessionsScreen.swift
+++ b/apps/ios/Sources/Litter/Views/SessionsScreen.swift
@@ -86,6 +86,7 @@ struct SessionsScreen: View {
                     }
                 )
             }
+            .environment(serverManager)
         }
     }
 


### PR DESCRIPTION
## Purpose
Fix the iOS crash when opening Connect Server or New Session after the environment refactor.

## Key Changes
- inject `ServerManager` and `AppState` explicitly into the presented Discovery sheet
- inject `ServerManager` explicitly into the presented Directory Picker sheets
- keep the fix isolated to SwiftUI presentation boundaries on top of current `main`

## Verification
- `xcodebuild build -project apps/ios/Litter.xcodeproj -scheme Litter -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` succeeded
- manually-reported crash was `SwiftUICore/Environment+Objects.swift: No Observable object of type AppState found`
