### PR TITLE
ios: fix attached image turn input and paste support

### DIFF
--- a/apps/ios/Litter.xcodeproj/project.pbxproj
+++ b/apps/ios/Litter.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		0D06E8940202B4A2043551DC /* rose-pine-dawn.json in Resources */ = {isa = PBXBuildFile; fileRef = 9B858CE89BDC1E0974263B28 /* rose-pine-dawn.json */; };
 		0D4116209C36B23F964BC070 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FE71A015A197F8B7F6AE82B8 /* Security.framework */; };
 		0E130B9217359464AA4F5CBB /* SessionsDerivation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC90A9241820BC40C754C2F9 /* SessionsDerivation.swift */; };
+		0F97D6A5A05056E18594449A /* ConversationAttachmentSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33000D9825376F952524F20C /* ConversationAttachmentSupport.swift */; };
 		0FA2D55FE17D4AD9A910FB74 /* gruvbox-light-hard.json in Resources */ = {isa = PBXBuildFile; fileRef = 9AF7E00FF3D6A3D37B161855 /* gruvbox-light-hard.json */; };
 		125C2E4CA18D9767C9B67DE1 /* sentry-dark.json in Resources */ = {isa = PBXBuildFile; fileRef = 59B08FFA16CBFD1A93E32980 /* sentry-dark.json */; };
 		145F611793C70C7B176AF3AC /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615E709D4D5722523052907E /* SnapshotHelper.swift */; };
@@ -75,6 +76,7 @@
 		2A1E623523793810458A4631 /* text.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CECEF29277C1DB1AD1EF304D /* text.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2AF52BFA4186BEE1A561FF0A /* solarized-light.json in Resources */ = {isa = PBXBuildFile; fileRef = 887F9EF05D2351DEB6B9602D /* solarized-light.json */; };
 		2B3482666DCC203FC1242D39 /* laserwave.json in Resources */ = {isa = PBXBuildFile; fileRef = 9AB673AF3C45AA3144F784F4 /* laserwave.json */; };
+		2B9DD5A54D6958BFE4369B38 /* ConversationComposerTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75F91259F006987853B6929F /* ConversationComposerTextView.swift */; };
 		2C1E2164BB03C57BDC4151EA /* kanagawa-lotus.json in Resources */ = {isa = PBXBuildFile; fileRef = D2608C1F271D28BFEFBA5EFB /* kanagawa-lotus.json */; };
 		2DBCCE766D2356AB34EA47CF /* brand_logo.png in Resources */ = {isa = PBXBuildFile; fileRef = 17BD69B0550C63596995AC18 /* brand_logo.png */; };
 		2E4F6BA31997A35C1D8041AA /* lg2.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 728942810EA5AD9DBBD6CAF4 /* lg2.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -207,6 +209,7 @@
 		847B2A9216E2C53D8A220303 /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F79D1C06A25D0ABAA5042BA /* SafariView.swift */; };
 		84F6C5BF84085B7B2A6B4EAC /* sentry-dark.json in Resources */ = {isa = PBXBuildFile; fileRef = 59B08FFA16CBFD1A93E32980 /* sentry-dark.json */; };
 		85378EE3CE3AE3C8FB27723E /* ServerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2741603625C765D5BC95E39 /* ServerManager.swift */; };
+		85ACC46459DA8D7AF4356246 /* ConversationComposerAttachSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56EFBFE7DF8014B177A1F7B9 /* ConversationComposerAttachSheet.swift */; };
 		85EE90E928ECA05143299FEA /* github-dark-high-contrast.json in Resources */ = {isa = PBXBuildFile; fileRef = E1FAA725B26C5805C94EF40E /* github-dark-high-contrast.json */; };
 		863E974F904C137CB6669DE0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 35949923355BB19A7209FD65 /* Assets.xcassets */; };
 		86AC3AA3AE8BB644441094A7 /* one-light.json in Resources */ = {isa = PBXBuildFile; fileRef = 795964BC1D4B7081B774B65E /* one-light.json */; };
@@ -220,6 +223,7 @@
 		89324C555E2014AB0DC466B7 /* ConversationComposerContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35815D57BE688636CDD27415 /* ConversationComposerContentView.swift */; };
 		8A04BCA096806B66BF373FF0 /* solarized-dark.json in Resources */ = {isa = PBXBuildFile; fileRef = 45F4850CDE17E426ECBF4EA5 /* solarized-dark.json */; };
 		8B8335F1D0AA1E5584BCAF20 /* CodexProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2C91E2BA1A8F93DA7FF4EF /* CodexProtocol.swift */; };
+		8C23140CEA84BA8C4DE2BC69 /* ConversationAttachmentSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33000D9825376F952524F20C /* ConversationAttachmentSupport.swift */; };
 		8C573877188B1CF76579523A /* DiscoveredServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7779BD02F3B304F9C3AD32A1 /* DiscoveredServer.swift */; };
 		8C615C89FB0F8463243B4451 /* material-theme-ocean.json in Resources */ = {isa = PBXBuildFile; fileRef = C39258ECD6AC8BD99B1BED81 /* material-theme-ocean.json */; };
 		8CA530EBFB89D5E73C52F9A0 /* VoiceTranscriptionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A57573910BEE96B3224934D2 /* VoiceTranscriptionManager.swift */; };
@@ -297,6 +301,7 @@
 		C327D9AB807FE6D4303FD1B2 /* codex-dark.json in Resources */ = {isa = PBXBuildFile; fileRef = 251EBDF798A64303E84D4139 /* codex-dark.json */; };
 		C3FE02460B9CA3CA105BADBA /* curl_ios.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4E2BBC2265A3D566D0069278 /* curl_ios.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C5C3B938B613138273F4E1AD /* temple-dark.json in Resources */ = {isa = PBXBuildFile; fileRef = 885259DDCC6E448B237FAA61 /* temple-dark.json */; };
