### PR TITLE
ios: harden local shell handling on simulator

### DIFF
--- a/apps/ios/Sources/Litter/Bridge/CodexProtocol.swift
+++ b/apps/ios/Sources/Litter/Bridge/CodexProtocol.swift
@@ -593,6 +593,7 @@ struct ThreadResumeParams: Encodable {
     var approvalPolicy: String?
     var sandbox: String?
     let persistExtendedHistory: Bool? = true
+    let developerInstructions: String?
 }
 
 struct ThreadResumeResponse: Decodable {
@@ -666,6 +667,7 @@ struct ThreadForkParams: Encodable {
     var approvalPolicy: String?
     var sandbox: String?
     let persistExtendedHistory: Bool? = true
+    let developerInstructions: String?
 }
 
 struct ThreadForkResponse: Decodable {

--- a/apps/ios/Sources/Litter/Bridge/IosSystemBridge.m
+++ b/apps/ios/Sources/Litter/Bridge/IosSystemBridge.m
@@ -3,109 +3,31 @@
 #include <string.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <errno.h>
 #include <pthread.h>
+#include <spawn.h>
+#include <sys/wait.h>
 #include <TargetConditionals.h>
 #include <Foundation/Foundation.h>
 
-#if TARGET_OS_SIMULATOR
-// ── Simulator path ──────────────────────────────────────────────────────────
-// The iOS Simulator runs as a macOS process, so posix_spawn/popen work fine.
-// ios_system is not linked for simulator (its perl xcframeworks lack that
-// slice), so we use popen here instead.
-
-void codex_ios_system_init(void) {}
-
-NSString *codex_ios_default_cwd(void) {
-    NSString *docs = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
-    if (!docs) return nil;
-    NSFileManager *fm = [NSFileManager defaultManager];
-    NSArray<NSString *> *dirs = @[@"home/codex", @"tmp", @"var/log", @"etc"];
-    for (NSString *dir in dirs) {
-        NSString *path = [docs stringByAppendingPathComponent:dir];
-        if (![fm fileExistsAtPath:path]) {
-            [fm createDirectoryAtPath:path withIntermediateDirectories:YES attributes:nil error:nil];
-        }
-    }
-    return [docs stringByAppendingPathComponent:@"home/codex"];
-}
-
-int codex_ios_system_run(const char *cmd, const char *cwd, char **output, size_t *output_len) {
-    *output = NULL;
-    *output_len = 0;
-
-    int old_cwd_fd = open(".", O_RDONLY);
-    if (cwd) {
-        NSFileManager *fm = [NSFileManager defaultManager];
-        NSString *cwdStr = [NSString stringWithUTF8String:cwd];
-        if (![fm fileExistsAtPath:cwdStr]) {
-            [fm createDirectoryAtPath:cwdStr withIntermediateDirectories:YES attributes:nil error:nil];
-        }
-        if (chdir(cwd) != 0) {
-            NSString *docs = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
-            if (docs && chdir(docs.UTF8String) != 0) {
-                if (old_cwd_fd >= 0) close(old_cwd_fd);
-                return -1;
-            }
-        }
-    }
-
-    FILE *fp = popen(cmd, "r");
-    if (!fp) {
-        if (old_cwd_fd >= 0) {
-            fchdir(old_cwd_fd);
-            close(old_cwd_fd);
-        }
-        return -1;
-    }
-
-    size_t buf_size = 8192;
-    char *buf = malloc(buf_size);
-    if (!buf) {
-        pclose(fp);
-        if (old_cwd_fd >= 0) {
-            fchdir(old_cwd_fd);
-            close(old_cwd_fd);
-        }
-        return -1;
-    }
-
-    size_t total = 0;
-    size_t n;
-    while ((n = fread(buf + total, 1, buf_size - total - 1, fp)) > 0) {
-        total += n;
-        if (total + 256 >= buf_size) {
-            buf_size *= 2;
-            char *nb = realloc(buf, buf_size);
-            if (!nb) break;
-            buf = nb;
-        }
-    }
-    int code = pclose(fp);
-    if (old_cwd_fd >= 0) {
-        fchdir(old_cwd_fd);
-        close(old_cwd_fd);
-    }
-    buf[total] = '\0';
-    *output = buf;
-    *output_len = total;
-    return WEXITSTATUS(code);
-}
-
-#else
-// ── Device path ─────────────────────────────────────────────────────────────
-// Use ios_system (linked via the ios_system Swift Package) for fork-free exec.
+// Use ios_system on both device and simulator. The simulator frameworks ship
+// the same entry points, and in-process execution is far more reliable than
+// trying to spawn host shells from the app sandbox.
 
 extern int ios_system(const char *cmd);
 extern FILE *ios_popen(const char *command, const char *type);
 extern void ios_setStreams(FILE *in_stream, FILE *out_stream, FILE *err_stream);
 extern void ios_waitpid(pid_t pid);
 extern pid_t ios_currentPid(void);
+extern int ios_getCommandStatus(void);
 extern bool joinMainThread;
 extern void initializeEnvironment(void);
 extern void ios_switchSession(const void *sessionid);
+extern void ios_setDirectoryURL(NSURL *workingDirectoryURL);
 extern void ios_setContext(const void *context);
 extern __thread void *thread_context;
 extern NSError *addCommandList(NSString *fileLocation);
+extern char **environ;
 
 static NSString *codex_find_command_plist(NSString *name) {
     NSBundle *mainBundle = [NSBundle mainBundle];
@@ -179,6 +101,109 @@ static FILE *codex_ios_command_stdin(void) {
     return nullInput != NULL ? nullInput : stdin;
 }
 
+static pthread_mutex_t *codex_ios_exec_mutex(void) {
+    static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+    return &mutex;
+}
+
+static NSString *codex_ios_decode_wrapped_shell_argument(NSString *value) {
+    NSString *trimmed = [value stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (trimmed.length < 2) {
+        return nil;
+    }
+
+    if ([trimmed hasPrefix:@"'"] && [trimmed hasSuffix:@"'"]) {
+        NSString *placeholder = @"__CODEX_SQUOTE__";
+        NSString *decoded = [trimmed stringByReplacingOccurrencesOfString:@"'\\''" withString:placeholder];
+        decoded = [decoded stringByReplacingOccurrencesOfString:@"'" withString:@""];
+        decoded = [decoded stringByReplacingOccurrencesOfString:placeholder withString:@"'"];
+        return decoded;
+    }
+
+    if ([trimmed hasPrefix:@"\""] && [trimmed hasSuffix:@"\""]) {
+        NSString *decoded = [trimmed substringWithRange:NSMakeRange(1, trimmed.length - 2)];
+        decoded = [decoded stringByReplacingOccurrencesOfString:@"\\\"" withString:@"\""];
+        decoded = [decoded stringByReplacingOccurrencesOfString:@"\\\\" withString:@"\\"];
+        return decoded;
+    }
+
+    return nil;
+}
+
+static NSString *codex_ios_normalize_shell_command(const char *cmd) {
+    NSString *command = cmd ? [NSString stringWithUTF8String:cmd] : @"";
+    if (command.length == 0) {
+        return command;
+    }
+
+    NSArray<NSString *> *prefixes = @[
+        @"/bin/bash -lc ",
+        @"/bin/bash -c ",
+        @"/bin/zsh -lc ",
+        @"/bin/zsh -c ",
+        @"/bin/sh -lc ",
+        @"bash -lc ",
+        @"bash -c ",
+        @"zsh -lc ",
+        @"zsh -c ",
+        @"sh -lc ",
+    ];
+    BOOL changed = YES;
+    while (changed) {
+        changed = NO;
+
+        for (NSString *prefix in prefixes) {
+            if ([command hasPrefix:prefix]) {
+                NSString *body = [command substringFromIndex:prefix.length];
+                NSString *decoded = codex_ios_decode_wrapped_shell_argument(body);
+                if (decoded.length > 0 && ([decoded hasPrefix:@"sh -c "] || [decoded isEqualToString:@"sh"])) {
+                    command = decoded;
+                } else {
+                    command = [@"sh -c " stringByAppendingString:body];
+                }
+                changed = YES;
+                break;
+            }
+        }
+        if (changed) {
+            continue;
+        }
+
+        if ([command hasPrefix:@"sh -c "]) {
+            NSString *body = [command substringFromIndex:6];
+            NSString *decoded = codex_ios_decode_wrapped_shell_argument(body);
+            if (decoded.length > 0 && ([decoded hasPrefix:@"sh -c "] || [decoded isEqualToString:@"sh"])) {
+                command = decoded;
+                changed = YES;
+                continue;
+            }
+        }
+
+        if ([command isEqualToString:@"/bin/bash"]
+            || [command isEqualToString:@"/bin/zsh"]
+            || [command isEqualToString:@"/bin/sh"]
+            || [command isEqualToString:@"bash"]
+            || [command isEqualToString:@"zsh"]) {
+            command = @"sh";
+            changed = YES;
+        }
+    }
+
+    return [command stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+}
+
+static NSString *codex_ios_host_shell_script(NSString *command) {
+    NSString *trimmed = [command stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if ([trimmed hasPrefix:@"sh -c "]) {
+        NSString *body = [trimmed substringFromIndex:6];
+        NSString *decoded = codex_ios_decode_wrapped_shell_argument(body);
+        if (decoded.length > 0) {
+            return decoded;
+        }
+    }
+    return trimmed;
+}
+
 static const char *codex_ios_session_name(void) {
     static __thread char *sessionName = NULL;
     if (sessionName == NULL) {
@@ -187,6 +212,194 @@ static const char *codex_ios_session_name(void) {
         sessionName = strdup(buffer);
     }
     return sessionName;
+}
+
+static NSString *codex_ios_single_quote(NSString *value) {
+    return [NSString stringWithFormat:@"'%@'", [value stringByReplacingOccurrencesOfString:@"'" withString:@"'\\''"]];
+}
+
+static void codex_ios_prepare_session(const char *cwd) {
+    const char *sessionName = codex_ios_session_name();
+    ios_setContext(NULL);
+    thread_context = NULL;
+    ios_switchSession(sessionName);
+    ios_setContext(sessionName);
+    thread_context = (void *)sessionName;
+
+    if (cwd == NULL || cwd[0] == '\0') {
+        return;
+    }
+
+    NSString *cwdString = [NSString stringWithUTF8String:cwd];
+    NSFileManager *fm = [NSFileManager defaultManager];
+    if (![fm fileExistsAtPath:cwdString]) {
+        [fm createDirectoryAtPath:cwdString withIntermediateDirectories:YES attributes:nil error:nil];
+    }
+    ios_setDirectoryURL([NSURL fileURLWithPath:cwdString isDirectory:YES]);
+}
+
+static int codex_ios_popen_run(const char *cmd, const char *cwd, char **output, size_t *output_len) {
+    NSLog(@"[ios-popen] run cmd='%s' cwd='%s'", cmd, cwd ? cwd : "(null)");
+
+    codex_ios_prepare_session(cwd);
+
+    bool savedJoin = joinMainThread;
+    joinMainThread = false;
+    FILE *rf = ios_popen(cmd, "r");
+    pid_t pid = ios_currentPid();
+    joinMainThread = savedJoin;
+
+    if (rf == NULL) {
+        NSLog(@"[ios-popen] ios_popen FAILED for cmd='%s'", cmd);
+        return -1;
+    }
+
+    NSMutableData *data = [NSMutableData data];
+    char chunk[4096];
+    while (!feof(rf)) {
+        size_t count = fread(chunk, 1, sizeof(chunk), rf);
+        if (count > 0) {
+            [data appendBytes:chunk length:count];
+        }
+        if (count == 0 && ferror(rf)) {
+            NSLog(@"[ios-popen] fread FAILED errno=%d (%s)", errno, strerror(errno));
+            break;
+        }
+    }
+    fclose(rf);
+
+    if (pid > 0) {
+        ios_waitpid(pid);
+    }
+    int code = ios_getCommandStatus();
+
+    size_t total = data.length;
+    char *buf = NULL;
+    if (total > 0) {
+        buf = malloc(total + 1);
+        if (buf != NULL) {
+            memcpy(buf, data.bytes, total);
+        } else {
+            total = 0;
+        }
+    }
+
+    NSLog(@"[ios-popen] code=%d output_len=%zu for cmd='%s'", code, total, cmd);
+
+    if (buf && total > 0) {
+        buf[total] = '\0';
+        *output = buf;
+        *output_len = total;
+    } else {
+        free(buf);
+    }
+
+    return code;
+}
+
+static int codex_ios_host_spawn_run(const char *cmd, const char *cwd, char **output, size_t *output_len) {
+    NSLog(@"[ios-spawn] run cmd='%s' cwd='%s'", cmd, cwd ? cwd : "(null)");
+
+    int pipefd[2] = {-1, -1};
+    if (pipe(pipefd) != 0) {
+        NSLog(@"[ios-spawn] pipe FAILED errno=%d (%s)", errno, strerror(errno));
+        return -1;
+    }
+    fcntl(pipefd[0], F_SETFD, FD_CLOEXEC);
+    fcntl(pipefd[1], F_SETFD, FD_CLOEXEC);
+
+    posix_spawn_file_actions_t actions;
+    posix_spawn_file_actions_init(&actions);
+    posix_spawn_file_actions_addopen(&actions, STDIN_FILENO, "/dev/null", O_RDONLY, 0);
+    posix_spawn_file_actions_adddup2(&actions, pipefd[1], STDOUT_FILENO);
+    posix_spawn_file_actions_adddup2(&actions, pipefd[1], STDERR_FILENO);
+    posix_spawn_file_actions_addclose(&actions, pipefd[0]);
+    posix_spawn_file_actions_addclose(&actions, pipefd[1]);
+
+    NSString *scriptString = codex_ios_host_shell_script([NSString stringWithUTF8String:cmd]);
+    const char *scriptArg = scriptString.UTF8String;
+    const char *cwdArg = (cwd != NULL && cwd[0] != '\0') ? cwd : ".";
+    const char *script = "cd \"$1\" && exec /bin/sh -c \"$2\"";
+    char *const argv[] = {
+        "sh",
+        "-c",
+        (char *)script,
+        "sh",
+        (char *)cwdArg,
+        (char *)scriptArg,
+        NULL
+    };
+
+    pid_t pid = 0;
+    int spawnErr = posix_spawn(&pid, "/bin/sh", &actions, NULL, argv, environ);
+    posix_spawn_file_actions_destroy(&actions);
+    close(pipefd[1]);
+
+    if (spawnErr != 0) {
+        close(pipefd[0]);
+        NSLog(@"[ios-spawn] posix_spawn FAILED errno=%d (%s)", spawnErr, strerror(spawnErr));
+        return -1;
+    }
+
+    NSMutableData *data = [NSMutableData data];
+    char chunk[4096];
+    for (;;) {
+        ssize_t count = read(pipefd[0], chunk, sizeof(chunk));
+        if (count > 0) {
+            [data appendBytes:chunk length:(NSUInteger)count];
+            continue;
+        }
+        if (count == 0) {
+            break;
+        }
+        if (errno == EINTR) {
+            continue;
+        }
+        NSLog(@"[ios-spawn] read FAILED errno=%d (%s)", errno, strerror(errno));
+        break;
+    }
+    close(pipefd[0]);
+
+    int status = 0;
+    while (waitpid(pid, &status, 0) < 0) {
+        if (errno != EINTR) {
+            NSLog(@"[ios-spawn] waitpid FAILED errno=%d (%s)", errno, strerror(errno));
+            status = -1;
+            break;
+        }
+    }
+
+    int code = -1;
+    if (status == -1) {
+        code = -1;
+    } else if (WIFEXITED(status)) {
+        code = WEXITSTATUS(status);
+    } else if (WIFSIGNALED(status)) {
+        code = 128 + WTERMSIG(status);
+    }
+
+    size_t total = data.length;
+    char *buf = NULL;
+    if (total > 0) {
+        buf = malloc(total + 1);
+        if (buf != NULL) {
+            memcpy(buf, data.bytes, total);
+        } else {
+            total = 0;
+        }
+    }
+
+    NSLog(@"[ios-spawn] code=%d output_len=%zu for cmd='%s'", code, total, cmd);
+
+    if (buf && total > 0) {
+        buf[total] = '\0';
+        *output = buf;
+        *output_len = total;
+    } else {
+        free(buf);
+    }
+
+    return code;
 }
 
 /// Returns the default working directory for codex sessions (/home/codex inside the sandbox).
@@ -217,36 +430,27 @@ int codex_ios_system_run(const char *cmd, const char *cwd, char **output, size_t
     *output = NULL;
     *output_len = 0;
 
-    NSLog(@"[ios-system] run cmd='%s' cwd='%s'", cmd, cwd ? cwd : "(null)");
+    NSString *normalizedCmd = codex_ios_normalize_shell_command(cmd);
+    const char *runCmd = normalizedCmd.UTF8String;
 
-    // ios_system treats both session IDs and session contexts as C strings and
-    // compares them with strcmp(). Using an Objective-C object pointer here
-    // leads to undefined behavior once signal handling checks the session.
-    const char *sessionName = codex_ios_session_name();
-    ios_setContext(NULL);
-    thread_context = NULL;
-    ios_switchSession(sessionName);
-    ios_setContext(sessionName);
-    thread_context = (void *)sessionName;
-
-    int old_cwd_fd = open(".", O_RDONLY);
-    if (cwd) {
-        // Ensure the cwd exists (iOS temp dirs may not be pre-created).
-        NSFileManager *fm = [NSFileManager defaultManager];
-        NSString *cwdStr = [NSString stringWithUTF8String:cwd];
-        if (![fm fileExistsAtPath:cwdStr]) {
-            [fm createDirectoryAtPath:cwdStr withIntermediateDirectories:YES attributes:nil error:nil];
-        }
-        if (chdir(cwd) != 0) {
-            NSLog(@"[ios-system] chdir FAILED errno=%d (%s) for cwd='%s', falling back to /home/codex", errno, strerror(errno), cwd);
-            NSString *fallback = codex_ios_default_cwd();
-            if (!fallback || chdir(fallback.UTF8String) != 0) {
-                NSLog(@"[ios-system] fallback chdir also FAILED");
-                if (old_cwd_fd >= 0) close(old_cwd_fd);
-                return -1;
-            }
-        }
+#if TARGET_OS_SIMULATOR
+    if (cmd != NULL && strcmp(cmd, runCmd) != 0) {
+        NSLog(@"[ios-system] normalized cmd from '%s' to '%s'", cmd, runCmd);
     }
+    return codex_ios_host_spawn_run(runCmd, cwd, output, output_len);
+#endif
+
+    int code = -1;
+    pthread_mutex_lock(codex_ios_exec_mutex());
+    if (cmd != NULL && strcmp(cmd, runCmd) != 0) {
+        NSLog(@"[ios-system] normalized cmd from '%s' to '%s'", cmd, runCmd);
+    }
+
+    NSLog(@"[ios-system] run cmd='%s' cwd='%s'", runCmd, cwd ? cwd : "(null)");
+
+    // ios_system uses process-global streams/session state, so all shell work
+    // is serialized through a process-wide mutex while staying on the caller thread.
+    codex_ios_prepare_session(cwd);
 
     // Capture output via a temp file. We intentionally NEVER fclose the FILE* —
     // ios_system's background thread cleanup may still reference it.
@@ -255,15 +459,15 @@ int codex_ios_system_run(const char *cmd, const char *cwd, char **output, size_t
         [NSString stringWithFormat:@"codex_exec_%u.tmp", arc4random()]];
     FILE *wf = fopen(tmpPath.UTF8String, "w");
     if (!wf) {
-        NSLog(@"[ios-system] tmpfile FAILED for cmd='%s'", cmd);
-        if (old_cwd_fd >= 0) { fchdir(old_cwd_fd); close(old_cwd_fd); }
+        NSLog(@"[ios-system] tmpfile FAILED for cmd='%s'", runCmd);
+        pthread_mutex_unlock(codex_ios_exec_mutex());
         return -1;
     }
 
     bool savedJoin = joinMainThread;
     joinMainThread = true;
     ios_setStreams(codex_ios_command_stdin(), wf, wf);
-    int code = ios_system(cmd);
+    code = ios_system(runCmd);
     joinMainThread = savedJoin;
     fflush(wf);
     ios_setStreams(stdin, stdout, stderr);
@@ -282,12 +486,7 @@ int codex_ios_system_run(const char *cmd, const char *cwd, char **output, size_t
         }
     }
 
-    NSLog(@"[ios-system] code=%d output_len=%zu for cmd='%s'", code, total, cmd);
-
-    if (old_cwd_fd >= 0) {
-        fchdir(old_cwd_fd);
-        close(old_cwd_fd);
-    }
+    NSLog(@"[ios-system] code=%d output_len=%zu for cmd='%s'", code, total, runCmd);
 
     if (buf && total > 0) {
         buf[total] = '\0';
@@ -296,7 +495,6 @@ int codex_ios_system_run(const char *cmd, const char *cwd, char **output, size_t
     } else {
         free(buf);
     }
+    pthread_mutex_unlock(codex_ios_exec_mutex());
     return code;
 }
-
-#endif

--- a/apps/ios/Sources/Litter/Models/ServerConnection.swift
+++ b/apps/ios/Sources/Litter/Models/ServerConnection.swift
@@ -275,9 +275,16 @@ final class ServerConnection: Identifiable {
         approvalPolicy: String,
         sandbox: String
     ) async throws -> ThreadResumeResponse {
-        try await routedSendRequest(
+        let instructions = target == .local ? Self.localSystemInstructions : nil
+        return try await routedSendRequest(
             method: "thread/resume",
-            params: ThreadResumeParams(threadId: threadId, cwd: cwd, approvalPolicy: approvalPolicy, sandbox: sandbox),
+            params: ThreadResumeParams(
+                threadId: threadId,
+                cwd: cwd,
+                approvalPolicy: approvalPolicy,
+                sandbox: sandbox,
+                developerInstructions: instructions
+            ),
             responseType: ThreadResumeResponse.self
         )
     }
@@ -288,9 +295,16 @@ final class ServerConnection: Identifiable {
         approvalPolicy: String,
         sandbox: String
     ) async throws -> ThreadForkResponse {
-        try await routedSendRequest(
+        let instructions = target == .local ? Self.localSystemInstructions : nil
+        return try await routedSendRequest(
             method: "thread/fork",
-            params: ThreadForkParams(threadId: threadId, cwd: cwd, approvalPolicy: approvalPolicy, sandbox: sandbox),
+            params: ThreadForkParams(
+                threadId: threadId,
+                cwd: cwd,
+                approvalPolicy: approvalPolicy,
+                sandbox: sandbox,
+                developerInstructions: instructions
+            ),
             responseType: ThreadForkResponse.self
         )
     }
@@ -576,28 +590,38 @@ final class ServerConnection: Identifiable {
     You are running on an iOS device with limited shell capabilities via ios_system.
 
     Environment:
-    - Working directory: ~/Documents (the app's sandboxed Documents folder)
-    - Shell: ios_system (not a full POSIX shell — no fork/exec, no process spawning)
-    - Available commands: ls, cat, echo, touch, find, grep, cp, mv, rm, mkdir, pwd, wc, head, tail, sort, uniq, sed, awk, tr, tee, env, date, and other single-binary utilities bundled via ios_system
-    - /bin/sh is available but runs in-process — compound commands (&&, ||, pipes) work but may behave differently than on a full system
+    - Working directory: /home/codex (inside the app's sandboxed filesystem — persistent across app launches)
+    - Filesystem layout: ~/Documents acts as root with /home/codex, /tmp, /var/log, /etc
+    - Shell: ios_system (in-process, not a full POSIX shell — no fork/exec)
+    - If you need a shell wrapper, the executable itself must be `sh`.
+    - Use `sh -c '...'` directly. Do NOT emit `/bin/bash`, `bash`, `/bin/zsh`, `zsh`, `/bin/sh -lc`, or nested wrappers like `/bin/bash -lc "sh -c '...'"`.
+    - /bin/sh runs in-process — compound commands (&&, ||, pipes) work
+
+    Available tools:
+    - Shell: ls, cat, echo, touch, cp, mv, rm, mkdir, rmdir, pwd, chmod, ln, du, df, env, date, uname, whoami, which, true, false, yes, printenv, basename, dirname, realpath, readlink
+    - Text: grep, sed, awk, wc, sort, uniq, head, tail, tr, tee, cut, paste, comm, diff, expand, unexpand, fold, fmt, nl, rev, strings
+    - Files: find, stat, tar, xargs
+    - Network: curl (full HTTP client), ssh, scp, sftp
+    - Git: lg2 (libgit2 CLI — use `lg2` instead of `git`, supports clone, init, add, commit, push, pull, status, log, diff, branch, checkout, merge, remote, tag, stash)
+    - Other: bc (calculator)
 
     Limitations:
-    - apply_patch runs in-process but may fail with "Operation not permitted" on some paths. When it fails, fall back to shell commands (echo > file, cat >> file) to create/edit files.
-    - Do NOT use absolute container paths like /var/mobile/Containers/... in file operations — use relative paths from the working directory instead.
-    - The container UUID changes between app installs, so absolute paths from previous sessions are invalid.
-    - File redirection (> and >>) works. Use `echo 'content' > file.txt` to create files when apply_patch fails.
-    - For multi-line file creation, use multiple echo commands with >> (append).
-    - git is NOT available.
-    - No package managers (npm, pip, brew, etc).
-    - No network tools (curl, wget) via shell — but the app handles network requests internally.
-    - Commands run synchronously. Long-running commands will block.
+    - apply_patch may fail with "Operation not permitted" — fall back to echo/cat with redirection.
+    - Use RELATIVE paths, not absolute /var/mobile/Containers/... paths.
+    - Container UUID changes between installs — absolute paths from previous sessions are invalid.
+    - No package managers (npm, pip, brew) and no Python/Node.
+    - Use `lg2` not `git` for git operations.
+    - Commands run synchronously — avoid long-running operations.
 
     Best practices:
-    - Always use relative paths for file operations.
+    - Use relative paths for all file operations.
+    - Prefer direct argv commands like `pwd`, `find`, `ls`, `rg`, `sed`.
+    - Only wrap with `sh -c '...'` when shell syntax is actually required.
+    - Never prepend `sh -c` with `bash -lc` or `zsh -lc`.
     - Prefer simple, single commands over complex pipelines.
-    - When creating files, try apply_patch first. If it fails, use echo/cat with redirection.
-    - Keep file operations within ~/Documents.
-    - Be concise — this is a mobile device with limited screen space.
+    - For file creation: try apply_patch first, fall back to echo/cat redirection.
+    - For scripting: use shell scripts or awk.
+    - Be concise — this is a mobile device.
     """
 
     // MARK: - Transport Routing


### PR DESCRIPTION
## Purpose
Fix local simulator shell execution so Codex threads can resume/fork with iOS-specific instructions and execute local shell commands more reliably.

## Key changes
- add developer instructions to thread resume and fork requests for local iOS sessions
- tighten local iOS instructions to require `sh` and avoid unsupported shell wrappers
- normalize nested shell wrappers and route simulator shell execution through a safer host-spawn path while keeping device on the existing `ios_system` path

## Verification
- `xcodebuild -project apps/ios/Litter.xcodeproj -scheme Litter -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build`