### PR TITLE
Support wss:// reverse-proxied deployments (iOS & Android)

### DIFF
--- a/apps/android/app/src/main/java/com/litter/android/state/BridgeRpcTransport.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/BridgeRpcTransport.kt
@@ -9,6 +9,7 @@ import java.io.OutputStream
 import java.net.InetSocketAddress
 import java.net.Socket
 import java.net.URI
+import javax.net.ssl.SSLSocketFactory
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 import java.security.SecureRandom
@@ -72,13 +73,22 @@ internal class BridgeRpcTransport(
 
             val uri = URI(url)
             val host = uri.host ?: throw IllegalStateException("Invalid websocket host for URL: $url")
-            val port = if (uri.port > 0) uri.port else 80
+            val useTls = uri.scheme?.lowercase() == "wss"
+            val defaultPort = if (useTls) 443 else 80
+            val port = if (uri.port > 0) uri.port else defaultPort
             val path = buildPath(uri)
 
-            val sock = Socket()
+            val sock: Socket = if (useTls) {
+                SSLSocketFactory.getDefault().createSocket(host, port).also {
+                    it.soTimeout = (timeoutSeconds * 1000L).toInt()
+                }
+            } else {
+                Socket().also {
+                    it.connect(InetSocketAddress(host, port), (timeoutSeconds * 1000L).toInt())
+                    it.soTimeout = (timeoutSeconds * 1000L).toInt()
+                }
+            }
             try {
-                sock.connect(InetSocketAddress(host, port), (timeoutSeconds * 1000L).toInt())
-                sock.soTimeout = (timeoutSeconds * 1000L).toInt()
                 val inStream = sock.getInputStream()
                 val outStream = sock.getOutputStream()
 
@@ -298,7 +308,7 @@ internal class BridgeRpcTransport(
         val keyBytes = ByteArray(16)
         random.nextBytes(keyBytes)
         val key = Base64.getEncoder().encodeToString(keyBytes)
-        val hostHeader = if (port == 80) host else "$host:$port"
+        val hostHeader = if (port == 80 || port == 443) host else "$host:$port"
         val request = buildString {
             append("GET $path HTTP/1.1\r\n")
             append("Host: $hostHeader\r\n")

--- a/apps/android/app/src/main/java/com/litter/android/state/ServerManager.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/ServerManager.kt
@@ -1069,10 +1069,12 @@ class ServerManager(
             left.hasCodexServer == right.hasCodexServer &&
             left.username == right.username &&
             left.password == right.password &&
-            left.directory == right.directory
+            left.directory == right.directory &&
+            left.websocketUrl == right.websocketUrl
     }
 
     private fun websocketUrl(server: ServerConfig): String {
+        server.websocketUrl?.let { return it }
         val host = normalizeServerHost(server.host)
         val normalizedHost =
             if (host.contains(':') && !host.startsWith("[") && !host.endsWith("]")) {
@@ -7092,6 +7094,7 @@ class ServerManager(
                     username = mergedCredentials.username,
                     password = mergedCredentials.password,
                     directory = nullableString(item, "directory"),
+                    websocketUrl = nullableString(item, "websocketUrl"),
                 )
         }
         if (migratedLegacyCredentials) {
@@ -7211,6 +7214,7 @@ internal fun buildSavedServersPersistencePayload(
                 .put("backendKind", saved.backendKind)
                 .put("hasCodexServer", saved.hasCodexServer)
                 .put("directory", saved.directory ?: JSONObject.NULL)
+                .put("websocketUrl", saved.websocketUrl ?: JSONObject.NULL)
         if (includeCredentials) {
             encoded
                 .put("username", saved.username ?: JSONObject.NULL)

--- a/apps/android/app/src/main/java/com/litter/android/state/StateModels.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/StateModels.kt
@@ -117,6 +117,7 @@ data class ServerConfig(
     val username: String? = null,
     val password: String? = null,
     val directory: String? = null,
+    val websocketUrl: String? = null,
 ) {
     companion object {
         fun local(port: Int): ServerConfig =
@@ -154,6 +155,7 @@ data class SavedServer(
     val username: String? = null,
     val password: String? = null,
     val directory: String? = null,
+    val websocketUrl: String? = null,
 ) {
     fun toServerConfig(): ServerConfig =
         ServerConfig(
@@ -167,6 +169,7 @@ data class SavedServer(
             username = username,
             password = password,
             directory = directory,
+            websocketUrl = websocketUrl,
         )
 
     companion object {
@@ -182,6 +185,7 @@ data class SavedServer(
                 username = server.username,
                 password = server.password,
                 directory = server.directory,
+                websocketUrl = server.websocketUrl,
             )
     }
 }

--- a/apps/android/app/src/main/java/com/litter/android/ui/LitterAppShell.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/LitterAppShell.kt
@@ -444,10 +444,12 @@ fun LitterAppShell(
                 onManualBackendKindChanged = appState::updateManualBackendKind,
                 onManualHostChanged = appState::updateManualHost,
                 onManualPortChanged = appState::updateManualPort,
+                onManualUrlChanged = appState::updateManualUrl,
                 onManualUsernameChanged = appState::updateManualUsername,
                 onManualPasswordChanged = appState::updateManualPassword,
                 onManualDirectoryChanged = appState::updateManualDirectory,
                 onConnectManual = appState::connectManualServer,
+                onConnectManualUrl = appState::connectManualUrl,
             )
         }
 
@@ -6696,10 +6698,12 @@ private fun DiscoverySheet(
     onManualBackendKindChanged: (BackendKind) -> Unit,
     onManualHostChanged: (String) -> Unit,
     onManualPortChanged: (String) -> Unit,
+    onManualUrlChanged: (String) -> Unit,
     onManualUsernameChanged: (String) -> Unit,
     onManualPasswordChanged: (String) -> Unit,
     onManualDirectoryChanged: (String) -> Unit,
     onConnectManual: () -> Unit,
+    onConnectManualUrl: () -> Unit,
 ) {
     val configuration = LocalConfiguration.current
     val useLargeScreenDialog =
@@ -6714,7 +6718,7 @@ private fun DiscoverySheet(
         val manualConnectFocusRequester = remember { FocusRequester() }
         var editingField by remember { mutableStateOf<ManualField?>(null) }
         var editingValue by remember { mutableStateOf("") }
-        val canConnect = state.manualHost.isNotBlank() && state.manualPort.isNotBlank()
+        val canConnect = if (state.manualBackendKind == BackendKind.CODEX) state.manualUrl.isNotBlank() else state.manualHost.isNotBlank() && state.manualPort.isNotBlank()
         val firstServerId = state.servers.firstOrNull()?.id
 
         BackHandler(enabled = editingField != null) {
@@ -6905,7 +6909,21 @@ private fun DiscoverySheet(
                                             }
                                         }
 
-                                        if (editingField == ManualField.HOST) {
+                                        if (state.manualBackendKind == BackendKind.CODEX) {
+                                            OutlinedTextField(
+                                                value = state.manualUrl,
+                                                onValueChange = onManualUrlChanged,
+                                                label = { Text("ws://host:port or wss://...") },
+                                                modifier = Modifier.fillMaxWidth(),
+                                                singleLine = true,
+                                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                                            )
+                                            Text(
+                                                "Run: codex app-server --listen ws://0.0.0.0:8390\nFor reverse proxies: wss://example.com/ws?token=SECRET\nDo not expose directly to the internet unless you know what you are doing.",
+                                                style = MaterialTheme.typography.labelSmall,
+                                                color = LitterTheme.textMuted,
+                                            )
+                                        } else if (editingField == ManualField.HOST) {
                                             Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
                                                 OutlinedTextField(
                                                     value = editingValue,
@@ -7012,102 +7030,104 @@ private fun DiscoverySheet(
                                             }
                                         }
 
-                                        if (editingField == ManualField.PORT) {
-                                            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                                                OutlinedTextField(
-                                                    value = editingValue,
-                                                    onValueChange = {
-                                                        val digitsOnly = it.filter { ch -> ch.isDigit() }
-                                                        editingValue = digitsOnly
-                                                        onManualPortChanged(digitsOnly)
-                                                    },
+                                        if (state.manualBackendKind != BackendKind.CODEX) {
+                                            if (editingField == ManualField.PORT) {
+                                                Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                                                    OutlinedTextField(
+                                                        value = editingValue,
+                                                        onValueChange = {
+                                                            val digitsOnly = it.filter { ch -> ch.isDigit() }
+                                                            editingValue = digitsOnly
+                                                            onManualPortChanged(digitsOnly)
+                                                        },
+                                                        modifier =
+                                                            Modifier
+                                                                .fillMaxWidth()
+                                                                .focusRequester(manualInlineEditorFocusRequester)
+                                                                .focusProperties {
+                                                                    up = manualHostFocusRequester
+                                                                    down = manualInlineDoneFocusRequester
+                                                                }
+                                                                .onPreviewKeyEvent { event ->
+                                                                    if (event.type != KeyEventType.KeyDown) {
+                                                                        return@onPreviewKeyEvent false
+                                                                    }
+                                                                    when (event.key) {
+                                                                        Key.Back, Key.Escape -> {
+                                                                            editingField = null
+                                                                            true
+                                                                        }
+
+                                                                        Key.DirectionDown -> {
+                                                                            manualInlineDoneFocusRequester.requestFocus()
+                                                                            true
+                                                                        }
+
+                                                                        Key.DirectionUp -> {
+                                                                            manualHostFocusRequester.requestFocus()
+                                                                            true
+                                                                        }
+
+                                                                        else -> false
+                                                                    }
+                                                                },
+                                                        singleLine = true,
+                                                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                                        label = { Text("Port") },
+                                                    )
+                                                    Row(
+                                                        modifier = Modifier.fillMaxWidth(),
+                                                        horizontalArrangement = Arrangement.SpaceBetween,
+                                                        verticalAlignment = Alignment.CenterVertically,
+                                                    ) {
+                                                        Text(
+                                                            "Editing port",
+                                                            color = LitterTheme.textMuted,
+                                                            style = MaterialTheme.typography.labelLarge,
+                                                        )
+                                                        TextButton(
+                                                            onClick = { editingField = null },
+                                                            modifier =
+                                                                Modifier
+                                                                    .focusRequester(manualInlineDoneFocusRequester)
+                                                                    .focusProperties {
+                                                                        up = manualInlineEditorFocusRequester
+                                                                        down = if (canConnect) manualConnectFocusRequester else manualHostFocusRequester
+                                                                    },
+                                                        ) {
+                                                            Text("Done")
+                                                        }
+                                                    }
+                                                }
+                                            } else {
+                                                Surface(
                                                     modifier =
                                                         Modifier
                                                             .fillMaxWidth()
-                                                            .focusRequester(manualInlineEditorFocusRequester)
+                                                            .focusRequester(manualPortFocusRequester)
                                                             .focusProperties {
                                                                 up = manualHostFocusRequester
-                                                                down = manualInlineDoneFocusRequester
-                                                            }
-                                                            .onPreviewKeyEvent { event ->
-                                                                if (event.type != KeyEventType.KeyDown) {
-                                                                    return@onPreviewKeyEvent false
-                                                                }
-                                                                when (event.key) {
-                                                                    Key.Back, Key.Escape -> {
-                                                                        editingField = null
-                                                                        true
-                                                                    }
-
-                                                                    Key.DirectionDown -> {
-                                                                        manualInlineDoneFocusRequester.requestFocus()
-                                                                        true
-                                                                    }
-
-                                                                    Key.DirectionUp -> {
-                                                                        manualHostFocusRequester.requestFocus()
-                                                                        true
-                                                                    }
-
-                                                                    else -> false
-                                                                }
+                                                                down = if (canConnect) manualConnectFocusRequester else manualHostFocusRequester
+                                                            }.clickable {
+                                                                editingField = ManualField.PORT
+                                                                editingValue = state.manualPort
                                                             },
-                                                    singleLine = true,
-                                                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                                                    label = { Text("Port") },
-                                                )
-                                                Row(
-                                                    modifier = Modifier.fillMaxWidth(),
-                                                    horizontalArrangement = Arrangement.SpaceBetween,
-                                                    verticalAlignment = Alignment.CenterVertically,
+                                                    color = LitterTheme.surfaceLight.copy(alpha = 0.65f),
+                                                    shape = RoundedCornerShape(8.dp),
+                                                    border = androidx.compose.foundation.BorderStroke(1.dp, LitterTheme.border),
                                                 ) {
-                                                    Text(
-                                                        "Editing port",
-                                                        color = LitterTheme.textMuted,
-                                                        style = MaterialTheme.typography.labelLarge,
-                                                    )
-                                                    TextButton(
-                                                        onClick = { editingField = null },
-                                                        modifier =
-                                                            Modifier
-                                                                .focusRequester(manualInlineDoneFocusRequester)
-                                                                .focusProperties {
-                                                                    up = manualInlineEditorFocusRequester
-                                                                    down = if (canConnect) manualConnectFocusRequester else manualHostFocusRequester
-                                                                },
+                                                    Column(
+                                                        modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 9.dp),
+                                                        verticalArrangement = Arrangement.spacedBy(2.dp),
                                                     ) {
-                                                        Text("Done")
+                                                        Text("Port", color = LitterTheme.textSecondary, style = MaterialTheme.typography.labelLarge)
+                                                        Text(
+                                                            if (state.manualPort.isBlank()) "Set port" else state.manualPort,
+                                                            color = if (state.manualPort.isBlank()) LitterTheme.textMuted else LitterTheme.textPrimary,
+                                                            maxLines = 1,
+                                                            overflow = TextOverflow.Ellipsis,
+                                                        )
                                                     }
-                                                }
-                                            }
-                                        } else {
-                                            Surface(
-                                                modifier =
-                                                    Modifier
-                                                        .fillMaxWidth()
-                                                        .focusRequester(manualPortFocusRequester)
-                                                        .focusProperties {
-                                                            up = manualHostFocusRequester
-                                                            down = if (canConnect) manualConnectFocusRequester else manualHostFocusRequester
-                                                        }.clickable {
-                                                            editingField = ManualField.PORT
-                                                            editingValue = state.manualPort
-                                                        },
-                                                color = LitterTheme.surfaceLight.copy(alpha = 0.65f),
-                                                shape = RoundedCornerShape(8.dp),
-                                                border = androidx.compose.foundation.BorderStroke(1.dp, LitterTheme.border),
-                                            ) {
-                                                Column(
-                                                    modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 9.dp),
-                                                    verticalArrangement = Arrangement.spacedBy(2.dp),
-                                                ) {
-                                                    Text("Port", color = LitterTheme.textSecondary, style = MaterialTheme.typography.labelLarge)
-                                                    Text(
-                                                        if (state.manualPort.isBlank()) "Set port" else state.manualPort,
-                                                        color = if (state.manualPort.isBlank()) LitterTheme.textMuted else LitterTheme.textPrimary,
-                                                        maxLines = 1,
-                                                        overflow = TextOverflow.Ellipsis,
-                                                    )
                                                 }
                                             }
                                         }
@@ -7139,7 +7159,7 @@ private fun DiscoverySheet(
                                 }
                                 Spacer(modifier = Modifier.weight(1f))
                                 Button(
-                                    onClick = onConnectManual,
+                                    onClick = if (state.manualBackendKind == BackendKind.CODEX) onConnectManualUrl else onConnectManual,
                                     modifier =
                                         Modifier
                                             .fillMaxWidth()
@@ -7149,7 +7169,7 @@ private fun DiscoverySheet(
                                             },
                                     enabled = canConnect,
                                 ) {
-                                    Text("Connect Manual Server")
+                                    Text("Connect")
                                 }
                             }
                         }
@@ -7282,29 +7302,49 @@ private fun DiscoverySheet(
                         Text("OpenCode")
                     }
                 }
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
+                if (state.manualBackendKind == BackendKind.CODEX) {
                     OutlinedTextField(
-                        value = state.manualHost,
-                        onValueChange = onManualHostChanged,
-                        label = { Text("Host") },
-                        modifier = Modifier.weight(1f),
+                        value = state.manualUrl,
+                        onValueChange = onManualUrlChanged,
+                        label = { Text("ws://host:port or wss://...") },
+                        modifier = Modifier.fillMaxWidth(),
                         singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
                     )
-                    OutlinedTextField(
-                        value = state.manualPort,
-                        onValueChange = onManualPortChanged,
-                        label = { Text("Port") },
-                        modifier = Modifier.width(110.dp),
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                        singleLine = true,
+                    Text(
+                        "Run: codex app-server --listen ws://0.0.0.0:8390\nFor reverse proxies: wss://example.com/ws?token=SECRET\nDo not expose directly to the internet unless you know what you are doing.",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = LitterTheme.textMuted,
                     )
-                }
-
-                if (state.manualBackendKind == BackendKind.OPENCODE) {
+                    Button(
+                        onClick = onConnectManualUrl,
+                        modifier = Modifier.fillMaxWidth(),
+                        enabled = state.manualUrl.isNotBlank(),
+                    ) {
+                        Text("Connect")
+                    }
+                } else {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        OutlinedTextField(
+                            value = state.manualHost,
+                            onValueChange = onManualHostChanged,
+                            label = { Text("Host") },
+                            modifier = Modifier.weight(1f),
+                            singleLine = true,
+                        )
+                        OutlinedTextField(
+                            value = state.manualPort,
+                            onValueChange = onManualPortChanged,
+                            label = { Text("Port") },
+                            modifier = Modifier.width(110.dp),
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                            singleLine = true,
+                        )
+                    }
                     OutlinedTextField(
                         value = state.manualUsername,
                         onValueChange = onManualUsernameChanged,
@@ -7326,16 +7366,14 @@ private fun DiscoverySheet(
                         modifier = Modifier.fillMaxWidth(),
                         singleLine = true,
                     )
+                    Button(
+                        onClick = onConnectManual,
+                        modifier = Modifier.fillMaxWidth(),
+                        enabled = state.manualHost.isNotBlank() && state.manualPort.isNotBlank(),
+                    ) {
+                        Text("Connect")
+                    }
                 }
-
-                Button(
-                    onClick = onConnectManual,
-                    modifier = Modifier.fillMaxWidth(),
-                    enabled = state.manualHost.isNotBlank() && state.manualPort.isNotBlank(),
-                ) {
-                    Text("Connect Manual Server")
-                }
-            }
         }
     }
 }

--- a/apps/android/app/src/main/java/com/litter/android/ui/LitterAppState.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/LitterAppState.kt
@@ -95,6 +95,7 @@ data class DiscoveryUiState(
     val manualBackendKind: BackendKind = BackendKind.CODEX,
     val manualHost: String = "",
     val manualPort: String = "8390",
+    val manualUrl: String = "",
     val manualUsername: String = "",
     val manualPassword: String = "",
     val manualDirectory: String = "",
@@ -364,6 +365,8 @@ interface LitterAppState : Closeable {
 
     fun updateManualPort(value: String)
 
+    fun updateManualUrl(value: String)
+
     fun updateManualBackendKind(value: BackendKind)
 
     fun updateManualUsername(value: String)
@@ -373,6 +376,8 @@ interface LitterAppState : Closeable {
     fun updateManualDirectory(value: String)
 
     fun connectManualServer()
+
+    fun connectManualUrl()
 
     fun dismissSshLogin()
 
@@ -1219,6 +1224,7 @@ class DefaultLitterAppState(
                         manualBackendKind = server?.backendKind ?: it.discovery.manualBackendKind,
                         manualHost = server?.host ?: it.discovery.manualHost,
                         manualPort = server?.port?.toString() ?: it.discovery.manualPort,
+                        manualUrl = server?.websocketUrl ?: if (server?.backendKind == BackendKind.CODEX) "${server.host}:${server.port}" else it.discovery.manualUrl,
                         manualUsername = server?.username ?: it.discovery.manualUsername,
                         manualPassword = server?.password ?: it.discovery.manualPassword,
                         manualDirectory = server?.directory ?: it.discovery.manualDirectory,
@@ -1363,6 +1369,14 @@ class DefaultLitterAppState(
         }
     }
 
+    override fun updateManualUrl(value: String) {
+        _uiState.update {
+            it.copy(
+                discovery = it.discovery.copy(manualUrl = value),
+            )
+        }
+    }
+
     override fun updateManualBackendKind(value: BackendKind) {
         _uiState.update {
             it.copy(
@@ -1448,6 +1462,79 @@ class DefaultLitterAppState(
                                 manualUsername = "",
                                 manualPassword = "",
                                 manualDirectory = "",
+                            ),
+                    )
+                }
+                postConnectPrime()
+            }
+        }
+    }
+
+    override fun connectManualUrl() {
+        val snapshot = _uiState.value.discovery
+        val raw = snapshot.manualUrl.trim()
+        if (raw.isEmpty()) {
+            setUiError("Enter a WebSocket URL or host:port")
+            return
+        }
+
+        val server: ServerConfig
+
+        // Try full ws:// or wss:// URL first
+        val uri = runCatching { java.net.URI(raw) }.getOrNull()
+        val scheme = uri?.scheme?.lowercase()
+        if (uri != null && (scheme == "ws" || scheme == "wss") && !uri.host.isNullOrEmpty()) {
+            val host = uri.host
+            val port = if (uri.port > 0) uri.port else if (scheme == "wss") 443 else 80
+            server = ServerConfig(
+                id = "manual-url-$raw",
+                name = host,
+                host = host,
+                port = port,
+                source = ServerSource.MANUAL,
+                backendKind = BackendKind.CODEX,
+                hasCodexServer = true,
+                websocketUrl = raw,
+            )
+        } else {
+            // Bare host:port (e.g. "192.168.1.5:8390")
+            val parts = raw.split(":", limit = 2)
+            val host: String
+            val port: Int
+            if (parts.size == 2 && parts[1].toIntOrNull() != null) {
+                host = parts[0]
+                port = parts[1].toInt()
+            } else if (parts.size == 1 && parts[0].isNotEmpty()) {
+                host = parts[0]
+                port = 8390
+            } else {
+                setUiError("Enter a ws:// URL or host:port")
+                return
+            }
+            server = ServerConfig(
+                id = manualServerId(BackendKind.CODEX, host, port),
+                name = host,
+                host = host,
+                port = port,
+                source = ServerSource.MANUAL,
+                backendKind = BackendKind.CODEX,
+                hasCodexServer = true,
+            )
+        }
+
+        serverManager.connectServer(server) { result ->
+            result.onFailure { error ->
+                setUiError(error.message ?: "Connection failed")
+            }
+            result.onSuccess {
+                _uiState.update {
+                    it.copy(
+                        discovery =
+                            it.discovery.copy(
+                                isVisible = false,
+                                errorMessage = null,
+                                reconfiguringServerId = null,
+                                manualUrl = "",
                             ),
                     )
                 }
@@ -1740,6 +1827,7 @@ class DefaultLitterAppState(
                         manualBackendKind = if (saved != null) BackendKind.from(saved.backendKind) else it.discovery.manualBackendKind,
                         manualHost = saved?.host ?: it.discovery.manualHost,
                         manualPort = saved?.port?.toString() ?: it.discovery.manualPort,
+                        manualUrl = saved?.websocketUrl.orEmpty(),
                         manualUsername = saved?.username.orEmpty(),
                         manualPassword = saved?.password.orEmpty(),
                         manualDirectory = saved?.directory.orEmpty(),

--- a/apps/ios/Sources/Litter/Bridge/JSONRPCClient.swift
+++ b/apps/ios/Sources/Litter/Bridge/JSONRPCClient.swift
@@ -17,16 +17,24 @@ actor JSONRPCClient {
     private var onHealthChange: ((Bool) -> Void)?
 
     func connect(url: URL) async throws {
-        guard url.scheme == "ws", let host = url.host else {
+        let useTLS = url.scheme == "wss"
+        guard url.scheme == "ws" || useTLS, let host = url.host else {
             throw URLError(.unsupportedURL)
         }
-        guard let port = NWEndpoint.Port(rawValue: UInt16(url.port ?? 80)) else {
+        let defaultPort: UInt16 = useTLS ? 443 : 80
+        guard let port = NWEndpoint.Port(rawValue: UInt16(url.port ?? Int(defaultPort))) else {
             throw URLError(.badURL)
         }
 
         disconnect()
 
-        let conn = NWConnection(host: NWEndpoint.Host(host), port: port, using: .tcp)
+        let parameters: NWParameters
+        if useTLS {
+            parameters = NWParameters(tls: .init())
+        } else {
+            parameters = .tcp
+        }
+        let conn = NWConnection(host: NWEndpoint.Host(host), port: port, using: parameters)
         connection = conn
 
         do {

--- a/apps/ios/Sources/Litter/Info.plist
+++ b/apps/ios/Sources/Litter/Info.plist
@@ -27,6 +27,10 @@
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>tailscale</string>
+	</array>
 	<key>NSSupportsLiveActivities</key>
 	<true/>
 	<key>NSSupportsLiveActivitiesFrequentUpdates</key>

--- a/apps/ios/Sources/Litter/Models/ConnectionTarget.swift
+++ b/apps/ios/Sources/Litter/Models/ConnectionTarget.swift
@@ -4,6 +4,7 @@ import Security
 enum ConnectionTarget: Equatable {
     case local
     case remote(host: String, port: UInt16)
+    case remoteURL(URL)
     case sshThenRemote(host: String, credentials: SSHCredentials)
 }
 

--- a/apps/ios/Sources/Litter/Models/DiscoveredServer.swift
+++ b/apps/ios/Sources/Litter/Models/DiscoveredServer.swift
@@ -38,6 +38,7 @@ struct DiscoveredServer: Identifiable, Hashable {
     let hasCodexServer: Bool
     let wakeMAC: String?
     let sshPortForwardingEnabled: Bool
+    let websocketURL: String?
 
     init(
         id: String,
@@ -48,7 +49,8 @@ struct DiscoveredServer: Identifiable, Hashable {
         source: ServerSource,
         hasCodexServer: Bool,
         wakeMAC: String? = nil,
-        sshPortForwardingEnabled: Bool = false
+        sshPortForwardingEnabled: Bool = false,
+        websocketURL: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -59,10 +61,12 @@ struct DiscoveredServer: Identifiable, Hashable {
         self.hasCodexServer = hasCodexServer
         self.wakeMAC = Self.normalizeWakeMAC(wakeMAC)
         self.sshPortForwardingEnabled = sshPortForwardingEnabled
+        self.websocketURL = websocketURL
     }
 
     var connectionTarget: ConnectionTarget? {
         if source == .local { return .local }
+        if let websocketURL, let url = URL(string: websocketURL) { return .remoteURL(url) }
         if hasCodexServer, let port { return .remote(host: hostname, port: port) }
         return nil
     }

--- a/apps/ios/Sources/Litter/Models/NetworkDiscovery.swift
+++ b/apps/ios/Sources/Litter/Models/NetworkDiscovery.swift
@@ -12,10 +12,86 @@ private struct DiscoveryCandidate: Hashable {
     let codexPortHint: UInt16?
 }
 
+struct TailscalePeerIdentity: Equatable {
+    let ip: String
+    let name: String?
+}
+
+struct TailscaleAvailability: Equatable, Sendable {
+    let appInstalled: Bool
+    let likelyActiveTunnel: Bool
+
+    var shouldSurfaceDiscoveryNotice: Bool {
+        appInstalled || likelyActiveTunnel
+    }
+
+    var logDescription: String {
+        "installed=\(appInstalled) likelyActive=\(likelyActiveTunnel)"
+    }
+}
+
 private struct CandidateReachability: Sendable {
     let candidate: DiscoveryCandidate
     let codexPort: UInt16?
     let sshPort: UInt16?
+}
+
+private struct TailscaleInterfaceSnapshot: Sendable {
+    struct InterfaceRecord: Sendable {
+        let name: String
+        let family: String
+        let address: String
+        let flags: [String]
+        let isTailscaleAddress: Bool
+    }
+
+    let localWiFiAddress: String?
+    let localWiFiInterface: String?
+    let activeTunnelInterfaces: [String]
+    let tailscaleInterfaces: [String]
+    let records: [InterfaceRecord]
+
+    var hasLikelyActiveTailscaleTunnel: Bool {
+        !activeTunnelInterfaces.isEmpty && !tailscaleInterfaces.isEmpty
+    }
+
+    var logDescription: String {
+        let wifiSummary: String
+        if let localWiFiInterface, let localWiFiAddress {
+            wifiSummary = "\(localWiFiInterface)=\(localWiFiAddress)"
+        } else {
+            wifiSummary = "none"
+        }
+
+        let tunnelSummary = activeTunnelInterfaces.isEmpty
+            ? "none"
+            : activeTunnelInterfaces.joined(separator: ",")
+        let tailscaleSummary = tailscaleInterfaces.isEmpty
+            ? "none"
+            : tailscaleInterfaces.joined(separator: ",")
+        let recordsSummary = records.isEmpty
+            ? "none"
+            : records.map { record in
+                let flags = record.flags.joined(separator: "+")
+                return "\(record.name):\(record.family):\(record.address):\(flags)\(record.isTailscaleAddress ? ":tailscale" : "")"
+            }.joined(separator: " | ")
+
+        return "wifi=\(wifiSummary) likelyActive=\(hasLikelyActiveTailscaleTunnel) utun=\(tunnelSummary) tailscale=\(tailscaleSummary) records=\(recordsSummary)"
+    }
+}
+
+private actor TailscaleDiscoveryDiagnostics {
+    private(set) var notice: String?
+
+    func markSuccess() {
+        notice = nil
+    }
+
+    func record(_ notice: String) {
+        if self.notice == nil {
+            self.notice = notice
+        }
+    }
 }
 
 @MainActor
@@ -23,6 +99,7 @@ private struct CandidateReachability: Sendable {
 final class NetworkDiscovery {
     var servers: [DiscoveredServer] = []
     var isScanning = false
+    var tailscaleDiscoveryNotice: String?
 
     @ObservationIgnored private var scanTask: Task<Void, Never>?
     @ObservationIgnored private var activeScanID = UUID()
@@ -47,6 +124,7 @@ final class NetworkDiscovery {
         stopScanning()
         let scanID = UUID()
         activeScanID = scanID
+        tailscaleDiscoveryNotice = nil
 
         let cachedNetworkServers = loadCachedNetworkServers()
         let retainedNetworkServers = servers.filter { $0.source != .local }
@@ -93,13 +171,15 @@ final class NetworkDiscovery {
 
         let localIPv4 = Self.localIPv4Address()?.0
         var cumulativeCandidates: [DiscoveryCandidate] = []
+        let tailscaleDiagnostics = TailscaleDiscoveryDiagnostics()
+        let tailscaleAppInstalled = await MainActor.run { Self.isTailscaleAppInstalled() }
 
         // Run two passes to reduce discovery misses from transient Bonjour/Tailscale timing.
         // Within each pass, stream source results and probe completions progressively so
         // DiscoveryView can render rows as soon as they are found.
         for pass in 0..<2 {
             let bonjourTimeout: TimeInterval = pass == 0 ? 5.0 : 3.0
-            let tailscaleTimeout: TimeInterval = pass == 0 ? 2.5 : 1.5
+            let tailscaleTimeout: TimeInterval = pass == 0 ? 1.0 : 0.75
             let probeTimeout: TimeInterval = pass == 0 ? 1.0 : 1.4
             let probeAttempts = pass == 0 ? 2 : 3
 
@@ -129,7 +209,13 @@ final class NetworkDiscovery {
 
             await withTaskGroup(of: [DiscoveryCandidate].self) { group in
                 group.addTask { await Self.discoverBonjourCandidates(timeout: bonjourTimeout) }
-                group.addTask { await Self.discoverTailscaleSSHCandidates(timeout: tailscaleTimeout) }
+                group.addTask {
+                    await Self.discoverTailscaleSSHCandidates(
+                        timeout: tailscaleTimeout,
+                        appInstalled: tailscaleAppInstalled,
+                        diagnostics: tailscaleDiagnostics
+                    )
+                }
                 group.addTask {
                     await Self.discoverLocalSubnetCodexCandidates(
                         localIPv4: localIPv4,
@@ -152,6 +238,12 @@ final class NetworkDiscovery {
 
                     await probePendingCandidates()
                 }
+            }
+
+            let tailscaleNotice = await tailscaleDiagnostics.notice
+            await MainActor.run { [weak self] in
+                guard let self, self.activeScanID == scanID else { return }
+                self.tailscaleDiscoveryNotice = tailscaleNotice
             }
 
             // Re-probe any candidates carried over from previous pass that were not
@@ -507,45 +599,121 @@ final class NetworkDiscovery {
         return await browser.discover(timeout: timeout)
     }
 
-    nonisolated private static func discoverTailscaleSSHCandidates(timeout: TimeInterval) async -> [DiscoveryCandidate] {
+    nonisolated static func parseTailscalePeerCandidates(
+        data: Data,
+        response: URLResponse
+    ) throws -> [TailscalePeerIdentity] {
+        enum ParseError: Error {
+            case unsupportedSurface
+            case invalidPayload
+        }
+
+        guard let http = response as? HTTPURLResponse,
+              (200...299).contains(http.statusCode) else {
+            throw ParseError.invalidPayload
+        }
+
+        let contentType = http.value(forHTTPHeaderField: "Content-Type")?.lowercased()
+        let preview = String(decoding: data.prefix(128), as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        if contentType?.contains("text/html") == true ||
+            preview.hasPrefix("<!doctype html") ||
+            preview.hasPrefix("<html") {
+            throw ParseError.unsupportedSurface
+        }
+
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let peers = json["Peer"] as? [String: Any] else {
+            throw ParseError.invalidPayload
+        }
+
+        var out: [TailscalePeerIdentity] = []
+        out.reserveCapacity(peers.count)
+        for peer in peers.values {
+            guard let peerDict = peer as? [String: Any] else { continue }
+            if let online = peerDict["Online"] as? Bool, !online {
+                continue
+            }
+            let hostName = cleanedHostName(peerDict["HostName"] as? String)
+                ?? cleanedHostName(peerDict["DNSName"] as? String)
+            let ips = (peerDict["TailscaleIPs"] as? [String]) ?? []
+            guard let ipv4 = ips.first(where: { isIPv4Address($0) }) else { continue }
+            out.append(TailscalePeerIdentity(ip: ipv4, name: hostName))
+        }
+
+        return out
+    }
+
+    nonisolated private static func discoverTailscaleSSHCandidates(
+        timeout: TimeInterval,
+        appInstalled: Bool,
+        diagnostics: TailscaleDiscoveryDiagnostics
+    ) async -> [DiscoveryCandidate] {
         guard let url = URL(string: "http://100.100.100.100/localapi/v0/status") else {
             return []
         }
 
+        let interfaceSnapshot = tailscaleInterfaceSnapshot()
+        let availability = TailscaleAvailability(
+            appInstalled: appInstalled,
+            likelyActiveTunnel: interfaceSnapshot.hasLikelyActiveTailscaleTunnel
+        )
+        NSLog(
+            "[tailscale] availability=%@ interface snapshot before request: %@",
+            availability.logDescription,
+            interfaceSnapshot.logDescription
+        )
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.timeoutIntervalForRequest = timeout
+        configuration.timeoutIntervalForResource = timeout + 0.25
+        configuration.waitsForConnectivity = false
+        configuration.urlCache = nil
+        let session = URLSession(configuration: configuration)
+
         var request = URLRequest(url: url)
         request.timeoutInterval = timeout
         request.cachePolicy = .reloadIgnoringLocalCacheData
-        for attempt in 0..<2 {
-            do {
-                let (data, response) = try await URLSession.shared.data(for: request)
-                guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
-                    continue
-                }
-                guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-                      let peers = json["Peer"] as? [String: Any] else {
-                    continue
-                }
 
-                var candidates: [DiscoveryCandidate] = []
-                for peer in peers.values {
-                    guard let peerDict = peer as? [String: Any] else { continue }
-                    if let online = peerDict["Online"] as? Bool, !online {
-                        continue
-                    }
-                    let hostName = cleanedHostName(peerDict["HostName"] as? String)
-                        ?? cleanedHostName(peerDict["DNSName"] as? String)
-                    let ips = (peerDict["TailscaleIPs"] as? [String]) ?? []
-                    guard let ipv4 = ips.first(where: { isIPv4Address($0) }) else { continue }
-                    candidates.append(DiscoveryCandidate(ip: ipv4, name: hostName, source: .tailscale, codexPortHint: nil))
-                }
-                return candidates
-            } catch {
-                if attempt == 0 {
-                    try? await Task.sleep(for: .milliseconds(180))
-                }
+        do {
+            let (data, response) = try await session.data(for: request)
+            if let http = response as? HTTPURLResponse {
+                let contentType = http.value(forHTTPHeaderField: "Content-Type") ?? "unknown"
+                NSLog("[tailscale] response status=%d contentType=%@", http.statusCode, contentType)
             }
+            let peers = try parseTailscalePeerCandidates(data: data, response: response)
+            await diagnostics.markSuccess()
+            NSLog("[tailscale] got %d peers", peers.count)
+            let candidates = peers.map {
+                DiscoveryCandidate(ip: $0.ip, name: $0.name, source: .tailscale, codexPortHint: nil)
+            }
+            NSLog("[tailscale] returning %d candidates", candidates.count)
+            return candidates
+        } catch {
+            let notice: String
+            let responsePreview = (error as NSError).localizedDescription
+            if let urlError = error as? URLError, urlError.code == .timedOut {
+                notice = "Tailscale peer discovery timed out. Add a server manually with its MagicDNS name or Tailscale IP."
+            } else {
+                notice = "Tailscale peer discovery is unavailable right now. Add a server manually with its MagicDNS name or Tailscale IP."
+            }
+            if availability.shouldSurfaceDiscoveryNotice {
+                await diagnostics.record(notice)
+            } else {
+                NSLog("[tailscale] suppressing notice because Tailscale does not look installed or active")
+            }
+            NSLog("[tailscale] request error: %@", responsePreview)
+            NSLog("[tailscale] interface snapshot after error: %@", tailscaleInterfaceSnapshot().logDescription)
         }
         return []
+    }
+
+    @MainActor
+    private static func isTailscaleAppInstalled() -> Bool {
+        guard let url = URL(string: "tailscale://") else { return false }
+        return UIApplication.shared.canOpenURL(url)
     }
 
     nonisolated private static func discoverLocalSubnetCodexCandidates(
@@ -632,6 +800,129 @@ final class NetworkDiscovery {
         return value.withCString { cstr in
             inet_pton(AF_INET, cstr, &addr) == 1
         }
+    }
+
+    nonisolated private static func isTailscaleIPv4Address(_ value: String) -> Bool {
+        let octets = value.split(separator: ".")
+        guard octets.count == 4,
+              let first = Int(octets[0]),
+              let second = Int(octets[1]) else {
+            return false
+        }
+        return first == 100 && (64...127).contains(second)
+    }
+
+    nonisolated private static func isTailscaleIPv6Address(_ value: String) -> Bool {
+        value.lowercased().hasPrefix("fd7a:115c:a1e0:")
+    }
+
+    nonisolated private static func interfaceFlagDescriptions(_ flags: Int32) -> [String] {
+        var out: [String] = []
+        if flags & IFF_UP != 0 { out.append("up") }
+        if flags & IFF_RUNNING != 0 { out.append("running") }
+        if flags & IFF_LOOPBACK != 0 { out.append("loopback") }
+        if flags & IFF_POINTOPOINT != 0 { out.append("ptp") }
+        if flags & IFF_MULTICAST != 0 { out.append("multicast") }
+        return out
+    }
+
+    nonisolated private static func ipAddress(fromSockaddr pointer: UnsafePointer<sockaddr>) -> (family: String, address: String)? {
+        let family = pointer.pointee.sa_family
+        switch family {
+        case sa_family_t(AF_INET):
+            let sinPtr = UnsafeRawPointer(pointer).assumingMemoryBound(to: sockaddr_in.self)
+            var addr = sinPtr.pointee.sin_addr
+            var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
+            guard inet_ntop(AF_INET, &addr, &buffer, socklen_t(INET_ADDRSTRLEN)) != nil else {
+                return nil
+            }
+            return ("ipv4", String(cString: buffer))
+        case sa_family_t(AF_INET6):
+            let sin6Ptr = UnsafeRawPointer(pointer).assumingMemoryBound(to: sockaddr_in6.self)
+            var addr = sin6Ptr.pointee.sin6_addr
+            var buffer = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
+            guard inet_ntop(AF_INET6, &addr, &buffer, socklen_t(INET6_ADDRSTRLEN)) != nil else {
+                return nil
+            }
+            return ("ipv6", String(cString: buffer))
+        default:
+            return nil
+        }
+    }
+
+    nonisolated private static func tailscaleInterfaceSnapshot() -> TailscaleInterfaceSnapshot {
+        var ifaddr: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&ifaddr) == 0, let first = ifaddr else {
+            return TailscaleInterfaceSnapshot(
+                localWiFiAddress: nil,
+                localWiFiInterface: nil,
+                activeTunnelInterfaces: [],
+                tailscaleInterfaces: [],
+                records: []
+            )
+        }
+        defer { freeifaddrs(ifaddr) }
+
+        var localWiFiAddress: String?
+        var localWiFiInterface: String?
+        var activeTunnelInterfaces = Set<String>()
+        var tailscaleInterfaces = Set<String>()
+        var records: [TailscaleInterfaceSnapshot.InterfaceRecord] = []
+
+        for ptr in sequence(first: first, next: { $0.pointee.ifa_next }) {
+            guard let sockaddr = ptr.pointee.ifa_addr else { continue }
+            guard let entry = ipAddress(fromSockaddr: sockaddr) else { continue }
+
+            let name = String(cString: ptr.pointee.ifa_name)
+            let flags = Int32(ptr.pointee.ifa_flags)
+            let flagDescriptions = interfaceFlagDescriptions(flags)
+            let isUp = flags & IFF_UP != 0
+            let isLoopback = flags & IFF_LOOPBACK != 0
+            let isTunnel = name.hasPrefix("utun")
+            let hasTailscaleAddress = isTailscaleIPv4Address(entry.address) || isTailscaleIPv6Address(entry.address)
+            let isLikelyTailscaleInterface = isTunnel && hasTailscaleAddress
+
+            if isUp && isTunnel {
+                activeTunnelInterfaces.insert(name)
+            }
+            if isLikelyTailscaleInterface {
+                tailscaleInterfaces.insert(name)
+            }
+            if isUp && !isLoopback && localWiFiAddress == nil && entry.family == "ipv4" && name.hasPrefix("en") {
+                localWiFiInterface = name
+                localWiFiAddress = entry.address
+            }
+
+            if isTunnel || isLikelyTailscaleInterface || (isUp && !isLoopback) {
+                records.append(
+                    TailscaleInterfaceSnapshot.InterfaceRecord(
+                        name: name,
+                        family: entry.family,
+                        address: entry.address,
+                        flags: flagDescriptions,
+                        isTailscaleAddress: isLikelyTailscaleInterface
+                    )
+                )
+            }
+        }
+
+        records.sort { lhs, rhs in
+            if lhs.name != rhs.name {
+                return lhs.name < rhs.name
+            }
+            if lhs.family != rhs.family {
+                return lhs.family < rhs.family
+            }
+            return lhs.address < rhs.address
+        }
+
+        return TailscaleInterfaceSnapshot(
+            localWiFiAddress: localWiFiAddress,
+            localWiFiInterface: localWiFiInterface,
+            activeTunnelInterfaces: activeTunnelInterfaces.sorted(),
+            tailscaleInterfaces: tailscaleInterfaces.sorted(),
+            records: records
+        )
     }
 
     nonisolated private static func localIPv4Address() -> (String, String)? {

--- a/apps/ios/Sources/Litter/Models/ServerConnection.swift
+++ b/apps/ios/Sources/Litter/Models/ServerConnection.swift
@@ -97,6 +97,9 @@ final class ServerConnection: Identifiable {
                 }
                 serverURL = url
                 connectionPhase = "remote-url"
+            case .remoteURL(let url):
+                serverURL = url
+                connectionPhase = "remote-url"
             case .sshThenRemote:
                 connectionPhase = "sshThenRemote-not-supported"
                 connectionHealth = .disconnected
@@ -136,7 +139,7 @@ final class ServerConnection: Identifiable {
         switch target {
         case .local:
             Task { _ = try? await URLSession.shared.data(from: url) }
-        case .remote:
+        case .remote, .remoteURL:
             Task {
                 _ = try? await execCommand(["curl", "-s", "-4", "-L", "--max-time", "10", url.absoluteString])
             }
@@ -593,7 +596,7 @@ final class ServerConnection: Identifiable {
 
     private func retryPolicy() -> ConnectionRetryPolicy {
         switch target {
-        case .remote:
+        case .remote, .remoteURL:
             return ConnectionRetryPolicy(
                 maxAttempts: 3,
                 retryDelay: .milliseconds(300),

--- a/apps/ios/Sources/Litter/Models/ThreadState.swift
+++ b/apps/ios/Sources/Litter/Models/ThreadState.swift
@@ -77,6 +77,7 @@ struct SavedServer: Codable, Identifiable {
     let hasCodexServer: Bool
     let wakeMAC: String?
     let sshPortForwardingEnabled: Bool?
+    let websocketURL: String?
 
     func toDiscoveredServer() -> DiscoveredServer {
         let codexPort = hasCodexServer ? port : nil
@@ -90,7 +91,8 @@ struct SavedServer: Codable, Identifiable {
             source: ServerSource.from(source),
             hasCodexServer: hasCodexServer,
             wakeMAC: wakeMAC,
-            sshPortForwardingEnabled: sshPortForwardingEnabled ?? false
+            sshPortForwardingEnabled: sshPortForwardingEnabled ?? false,
+            websocketURL: websocketURL
         )
     }
 
@@ -104,7 +106,8 @@ struct SavedServer: Codable, Identifiable {
             source: server.source.rawString,
             hasCodexServer: server.hasCodexServer,
             wakeMAC: server.wakeMAC,
-            sshPortForwardingEnabled: server.sshPortForwardingEnabled
+            sshPortForwardingEnabled: server.sshPortForwardingEnabled,
+            websocketURL: server.websocketURL
         )
     }
 }

--- a/apps/ios/Sources/Litter/Views/DiscoveryView.swift
+++ b/apps/ios/Sources/Litter/Views/DiscoveryView.swift
@@ -9,8 +9,8 @@ struct DiscoveryView: View {
     @State private var pendingSSHServer: DiscoveredServer?
     @State private var showManualEntry = false
     @State private var manualConnectionMode: ManualConnectionMode = .ssh
+    @State private var manualCodexURL = ""
     @State private var manualHost = ""
-    @State private var manualCodexPort = "8390"
     @State private var manualSSHPort = "22"
     @State private var manualWakeMAC = ""
     @State private var manualUseSSHPortForward = true
@@ -59,7 +59,8 @@ struct DiscoveryView: View {
                 source: liveServer.source,
                 hasCodexServer: liveServer.hasCodexServer,
                 wakeMAC: savedServer.wakeMAC ?? liveServer.wakeMAC,
-                sshPortForwardingEnabled: savedServer.sshPortForwardingEnabled || liveServer.sshPortForwardingEnabled
+                sshPortForwardingEnabled: savedServer.sshPortForwardingEnabled || liveServer.sshPortForwardingEnabled,
+                websocketURL: savedServer.websocketURL
             )
         }
         return mergeServers(discovered + reconciledSaved)
@@ -90,7 +91,8 @@ struct DiscoveryView: View {
                     source: candidate.source,
                     hasCodexServer: candidate.hasCodexServer,
                     wakeMAC: candidate.wakeMAC ?? existing.wakeMAC,
-                    sshPortForwardingEnabled: candidate.sshPortForwardingEnabled || existing.sshPortForwardingEnabled
+                    sshPortForwardingEnabled: candidate.sshPortForwardingEnabled || existing.sshPortForwardingEnabled,
+                    websocketURL: candidate.websocketURL ?? existing.websocketURL
                 )
                 let betterSource = sourceRank(candidate.source) < sourceRank(existing.source)
                 let hasCodexUpgrade = candidate.hasCodexServer && !existing.hasCodexServer
@@ -108,7 +110,8 @@ struct DiscoveryView: View {
                         source: existing.source,
                         hasCodexServer: existing.hasCodexServer,
                         wakeMAC: candidateWithWakeMAC.wakeMAC,
-                        sshPortForwardingEnabled: existing.sshPortForwardingEnabled || candidateWithWakeMAC.sshPortForwardingEnabled
+                        sshPortForwardingEnabled: existing.sshPortForwardingEnabled || candidateWithWakeMAC.sshPortForwardingEnabled,
+                        websocketURL: existing.websocketURL ?? candidateWithWakeMAC.websocketURL
                     )
                 }
             } else {
@@ -282,6 +285,18 @@ struct DiscoveryView: View {
                 ForEach(allServers) { server in
                     serverRow(server)
                 }
+            }
+
+            if let notice = discovery.tailscaleDiscoveryNotice {
+                HStack(alignment: .top, spacing: 10) {
+                    Image(systemName: "network.slash")
+                        .foregroundColor(LitterTheme.textSecondary)
+                        .frame(width: 18, alignment: .top)
+                    Text(notice)
+                        .font(LitterFont.styled(.caption))
+                        .foregroundColor(LitterTheme.textSecondary)
+                }
+                .listRowBackground(LitterTheme.surface.opacity(0.6))
             }
         } header: {
             HStack(spacing: 8) {
@@ -697,31 +712,44 @@ struct DiscoveryView: View {
                     .listRowBackground(LitterTheme.surface.opacity(0.6))
 
                     Section {
-                        TextField("hostname or IP", text: $manualHost)
-                            .font(LitterFont.styled(.footnote))
-                            .foregroundColor(LitterTheme.textPrimary)
-                            .textInputAutocapitalization(.never)
-                            .autocorrectionDisabled(true)
-                        TextField(manualConnectionMode.portPlaceholder, text: portBinding(for: manualConnectionMode))
-                            .font(LitterFont.styled(.footnote))
-                            .foregroundColor(LitterTheme.textPrimary)
-                            .keyboardType(.numberPad)
-                        if manualConnectionMode == .ssh {
+                        if manualConnectionMode == .codex {
+                            TextField("ws://host:port or wss://...", text: $manualCodexURL)
+                                .font(LitterFont.styled(.footnote))
+                                .foregroundColor(LitterTheme.textPrimary)
+                                .textInputAutocapitalization(.never)
+                                .autocorrectionDisabled(true)
+                                .keyboardType(.URL)
+                        } else {
+                            TextField("hostname or IP", text: $manualHost)
+                                .font(LitterFont.styled(.footnote))
+                                .foregroundColor(LitterTheme.textPrimary)
+                                .textInputAutocapitalization(.never)
+                                .autocorrectionDisabled(true)
+                            TextField("ssh port", text: $manualSSHPort)
+                                .font(LitterFont.styled(.footnote))
+                                .foregroundColor(LitterTheme.textPrimary)
+                                .keyboardType(.numberPad)
                             Toggle(isOn: $manualUseSSHPortForward) {
                                 Text("Use SSH port forward")
                                     .font(LitterFont.styled(.footnote))
                                     .foregroundColor(LitterTheme.textPrimary)
                             }
                             .tint(LitterTheme.accent)
+                            TextField("wake MAC (optional)", text: $manualWakeMAC)
+                                .font(LitterFont.styled(.footnote))
+                                .foregroundColor(LitterTheme.textPrimary)
+                                .textInputAutocapitalization(.never)
+                                .autocorrectionDisabled(true)
                         }
-                        TextField("wake MAC (optional)", text: $manualWakeMAC)
-                            .font(LitterFont.styled(.footnote))
-                            .foregroundColor(LitterTheme.textPrimary)
-                            .textInputAutocapitalization(.never)
-                            .autocorrectionDisabled(true)
                     } header: {
                         Text(manualConnectionMode.formHeader)
                             .foregroundColor(LitterTheme.textSecondary)
+                    } footer: {
+                        if manualConnectionMode == .codex {
+                            Text("Run: codex app-server --listen ws://0.0.0.0:8390\nFor reverse proxies: wss://example.com/ws?token=SECRET\nDo not expose directly to the internet unless you know what you are doing.")
+                                .font(LitterFont.styled(.caption2))
+                                .foregroundColor(LitterTheme.textMuted)
+                        }
                     }
                     .listRowBackground(LitterTheme.surface.opacity(0.6))
 
@@ -795,16 +823,70 @@ struct DiscoveryView: View {
         )
     }
 
-    private func portBinding(for mode: ManualConnectionMode) -> Binding<String> {
-        switch mode {
+    private func submitManualEntry() {
+        switch manualConnectionMode {
         case .codex:
-            return $manualCodexPort
+            submitManualCodexEntry()
         case .ssh:
-            return $manualSSHPort
+            submitManualSSHEntry()
         }
     }
 
-    private func submitManualEntry() {
+    private func submitManualCodexEntry() {
+        let raw = manualCodexURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !raw.isEmpty else { return }
+
+        // Full URL: ws:// or wss://
+        if let url = URL(string: raw),
+           let scheme = url.scheme?.lowercased(),
+           (scheme == "ws" || scheme == "wss"),
+           let host = url.host, !host.isEmpty {
+            let port = url.port.flatMap { UInt16(exactly: $0) }
+            let server = DiscoveredServer(
+                id: "manual-url-\(raw)",
+                name: host,
+                hostname: host,
+                port: port,
+                sshPort: nil,
+                source: .manual,
+                hasCodexServer: true,
+                websocketURL: raw
+            )
+            showManualEntry = false
+            Task { await connectToServer(server) }
+            return
+        }
+
+        // Bare host:port (e.g. "192.168.1.5:8390" or "myhost:8390")
+        let parts = raw.split(separator: ":", maxSplits: 1)
+        let host: String
+        let port: UInt16
+        if parts.count == 2, let p = UInt16(parts[1]) {
+            host = String(parts[0])
+            port = p
+        } else if parts.count == 1 {
+            host = raw
+            port = 8390
+        } else {
+            connectError = "Enter a ws:// URL or host:port"
+            return
+        }
+
+        guard !host.isEmpty else { return }
+        let server = DiscoveredServer(
+            id: "manual-\(host):\(port)",
+            name: host,
+            hostname: host,
+            port: port,
+            sshPort: nil,
+            source: .manual,
+            hasCodexServer: true
+        )
+        showManualEntry = false
+        Task { await connectToServer(server) }
+    }
+
+    private func submitManualSSHEntry() {
         let host = manualHost.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !host.isEmpty else { return }
 
@@ -815,43 +897,22 @@ struct DiscoveryView: View {
             return
         }
 
-        switch manualConnectionMode {
-        case .codex:
-            guard let port = UInt16(manualCodexPort) else {
-                connectError = "Codex port must be a valid number"
-                return
-            }
-            let server = DiscoveredServer(
-                id: "manual-\(host):\(port)",
-                name: host,
-                hostname: host,
-                port: port,
-                sshPort: nil,
-                source: .manual,
-                hasCodexServer: true,
-                wakeMAC: normalizedWakeMAC,
-                sshPortForwardingEnabled: false
-            )
-            showManualEntry = false
-            Task { await connectToServer(server) }
-        case .ssh:
-            guard let sshPort = UInt16(manualSSHPort) else {
-                connectError = "SSH port must be a valid number"
-                return
-            }
-            pendingSSHServer = DiscoveredServer(
-                id: "manual-ssh-\(host):\(sshPort)",
-                name: host,
-                hostname: host,
-                port: nil,
-                sshPort: sshPort,
-                source: .manual,
-                hasCodexServer: false,
-                wakeMAC: normalizedWakeMAC,
-                sshPortForwardingEnabled: manualUseSSHPortForward
-            )
-            showManualEntry = false
+        guard let sshPort = UInt16(manualSSHPort) else {
+            connectError = "SSH port must be a valid number"
+            return
         }
+        pendingSSHServer = DiscoveredServer(
+            id: "manual-ssh-\(host):\(sshPort)",
+            name: host,
+            hostname: host,
+            port: nil,
+            sshPort: sshPort,
+            source: .manual,
+            hasCodexServer: false,
+            wakeMAC: normalizedWakeMAC,
+            sshPortForwardingEnabled: manualUseSSHPortForward
+        )
+        showManualEntry = false
     }
 }
 
@@ -891,15 +952,6 @@ private enum ManualConnectionMode: String, CaseIterable, Identifiable {
             return "Codex Server"
         case .ssh:
             return "SSH Bootstrap"
-        }
-    }
-
-    var portPlaceholder: String {
-        switch self {
-        case .codex:
-            return "codex port"
-        case .ssh:
-            return "ssh port"
         }
     }
 

--- a/apps/ios/Tests/CodexIOSTests/NetworkDiscoveryTests.swift
+++ b/apps/ios/Tests/CodexIOSTests/NetworkDiscoveryTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+@testable import Litter
+
+final class NetworkDiscoveryTests: XCTestCase {
+    func testTailscaleAvailabilitySurfacesNoticeWhenAppIsInstalled() {
+        let availability = TailscaleAvailability(appInstalled: true, likelyActiveTunnel: false)
+
+        XCTAssertTrue(availability.shouldSurfaceDiscoveryNotice)
+    }
+
+    func testTailscaleAvailabilitySurfacesNoticeWhenTunnelLooksActive() {
+        let availability = TailscaleAvailability(appInstalled: false, likelyActiveTunnel: true)
+
+        XCTAssertTrue(availability.shouldSurfaceDiscoveryNotice)
+    }
+
+    func testTailscaleAvailabilitySuppressesNoticeWhenAppIsMissingAndTunnelIsInactive() {
+        let availability = TailscaleAvailability(appInstalled: false, likelyActiveTunnel: false)
+
+        XCTAssertFalse(availability.shouldSurfaceDiscoveryNotice)
+    }
+
+    func testParseTailscalePeerCandidatesFiltersOfflineAndNonIPv4Peers() throws {
+        let data = """
+        {
+          "Peer": {
+            "peer-1": {
+              "Online": true,
+              "HostName": "mac-mini",
+              "TailscaleIPs": ["fd7a:115c:a1e0::1", "100.64.0.12"]
+            },
+            "peer-2": {
+              "Online": false,
+              "HostName": "offline-host",
+              "TailscaleIPs": ["100.64.0.13"]
+            },
+            "peer-3": {
+              "Online": true,
+              "DNSName": "ipv6-only.example.ts.net.",
+              "TailscaleIPs": ["fd7a:115c:a1e0::2"]
+            }
+          }
+        }
+        """.data(using: .utf8)!
+        let response = HTTPURLResponse(
+            url: URL(string: "http://100.100.100.100/localapi/v0/status")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+
+        let peers = try NetworkDiscovery.parseTailscalePeerCandidates(data: data, response: response)
+
+        XCTAssertEqual(peers, [TailscalePeerIdentity(ip: "100.64.0.12", name: "mac-mini")])
+    }
+
+    func testParseTailscalePeerCandidatesRejectsHtmlSurface() {
+        let data = """
+        <!doctype html>
+        <html><body>Tailscale web interface</body></html>
+        """.data(using: .utf8)!
+        let response = HTTPURLResponse(
+            url: URL(string: "http://100.100.100.100/localapi/v0/status")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "text/html; charset=utf-8"]
+        )!
+
+        XCTAssertThrowsError(
+            try NetworkDiscovery.parseTailscalePeerCandidates(data: data, response: response)
+        )
+    }
+
+    func testParseTailscalePeerCandidatesRejectsDeviceStatusPayloadWithoutPeerList() {
+        let data = """
+        {
+          "Status": "Running",
+          "DeviceName": "sigkittens-mac-studio",
+          "IPv4": "100.113.43.109"
+        }
+        """.data(using: .utf8)!
+        let response = HTTPURLResponse(
+            url: URL(string: "http://100.100.100.100/localapi/v0/status")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+
+        XCTAssertThrowsError(
+            try NetworkDiscovery.parseTailscalePeerCandidates(data: data, response: response)
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Closes #31

- Unified Codex manual entry into a single URL field accepting `ws://host:port`, `wss://full-url`, or bare `host:port`
- Added TLS WebSocket support (`NWParameters(tls:)` on iOS, `SSLSocketFactory` on Android)
- Preserves path and query parameters in WebSocket upgrade handshake (e.g. `wss://codex.example.com/ws?token=SECRET`)
- `websocketUrl` field persisted in saved server models on both platforms
- Helper text with `codex app-server` command and security guidance shown in discovery UI

## Test plan

- [ ] Enter `ws://192.168.1.x:8390` in Codex URL field → connects via plain WebSocket
- [ ] Enter bare `192.168.1.x:8390` → connects via plain WebSocket (defaults to ws://)
- [ ] Enter `wss://codex.example.com/ws?token=SECRET` → connects via TLS WebSocket with path/query preserved
- [ ] Save a wss:// server, kill app, relaunch → server persists and reconnects
- [ ] SSH mode still works unchanged
- [ ] Verify on both iOS and Android (phone + large-screen layouts on Android)