+		C5F25BE88D32A0FC1FD72449 /* ConversationAttachmentSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 733401E26505A989A02B291D /* ConversationAttachmentSupportTests.swift */; };
 		C67F7D520DD9933074FC243E /* rose-pine-moon.json in Resources */ = {isa = PBXBuildFile; fileRef = E8ABCFE5B02E47BAA5599A8F /* rose-pine-moon.json */; };
 		C68B87BCE5AA3492ACA0D63D /* curl_ios.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4E2BBC2265A3D566D0069278 /* curl_ios.xcframework */; };
 		C7381D0F2B63D781225758BA /* material-theme-darker-D.json in Resources */ = {isa = PBXBuildFile; fileRef = 20596BA6184B72B07775A5E1 /* material-theme-darker-D.json */; };
@@ -338,6 +343,7 @@
 		DD00D8C3D23EDD846B828509 /* SessionLaunchSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2EAAADB209274FFFB94CC0 /* SessionLaunchSupport.swift */; };
 		DD6CAD6B87A8D48854446B86 /* extraCommandsDictionary.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7043F325D81EDDF6CE12024E /* extraCommandsDictionary.plist */; };
 		DE64D7B96EA0F50C1D546D44 /* ConversationComposerEntryRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 075CAE1122242626CE33A93F /* ConversationComposerEntryRowView.swift */; };
+		DE7DBCBC040626E9A0EEFAE5 /* ConversationComposerAttachSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56EFBFE7DF8014B177A1F7B9 /* ConversationComposerAttachSheet.swift */; };
 		DE8665F0FCD859C2795D74F0 /* openssl.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2E0AF2EFA47774F167F6D38B /* openssl.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DE96D1BCB62F83DC4DAEB37C /* catppuccin-mocha-Ry8aD-5u.json in Resources */ = {isa = PBXBuildFile; fileRef = D4BBEE5D22A050571A528EF0 /* catppuccin-mocha-Ry8aD-5u.json */; };
 		DEA6917F19B51C79024C052F /* slack-dark.json in Resources */ = {isa = PBXBuildFile; fileRef = 5DF2C84DD77E7A8282AE9831 /* slack-dark.json */; };
@@ -370,6 +376,7 @@
 		EA949A544AB380498924C89C /* gruvbox-light-soft.json in Resources */ = {isa = PBXBuildFile; fileRef = BAC7D83216AF4F0FFA325009 /* gruvbox-light-soft.json */; };
 		EAD20D467654A309CA42FEFA /* PushProxyClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B9830779CEF4EA2F95D85E /* PushProxyClient.swift */; };
 		EBFE2F25D8DE79EEC06C7870 /* absolutely-dark.json in Resources */ = {isa = PBXBuildFile; fileRef = 779157C60F55F38A05F3CD1A /* absolutely-dark.json */; };
+		ECB252BCA3F558822BCED6BC /* ConversationComposerTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75F91259F006987853B6929F /* ConversationComposerTextView.swift */; };
 		ED2D3EEED95B99520754296C /* diagram_types.md in Resources */ = {isa = PBXBuildFile; fileRef = 9F7DE27E2CB2ACF5158BCF99 /* diagram_types.md */; };
 		EDFF1AB0A0E4291A1F84D260 /* everforest-dark.json in Resources */ = {isa = PBXBuildFile; fileRef = 81C9F195FE7B59E6FF611CC4 /* everforest-dark.json */; };
 		EEEBA55C8002EECC829EB3E7 /* github-light.json in Resources */ = {isa = PBXBuildFile; fileRef = 760BBA087DD7F86B27829E23 /* github-light.json */; };
