### PR TITLE
fix: stop Live Activity timer when session completes in background

### DIFF
--- a/apps/ios/Sources/Litter/Models/ServerManager.swift
+++ b/apps/ios/Sources/Litter/Models/ServerManager.swift
@@ -3760,6 +3760,8 @@ final class ServerManager {
     private func updateLiveActivityBGWake(key: ThreadKey) {
         guard let activity = liveActivities[key] else { return }
         let thread = threads[key]
+        // If session already completed, don't update — let endLiveActivity's dismissal finish
+        guard thread?.hasTurnActive == true else { return }
         let elapsed = Int(Date().timeIntervalSince(liveActivityStartDates[key] ?? Date()))
 
         let toolCount = liveActivityToolCallCounts[key, default: 0]


### PR DESCRIPTION
## What

Session cards on the home screen kept counting the elapsed timer indefinitely after a turn completed, if the app was backgrounded during or shortly after completion.

## Why

`updateLiveActivityBGWake` is called when a push notification wakes the app from background. It recalculates `elapsed` from `liveActivityStartDates[key]` — but `endLiveActivity` already clears that entry when the session finishes. The fallback `?? Date()` resets the reference point to now, and since the Live Activity hasn't dismissed yet (it has a 4s delay), it gets updated with a fresh counter, making the timer appear to restart and run forever.

## Fix

One guard added in `updateLiveActivityBGWake` — return early if `hasTurnActive == false`. Completed sessions are left alone; `endLiveActivity`'s existing dismissal logic handles cleanup.

```swift
guard thread?.hasTurnActive == true else { return }
```

## Verification

1. Start a session on a remote server
2. Background the app while the session is running
3. Wait for the session to complete
4. Return to the app — timer should show the final elapsed time, not a running counter

## Changes

- `apps/ios/Sources/Litter/Models/ServerManager.swift` — 2 lines (1 guard + 1 comment)