@@ -515,6 +522,7 @@
 		2E0AF2EFA47774F167F6D38B /* openssl.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = openssl.xcframework; path = Frameworks/ios_system/openssl.xcframework; sourceTree = "<group>"; };
 		2FB206863136DF3B8FA50457 /* HomeDashboardSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeDashboardSupport.swift; sourceTree = "<group>"; };
 		318F2F8563E91AB97950F5DA /* DirectoryPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectoryPickerView.swift; sourceTree = "<group>"; };
+		33000D9825376F952524F20C /* ConversationAttachmentSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationAttachmentSupport.swift; sourceTree = "<group>"; };
 		33DE469299079F6EDB067A49 /* gruvbox-dark-hard.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "gruvbox-dark-hard.json"; sourceTree = "<group>"; };
 		34141C0068C950ECBC391996 /* github-light-default.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "github-light-default.json"; sourceTree = "<group>"; };
 		35815D57BE688636CDD27415 /* ConversationComposerContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationComposerContentView.swift; sourceTree = "<group>"; };
@@ -546,6 +554,7 @@
 		55A7968182C0B25044D38C00 /* Litter.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Litter.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		56597C90314B4DF5587C3949 /* ExperimentalFeatures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentalFeatures.swift; sourceTree = "<group>"; };
 		56CF8611EBE489C15696819A /* nord.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = nord.json; sourceTree = "<group>"; };
+		56EFBFE7DF8014B177A1F7B9 /* ConversationComposerAttachSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationComposerAttachSheet.swift; sourceTree = "<group>"; };
 		59B08FFA16CBFD1A93E32980 /* sentry-dark.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "sentry-dark.json"; sourceTree = "<group>"; };
 		5B2CEDF857883B2E36157356 /* gruvbox-dark-medium.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "gruvbox-dark-medium.json"; sourceTree = "<group>"; };
 		5BBD99B498CE5D6A1B9C87F1 /* NetworkDiscoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDiscoveryTests.swift; sourceTree = "<group>"; };
@@ -564,11 +573,13 @@
 		7043F325D81EDDF6CE12024E /* extraCommandsDictionary.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = extraCommandsDictionary.plist; sourceTree = "<group>"; };
 		70AB8E0BCCF3384EE9B4A0BF /* github-light-high-contrast.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "github-light-high-contrast.json"; sourceTree = "<group>"; };
 		728942810EA5AD9DBBD6CAF4 /* lg2.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = lg2.xcframework; path = Frameworks/ios_system/lg2.xcframework; sourceTree = "<group>"; };
+		733401E26505A989A02B291D /* ConversationAttachmentSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationAttachmentSupportTests.swift; sourceTree = "<group>"; };
 		73840201673E0D1EE9E9DEBF /* ServerConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerConnection.swift; sourceTree = "<group>"; };
 		73F81DFBE27A2FE1EB02C1DA /* catppuccin-macchiato.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "catppuccin-macchiato.json"; sourceTree = "<group>"; };
 		74E5DF89D0937E6C17F2BB94 /* brand_logo.svg */ = {isa = PBXFileReference; path = brand_logo.svg; sourceTree = "<group>"; };
 		75448098987C0B15698C8456 /* monokai.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = monokai.json; sourceTree = "<group>"; };
 		754A6F0D26DFBE19A8C6625F /* SSHSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHSessionManager.swift; sourceTree = "<group>"; };
+		75F91259F006987853B6929F /* ConversationComposerTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationComposerTextView.swift; sourceTree = "<group>"; };
 		760BBA087DD7F86B27829E23 /* github-light.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "github-light.json"; sourceTree = "<group>"; };
 		76B9969D2D4C7AA23FC9DB93 /* material-theme-lighter.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "material-theme-lighter.json"; sourceTree = "<group>"; };
 		7779BD02F3B304F9C3AD32A1 /* DiscoveredServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveredServer.swift; sourceTree = "<group>"; };
@@ -853,6 +864,7 @@
 		96523EF86C13A1CBD171F262 /* CodexIOSTests */ = {
 			isa = PBXGroup;
 			children = (
+				733401E26505A989A02B291D /* ConversationAttachmentSupportTests.swift */,
 				B36FEBF9CE861A652C25B7F6 /* ConversationPlanSemanticsTests.swift */,
 				89D9552DC45A94A8F6F33671 /* HomeDashboardSupportTests.swift */,
 				5BBD99B498CE5D6A1B9C87F1 /* NetworkDiscoveryTests.swift */,
@@ -970,6 +982,7 @@
 				125E05AE5CC346C8D2ED2FED /* ChatTypes.swift */,
 				D887FC87082710CC7B75CC8A /* CodexTurnAttributes.swift */,
 				4925417F70C546B80DBD9EFF /* ConnectionTarget.swift */,
+				33000D9825376F952524F20C /* ConversationAttachmentSupport.swift */,
 				FF5635331A74B2D510911B8E /* ConversationItem.swift */,
 				CD02327C52F16587C973B70F /* ConversationWarmupCoordinator.swift */,
 				7779BD02F3B304F9C3AD32A1 /* DiscoveredServer.swift */,
@@ -1003,11 +1016,13 @@
 				C361CBF40ED3D35C44D46880 /* BrandLogo.swift */,
 				EEDF2E1FEDF741D69062FDDD /* CodeBlockView.swift */,
 				D1E96C6677B2AA22A101A29C /* ContextBadgeView.swift */,
+				56EFBFE7DF8014B177A1F7B9 /* ConversationComposerAttachSheet.swift */,
 				35815D57BE688636CDD27415 /* ConversationComposerContentView.swift */,
 				D0D72714D0B3E9209EF907B3 /* ConversationComposerContextBarView.swift */,
 				075CAE1122242626CE33A93F /* ConversationComposerEntryRowView.swift */,
 				ED83627330437842851BBC07 /* ConversationComposerModalCoordinator.swift */,
 				25F1267B79425E5A42068216 /* ConversationComposerPopupOverlayView.swift */,
+				75F91259F006987853B6929F /* ConversationComposerTextView.swift */,
 				C91A1B7B1207FAD81D940DA8 /* ConversationScreenModel.swift */,
 				55700E32058BA95A9372AA41 /* ConversationTimelineView.swift */,
 				BF245554F39E59E68B72EB22 /* ConversationView.swift */,
@@ -1427,6 +1442,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C5F25BE88D32A0FC1FD72449 /* ConversationAttachmentSupportTests.swift in Sources */,
 				49005F651AE38A7F3F3C89F7 /* ConversationPlanSemanticsTests.swift in Sources */,
 				7A803091FAF581F8FD256C2A /* HomeDashboardSupportTests.swift in Sources */,
 				4849926C6A6B218DCEB3AB26 /* NetworkDiscoveryTests.swift in Sources */,
@@ -1465,11 +1481,14 @@
 				E191D8B64FB04973C18E5D9B /* CodexTurnAttributes.swift in Sources */,
 				2F3CAA82F0FC204D70DF24C9 /* ConnectionTarget.swift in Sources */,
 				32A551B31A8F20837476AE02 /* ContextBadgeView.swift in Sources */,
+				0F97D6A5A05056E18594449A /* ConversationAttachmentSupport.swift in Sources */,
+				DE7DBCBC040626E9A0EEFAE5 /* ConversationComposerAttachSheet.swift in Sources */,
 				4A136CF41978B6B528DD34CD /* ConversationComposerContentView.swift in Sources */,
 				B85DEDE81E5FF112F17523DA /* ConversationComposerContextBarView.swift in Sources */,
 				DE64D7B96EA0F50C1D546D44 /* ConversationComposerEntryRowView.swift in Sources */,
 				15A95B9F58C1DAF1CA03165B /* ConversationComposerModalCoordinator.swift in Sources */,
 				52E304985FFE5033A3BB13FD /* ConversationComposerPopupOverlayView.swift in Sources */,
+				ECB252BCA3F558822BCED6BC /* ConversationComposerTextView.swift in Sources */,
 				7B6B4231D489F3640FB2117A /* ConversationItem.swift in Sources */,
 				B9E55FF9587CE7F50F5B07CF /* ConversationScreenModel.swift in Sources */,
 				54251D758A320846C581F274 /* ConversationTimelineView.swift in Sources */,
@@ -1554,11 +1573,14 @@
 				3BEE4213B5E4E91944903E8C /* CodexTurnLiveActivity.swift in Sources */,
 				CDE88674C0C5A1B4C801267E /* ConnectionTarget.swift in Sources */,
 				D41343090B77E348E58FA656 /* ContextBadgeView.swift in Sources */,
+				8C23140CEA84BA8C4DE2BC69 /* ConversationAttachmentSupport.swift in Sources */,
+				85ACC46459DA8D7AF4356246 /* ConversationComposerAttachSheet.swift in Sources */,
 				89324C555E2014AB0DC466B7 /* ConversationComposerContentView.swift in Sources */,
 				980F1458FEEA8970E9F29FCF /* ConversationComposerContextBarView.swift in Sources */,
 				D465AB9C7DB4638C39B534D0 /* ConversationComposerEntryRowView.swift in Sources */,
 				A6FF1F7811A4B6626BD440F5 /* ConversationComposerModalCoordinator.swift in Sources */,
 				F8FA54A11D223E760DD20173 /* ConversationComposerPopupOverlayView.swift in Sources */,
+				2B9DD5A54D6958BFE4369B38 /* ConversationComposerTextView.swift in Sources */,
 				E010B8AEEBFF38A28018121D /* ConversationItem.swift in Sources */,
 				F320C894D7E17636EE4B5535 /* ConversationScreenModel.swift in Sources */,
 				09CF276ECAC507A366D8AC10 /* ConversationTimelineView.swift in Sources */,

--- a/apps/ios/Sources/Litter/Bridge/CodexProtocol.swift
+++ b/apps/ios/Sources/Litter/Bridge/CodexProtocol.swift
@@ -265,7 +265,7 @@ struct UserInput: Encodable {
         case text
         case path
         case name
-        case imageURL = "image_url"
+        case url
     }
 
     init(type: String, text: String? = nil, path: String? = nil, name: String? = nil, imageURL: String? = nil) {
@@ -274,6 +274,17 @@ struct UserInput: Encodable {
         self.path = path
         self.name = name
         self.imageURL = imageURL
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        try container.encodeIfPresent(text, forKey: .text)
+        try container.encodeIfPresent(path, forKey: .path)
+        try container.encodeIfPresent(name, forKey: .name)
+        if type == "image" {
+            try container.encodeIfPresent(imageURL, forKey: .url)
+        }
     }
 }
 

--- a/apps/ios/Sources/Litter/Models/ConversationAttachmentSupport.swift
+++ b/apps/ios/Sources/Litter/Models/ConversationAttachmentSupport.swift
@@ -1,0 +1,60 @@
+import Foundation
+import UIKit
+
+struct PreparedImageAttachment {
+    let data: Data
+    let mimeType: String
+
+    var userInput: UserInput {
+        UserInput(type: "image", imageURL: dataURI)
+    }
+
+    var chatImage: ChatImage {
+        ChatImage(data: data)
+    }
+
+    private var dataURI: String {
+        "data:\(mimeType);base64,\(data.base64EncodedString())"
+    }
+}
+
+enum ConversationAttachmentSupport {
+    static func prepareImage(_ image: UIImage) -> PreparedImageAttachment? {
+        guard let encodedImage = encodedImageData(for: image) else { return nil }
+        return PreparedImageAttachment(data: encodedImage.data, mimeType: encodedImage.mimeType)
+    }
+
+    static func buildTurnInputs(text: String, additionalInput: [UserInput]) -> [UserInput] {
+        var inputs: [UserInput] = []
+        if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            inputs.append(UserInput(type: "text", text: text))
+        }
+        inputs.append(contentsOf: additionalInput)
+        return inputs
+    }
+
+    private static func encodedImageData(for image: UIImage) -> (data: Data, mimeType: String)? {
+        if image.litterHasAlpha, let pngData = image.pngData() {
+            return (pngData, "image/png")
+        }
+        if let jpegData = image.jpegData(compressionQuality: 0.85) {
+            return (jpegData, "image/jpeg")
+        }
+        if let pngData = image.pngData() {
+            return (pngData, "image/png")
+        }
+        return nil
+    }
+}
+
+private extension UIImage {
+    var litterHasAlpha: Bool {
+        guard let alphaInfo = cgImage?.alphaInfo else { return false }
+        switch alphaInfo {
+        case .first, .last, .premultipliedFirst, .premultipliedLast:
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/apps/ios/Sources/Litter/Models/ServerConnection.swift
+++ b/apps/ios/Sources/Litter/Models/ServerConnection.swift
@@ -329,8 +329,14 @@ final class ServerConnection: Identifiable {
         serviceTier: String? = nil,
         additionalInput: [UserInput] = []
     ) async throws -> TurnStartResponse {
-        var inputs: [UserInput] = [UserInput(type: "text", text: text)]
-        inputs.append(contentsOf: additionalInput)
+        let inputs = ConversationAttachmentSupport.buildTurnInputs(text: text, additionalInput: additionalInput)
+        guard !inputs.isEmpty else {
+            throw NSError(
+                domain: "Litter",
+                code: 1020,
+                userInfo: [NSLocalizedDescriptionKey: "Cannot send an empty turn"]
+            )
+        }
         return try await routedSendRequest(
             method: "turn/start",
             params: TurnStartParams(

--- a/apps/ios/Sources/Litter/Models/ServerManager.swift
+++ b/apps/ios/Sources/Litter/Models/ServerManager.swift
@@ -1098,6 +1098,7 @@ final class ServerManager {
 
     func send(
         _ text: String,
+        attachmentImage: UIImage? = nil,
         skillMentions: [SkillMentionSelection] = [],
         cwd: String,
         model: String? = nil,
@@ -1106,6 +1107,10 @@ final class ServerManager {
         approvalPolicy: String = "never",
         sandboxMode: String? = nil
     ) async {
+        let preparedAttachment = attachmentImage.flatMap(ConversationAttachmentSupport.prepareImage)
+        let images = preparedAttachment.map { [$0.chatImage] } ?? []
+        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedText.isEmpty || !images.isEmpty || !skillMentions.isEmpty else { return }
         var key = activeThreadKey
         if key == nil {
             guard let serverId = connections.values.first(where: { $0.isConnected })?.id else { return }
@@ -1127,7 +1132,7 @@ final class ServerManager {
                     serverName: conn?.server.name ?? "Server",
                     serverSource: conn?.server.source ?? .local
                 )
-                state.items.append(makeUserItem(text: text, sourceTurnId: nil, sourceTurnIndex: nil, isBoundary: true))
+                state.items.append(makeUserItem(text: text, images: images, sourceTurnId: nil, sourceTurnIndex: nil, isBoundary: true))
                 state.items.append(makeErrorItem(message: error.localizedDescription, sourceTurnId: nil, sourceTurnIndex: nil))
                 state.status = .error(error.localizedDescription)
                 threads[errorKey] = state
@@ -1137,14 +1142,22 @@ final class ServerManager {
         }
         guard let key, let thread = threads[key], let conn = connections[key.serverId] else { return }
         let nextTurnIndex = threadTurnCounts[key] ?? inferredTurnCount(from: thread.items)
-        thread.items.append(makeUserItem(text: text, sourceTurnId: nil, sourceTurnIndex: nextTurnIndex, isBoundary: true))
+        thread.items.append(makeUserItem(text: text, images: images, sourceTurnId: nil, sourceTurnIndex: nextTurnIndex, isBoundary: true))
         thread.status = .thinking
         thread.updatedAt = Date()
         requestNotificationPermissionIfNeeded()
-        startLiveActivity(key: key, model: thread.model, cwd: thread.cwd, prompt: text)
+        startLiveActivity(
+            key: key,
+            model: thread.model,
+            cwd: thread.cwd,
+            prompt: !trimmedText.isEmpty ? text : (!images.isEmpty ? "Shared image" : text)
+        )
         do {
-            let skillInputs = skillMentions.map { mention in
+            var additionalInputs = skillMentions.map { mention in
                 UserInput(type: "skill", path: mention.path, name: mention.name)
+            }
+            if let preparedAttachment {
+                additionalInputs.append(preparedAttachment.userInput)
             }
             let resp = try await conn.sendTurn(
                 threadId: key.threadId,
@@ -1154,7 +1167,7 @@ final class ServerManager {
                 model: model,
                 effort: effort,
                 serviceTier: serviceTier,
-                additionalInput: skillInputs
+                additionalInput: additionalInputs
             )
             NSLog("[send] sendTurn succeeded, turnId=%@", resp.turnId ?? "nil")
             thread.activeTurnId = resp.turnId

--- a/apps/ios/Sources/Litter/Views/ConversationComposerAttachSheet.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationComposerAttachSheet.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+struct ConversationComposerAttachSheet: View {
+    let onPickPhotoLibrary: () -> Void
+    let onTakePhoto: () -> Void
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Text("Attach")
+                .litterFont(.headline, weight: .semibold)
+                .foregroundColor(LitterTheme.textPrimary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            Button(action: onPickPhotoLibrary) {
+                sheetButtonLabel("Photo Library", systemImage: "photo.on.rectangle")
+            }
+
+            Button(action: onTakePhoto) {
+                sheetButtonLabel("Take Photo", systemImage: "camera")
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 12)
+        .padding(.bottom, 20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .background(LitterTheme.backgroundGradient.ignoresSafeArea())
+    }
+
+    @ViewBuilder
+    private func sheetButtonLabel(_ title: String, systemImage: String) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: systemImage)
+                .litterFont(.body, weight: .medium)
+                .foregroundColor(LitterTheme.accent)
+                .frame(width: 20)
+
+            Text(title)
+                .litterFont(.body, weight: .medium)
+                .foregroundColor(LitterTheme.textPrimary)
+
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .frame(height: 52)
+        .modifier(GlassRoundedRectModifier(cornerRadius: 18))
+    }
+}

--- a/apps/ios/Sources/Litter/Views/ConversationComposerContentView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationComposerContentView.swift
@@ -8,15 +8,16 @@ struct ConversationComposerContentView: View {
     let contextPercent: Int64?
     let isTurnActive: Bool
     let voiceManager: VoiceTranscriptionManager
+    @Binding var showAttachMenu: Bool
     let onClearAttachment: () -> Void
     let onRespondToPendingUserInput: ([String: [String]]) -> Void
-    let onShowAttachMenu: () -> Void
+    let onPasteImage: (UIImage) -> Void
     let onSendText: () -> Void
     let onStopRecording: () -> Void
     let onStartRecording: () -> Void
     let onInterrupt: () -> Void
     @Binding var inputText: String
-    let isComposerFocused: FocusState<Bool>.Binding
+    @Binding var isComposerFocused: Bool
 
     var body: some View {
         VStack(spacing: 0) {
@@ -52,11 +53,13 @@ struct ConversationComposerContentView: View {
                 }
 
                 ConversationComposerEntryRowView(
+                    showAttachMenu: $showAttachMenu,
                     inputText: $inputText,
-                    isComposerFocused: isComposerFocused,
+                    isComposerFocused: $isComposerFocused,
                     voiceManager: voiceManager,
                     isTurnActive: isTurnActive,
-                    onShowAttachMenu: onShowAttachMenu,
+                    hasAttachment: attachedImage != nil,
+                    onPasteImage: onPasteImage,
                     onSendText: onSendText,
                     onStopRecording: onStopRecording,
                     onStartRecording: onStartRecording,

--- a/apps/ios/Sources/Litter/Views/ConversationComposerEntryRowView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationComposerEntryRowView.swift
@@ -1,11 +1,14 @@
 import SwiftUI
+import UIKit
 
 struct ConversationComposerEntryRowView: View {
+    @Binding var showAttachMenu: Bool
     @Binding var inputText: String
-    let isComposerFocused: FocusState<Bool>.Binding
+    @Binding var isComposerFocused: Bool
     let voiceManager: VoiceTranscriptionManager
     let isTurnActive: Bool
-    let onShowAttachMenu: () -> Void
+    let hasAttachment: Bool
+    let onPasteImage: (UIImage) -> Void
     let onSendText: () -> Void
     let onStopRecording: () -> Void
     let onStartRecording: () -> Void
@@ -15,10 +18,16 @@ struct ConversationComposerEntryRowView: View {
         !inputText.trimmingCharacters(in: .whitespaces).isEmpty
     }
 
+    private var canSend: Bool {
+        hasText || hasAttachment
+    }
+
     var body: some View {
         HStack(alignment: .center, spacing: 8) {
             if !voiceManager.isRecording && !voiceManager.isTranscribing && !isTurnActive {
-                Button(action: onShowAttachMenu) {
+                Button {
+                    showAttachMenu = true
+                } label: {
                     Image(systemName: "plus")
                         .litterFont(.body, weight: .semibold)
                         .foregroundColor(LitterTheme.textPrimary)
@@ -29,17 +38,24 @@ struct ConversationComposerEntryRowView: View {
             }
 
             HStack(spacing: 0) {
-                TextField("Message litter...", text: $inputText, axis: .vertical)
-                    .litterFont(.body)
-                    .foregroundColor(LitterTheme.textPrimary)
-                    .lineLimit(1...5)
-                    .focused(isComposerFocused)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled(true)
-                    .padding(.leading, 16)
-                    .padding(.vertical, 10)
+                ZStack(alignment: .topLeading) {
+                    ConversationComposerTextView(
+                        text: $inputText,
+                        isFocused: $isComposerFocused,
+                        onPasteImage: onPasteImage
+                    )
 
-                if hasText {
+                    if inputText.isEmpty {
+                        Text("Message litter...")
+                            .litterFont(.body)
+                            .foregroundColor(LitterTheme.textMuted)
+                            .padding(.leading, 16)
+                            .padding(.top, 10)
+                            .allowsHitTesting(false)
+                    }
+                }
+
+                if canSend {
                     Button(action: onSendText) {
                         Image(systemName: "arrow.up.circle.fill")
                             .litterFont(.title2)

--- a/apps/ios/Sources/Litter/Views/ConversationComposerModalCoordinator.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationComposerModalCoordinator.swift
@@ -61,9 +61,19 @@ struct ConversationComposerModalCoordinator<Content: View>: View {
 
     var body: some View {
         content
-            .confirmationDialog("Attach", isPresented: $showAttachMenu) {
-                Button("Photo Library") { showPhotoPicker = true }
-                Button("Take Photo") { showCamera = true }
+            .sheet(isPresented: $showAttachMenu) {
+                ConversationComposerAttachSheet(
+                    onPickPhotoLibrary: {
+                        showAttachMenu = false
+                        showPhotoPicker = true
+                    },
+                    onTakePhoto: {
+                        showAttachMenu = false
+                        showCamera = true
+                    }
+                )
+                .presentationDetents([.height(210)])
+                .presentationDragIndicator(.visible)
             }
             .photosPicker(isPresented: $showPhotoPicker, selection: $selectedPhoto, matching: .images)
             .onChange(of: selectedPhoto) { _, item in

--- a/apps/ios/Sources/Litter/Views/ConversationComposerTextView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationComposerTextView.swift
@@ -1,0 +1,158 @@
+import SwiftUI
+import UIKit
+
+struct ConversationComposerTextView: UIViewRepresentable {
+    @Binding var text: String
+    @Binding var isFocused: Bool
+    let onPasteImage: (UIImage) -> Void
+
+    @Environment(\.textScale) private var textScale
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeUIView(context: Context) -> PasteAwareComposerUITextView {
+        let textView = PasteAwareComposerUITextView()
+        textView.delegate = context.coordinator
+        textView.backgroundColor = .clear
+        textView.tintColor = UIColor(LitterTheme.accent)
+        textView.textContainerInset = UIEdgeInsets(top: 10, left: 16, bottom: 10, right: 12)
+        textView.textContainer.lineFragmentPadding = 0
+        textView.autocorrectionType = .no
+        textView.autocapitalizationType = .none
+        textView.spellCheckingType = .no
+        textView.keyboardDismissMode = .interactive
+        textView.showsVerticalScrollIndicator = false
+        textView.alwaysBounceVertical = false
+        textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        textView.onPasteImage = onPasteImage
+        textView.text = text
+        context.coordinator.applyStyling(to: textView, textScale: textScale)
+        context.coordinator.updateScrollState(for: textView)
+        return textView
+    }
+
+    func updateUIView(_ uiView: PasteAwareComposerUITextView, context: Context) {
+        context.coordinator.parent = self
+        uiView.onPasteImage = onPasteImage
+        context.coordinator.applyStyling(to: uiView, textScale: textScale)
+
+        if uiView.text != text, uiView.markedTextRange == nil {
+            context.coordinator.isSynchronizingText = true
+            uiView.text = text
+            context.coordinator.isSynchronizingText = false
+        }
+
+        context.coordinator.updateScrollState(for: uiView)
+        context.coordinator.syncFocus(for: uiView)
+    }
+
+    func sizeThatFits(_ proposal: ProposedViewSize, uiView: PasteAwareComposerUITextView, context: Context) -> CGSize? {
+        let width = proposal.width ?? uiView.bounds.width
+        guard width > 0 else { return nil }
+
+        let fittingSize = uiView.sizeThatFits(
+            CGSize(width: width, height: .greatestFiniteMagnitude)
+        )
+        let clampedHeight = min(
+            max(fittingSize.height, context.coordinator.minimumHeight(for: uiView)),
+            context.coordinator.maximumHeight(for: uiView)
+        )
+        return CGSize(width: width, height: clampedHeight)
+    }
+
+    final class Coordinator: NSObject, UITextViewDelegate {
+        var parent: ConversationComposerTextView
+        var isSynchronizingText = false
+
+        init(_ parent: ConversationComposerTextView) {
+            self.parent = parent
+        }
+
+        func textViewDidBeginEditing(_ textView: UITextView) {
+            if !parent.isFocused {
+                parent.isFocused = true
+            }
+        }
+
+        func textViewDidEndEditing(_ textView: UITextView) {
+            if parent.isFocused {
+                parent.isFocused = false
+            }
+        }
+
+        func textViewDidChange(_ textView: UITextView) {
+            guard !isSynchronizingText else { return }
+            let updatedText = textView.text ?? ""
+            if parent.text != updatedText {
+                parent.text = updatedText
+            }
+            updateScrollState(for: textView)
+        }
+
+        func syncFocus(for textView: UITextView) {
+            let requestedFocus = parent.isFocused
+            if requestedFocus {
+                if textView.window != nil, !textView.isFirstResponder {
+                    textView.becomeFirstResponder()
+                }
+            } else if textView.isFirstResponder {
+                textView.resignFirstResponder()
+            }
+        }
+
+        func applyStyling(to textView: UITextView, textScale: CGFloat) {
+            textView.font = composerFont(textScale: textScale)
+            textView.textColor = UIColor(LitterTheme.textPrimary)
+        }
+
+        func updateScrollState(for textView: UITextView) {
+            let availableWidth = max(textView.bounds.width, 1)
+            let fittingHeight = textView.sizeThatFits(
+                CGSize(width: availableWidth, height: .greatestFiniteMagnitude)
+            ).height
+            let shouldScroll = fittingHeight > maximumHeight(for: textView) + 0.5
+            if textView.isScrollEnabled != shouldScroll {
+                textView.isScrollEnabled = shouldScroll
+            }
+        }
+
+        func minimumHeight(for textView: UITextView) -> CGFloat {
+            let lineHeight = textView.font?.lineHeight ?? UIFont.preferredFont(forTextStyle: .body).lineHeight
+            return ceil(lineHeight + textView.textContainerInset.top + textView.textContainerInset.bottom)
+        }
+
+        func maximumHeight(for textView: UITextView) -> CGFloat {
+            let lineHeight = textView.font?.lineHeight ?? UIFont.preferredFont(forTextStyle: .body).lineHeight
+            return ceil((lineHeight * 5) + textView.textContainerInset.top + textView.textContainerInset.bottom)
+        }
+
+        private func composerFont(textScale: CGFloat) -> UIFont {
+            let pointSize = UIFont.preferredFont(forTextStyle: .body).pointSize * textScale
+            if LitterFont.storedFamily.isMono {
+                return LitterFont.uiMonoFont(size: pointSize)
+            }
+            return UIFont.systemFont(ofSize: pointSize)
+        }
+    }
+}
+
+final class PasteAwareComposerUITextView: UITextView {
+    var onPasteImage: ((UIImage) -> Void)?
+
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        if action == #selector(paste(_:)), UIPasteboard.general.hasImages {
+            return true
+        }
+        return super.canPerformAction(action, withSender: sender)
+    }
+
+    override func paste(_ sender: Any?) {
+        if let image = UIPasteboard.general.image {
+            onPasteImage?(image)
+            return
+        }
+        super.paste(sender)
+    }
+}

--- a/apps/ios/Sources/Litter/Views/ConversationView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationView.swift
@@ -124,10 +124,11 @@ struct ConversationView: View {
         .enableInjection()
     }
 
-    private func sendMessage(_ text: String, skillMentions: [SkillMentionSelection]) {
+    private func sendMessage(_ text: String, attachmentImage: UIImage?, skillMentions: [SkillMentionSelection]) {
         Task {
             await serverManager.send(
                 text,
+                attachmentImage: attachmentImage,
                 skillMentions: skillMentions,
                 cwd: workDir,
                 model: pendingModelOverride,
@@ -210,7 +211,7 @@ private struct ConversationBottomChrome: View {
     let composer: ConversationComposerSnapshot
     let connection: ServerConnection
     let serverManager: ServerManager
-    let onSend: (String, [SkillMentionSelection]) -> Void
+    let onSend: (String, UIImage?, [SkillMentionSelection]) -> Void
     let onFileSearch: (String) async throws -> [FuzzyFileSearchResult]
     var bottomInset: CGFloat = 0
     let onOpenConversation: ((ThreadKey) -> Void)?
@@ -1048,7 +1049,7 @@ private struct ConversationInputBar: View {
     let serverManager: ServerManager
     @AppStorage("workDir") private var workDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?.path ?? "/"
 
-    let onSend: (String, [SkillMentionSelection]) -> Void
+    let onSend: (String, UIImage?, [SkillMentionSelection]) -> Void
     let onFileSearch: (String) async throws -> [FuzzyFileSearchResult]
     var bottomInset: CGFloat = 0
     let onOpenConversation: ((ThreadKey) -> Void)?
@@ -1091,7 +1092,7 @@ private struct ConversationInputBar: View {
     @State private var showMicPermissionAlert = false
     @State private var hasLoggedFirstFocus = false
     @State private var hasLoggedKeyboardShown = false
-    @FocusState private var isComposerFocused: Bool
+    @State private var isComposerFocused = false
 
     private var pendingUserInputRequest: ServerManager.PendingUserInputRequest? {
         snapshot.pendingUserInputRequest
@@ -1193,9 +1194,10 @@ private struct ConversationInputBar: View {
             contextPercent: contextPercent(),
             isTurnActive: isTurnActive,
             voiceManager: voiceManager,
+            showAttachMenu: $showAttachMenu,
             onClearAttachment: clearAttachment,
             onRespondToPendingUserInput: respondToPendingUserInput,
-            onShowAttachMenu: { showAttachMenu = true },
+            onPasteImage: { image in attachedImage = image },
             onSendText: handleSend,
             onStopRecording: stopVoiceRecording,
             onStartRecording: startVoiceRecording,
@@ -1239,8 +1241,9 @@ private struct ConversationInputBar: View {
 
     private func handleSend() {
         let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty else { return }
-        if attachedImage == nil,
+        let image = attachedImage
+        guard !text.isEmpty || image != nil else { return }
+        if image == nil,
            let invocation = parseSlashCommandInvocation(text) {
             inputText = ""
             attachedImage = nil
@@ -1254,7 +1257,7 @@ private struct ConversationInputBar: View {
         hideComposerPopups()
         isComposerFocused = false
         let skillMentions = collectSkillMentionsForSubmission(text)
-        onSend(text, skillMentions)
+        onSend(text, image, skillMentions)
     }
 
     private func startVoiceRecording() {

--- a/apps/ios/Sources/Litter/Views/ConversationWarmupView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationWarmupView.swift
@@ -14,17 +14,20 @@ struct ConversationWarmupView: View {
     @State private var warmupInputText = ""
     @State private var shouldPrimeKeyboard = false
     @State private var didCompleteWarmup = false
-    @FocusState private var warmupComposerFocused: Bool
+    @State private var warmupComposerFocused = false
+    @State private var warmupShowAttachMenu = false
     @State private var voiceManager = VoiceTranscriptionManager()
 
     var body: some View {
         ZStack {
             ConversationComposerEntryRowView(
+                showAttachMenu: $warmupShowAttachMenu,
                 inputText: $warmupInputText,
                 isComposerFocused: $warmupComposerFocused,
                 voiceManager: voiceManager,
                 isTurnActive: false,
-                onShowAttachMenu: {},
+                hasAttachment: false,
+                onPasteImage: { _ in },
                 onSendText: {},
                 onStopRecording: {},
                 onStartRecording: {},

--- a/apps/ios/Tests/CodexIOSTests/ConversationAttachmentSupportTests.swift
+++ b/apps/ios/Tests/CodexIOSTests/ConversationAttachmentSupportTests.swift
@@ -1,0 +1,57 @@
+import UIKit
+import XCTest
+@testable import Litter
+
+final class ConversationAttachmentSupportTests: XCTestCase {
+    func testBuildTurnInputsOmitsWhitespaceOnlyTextAndKeepsAttachmentInput() {
+        let attachment = UserInput(type: "image", imageURL: "data:image/png;base64,abc")
+
+        let inputs = ConversationAttachmentSupport.buildTurnInputs(
+            text: "   \n",
+            additionalInput: [attachment]
+        )
+
+        XCTAssertEqual(inputs.count, 1)
+        XCTAssertEqual(inputs.first?.type, "image")
+        XCTAssertEqual(inputs.first?.imageURL, "data:image/png;base64,abc")
+    }
+
+    func testImageUserInputEncodesURLForTurnStartProtocol() throws {
+        let attachment = UserInput(type: "image", imageURL: "data:image/png;base64,abc")
+
+        let data = try JSONEncoder().encode(attachment)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: String])
+
+        XCTAssertEqual(json["type"], "image")
+        XCTAssertEqual(json["url"], "data:image/png;base64,abc")
+        XCTAssertNil(json["image_url"])
+    }
+
+    func testPrepareImageUsesPNGWhenImageHasTransparency() {
+        let image = UIGraphicsImageRenderer(size: CGSize(width: 4, height: 4)).image { context in
+            UIColor.clear.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 4, height: 4))
+            UIColor.systemGreen.setFill()
+            context.fill(CGRect(x: 1, y: 1, width: 2, height: 2))
+        }
+
+        let attachment = ConversationAttachmentSupport.prepareImage(image)
+
+        XCTAssertEqual(attachment?.mimeType, "image/png")
+        XCTAssertNotNil(attachment?.data)
+    }
+
+    func testPrepareImageUsesJPEGWhenImageIsOpaque() {
+        let format = UIGraphicsImageRendererFormat()
+        format.opaque = true
+        let image = UIGraphicsImageRenderer(size: CGSize(width: 4, height: 4), format: format).image { context in
+            UIColor.systemBlue.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 4, height: 4))
+        }
+
+        let attachment = ConversationAttachmentSupport.prepareImage(image)
+
+        XCTAssertEqual(attachment?.mimeType, "image/jpeg")
+        XCTAssertNotNil(attachment?.data)
+    }
+}


### PR DESCRIPTION
## Summary
- include attached images in outgoing `turn/start` input and use the current `url` image payload field
- route pasted images through the same attachment path and allow image-only sends
- replace the centered attach dialog with a dedicated attach sheet and keep composer focus owned by the UIKit text view

## Verification
- `cd apps/ios && xcodegen generate --spec project.yml`
- `xcodebuild -project apps/ios/Litter.xcodeproj -scheme Litter -derivedDataPath /tmp/codex-ios-pr-sim2 -destination 'id=6CF1782A-FBE3-49ED-A0AC-C9E7FEA07A8C' build`
- `xcodebuild -project apps/ios/Litter.xcodeproj -scheme Litter -derivedDataPath /tmp/codex-ios-pr-test3 -destination 'id=6CF1782A-FBE3-49ED-A0AC-C9E7FEA07A8C' -only-testing:CodexIOSTests/ConversationAttachmentSupportTests test` *(fails in unrelated existing `PerformanceHelpersTests.swift` because `MessageRenderCache.markdownEntryCount` is missing)*

## Notes
- the clean worktree needed the locally available `apps/ios/Frameworks` artifacts present to run simulator validation