### PR TITLE
mobile: fix runtime parity and automate releases

### DIFF
--- a/.github/workflows/android-play-release.yml
+++ b/.github/workflows/android-play-release.yml
@@ -1,0 +1,141 @@
+name: Android Play Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - Makefile
+      - .github/workflows/android-play-release.yml
+      - apps/android/**
+      - shared/rust-bridge/**
+      - patches/codex/**
+      - tools/scripts/build-android-rust.sh
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  play-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    environment: release
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Validate required secrets
+        env:
+          ANDROID_UPLOAD_KEYSTORE_B64: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_B64 }}
+          LITTER_UPLOAD_STORE_PASSWORD: ${{ secrets.LITTER_UPLOAD_STORE_PASSWORD }}
+          LITTER_UPLOAD_KEY_ALIAS: ${{ secrets.LITTER_UPLOAD_KEY_ALIAS }}
+          LITTER_UPLOAD_KEY_PASSWORD: ${{ secrets.LITTER_UPLOAD_KEY_PASSWORD }}
+          LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64: ${{ secrets.LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64 }}
+        run: |
+          set -euo pipefail
+          required=(
+            ANDROID_UPLOAD_KEYSTORE_B64
+            LITTER_UPLOAD_STORE_PASSWORD
+            LITTER_UPLOAD_KEY_ALIAS
+            LITTER_UPLOAD_KEY_PASSWORD
+            LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64
+          )
+          for name in "${required[@]}"; do
+            if [[ -z "${!name:-}" ]]; then
+              echo "Missing required secret: $name" >&2
+              exit 1
+            fi
+          done
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android platforms and NDK
+        run: |
+          yes | sdkmanager --licenses
+          sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0" "ndk;30.0.14904198"
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+        env:
+          SCCACHE_BUCKET: rust-cache
+          SCCACHE_ENDPOINT: ${{ secrets.SCCACHE_R2_ENDPOINT }}
+          SCCACHE_REGION: auto
+          SCCACHE_S3_USE_SSL: "true"
+          SCCACHE_S3_KEY_PREFIX: ci/android
+          AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
+
+      - name: Install cargo-ndk
+        run: cargo install cargo-ndk
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Decode release credentials
+        env:
+          ANDROID_UPLOAD_KEYSTORE_B64: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_B64 }}
+          LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64: ${{ secrets.LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64 }}
+        run: |
+          set -euo pipefail
+          echo "$ANDROID_UPLOAD_KEYSTORE_B64" | base64 --decode > "$RUNNER_TEMP/litter-upload.jks"
+          echo "$LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64" | base64 --decode > "$RUNNER_TEMP/play-service-account.json"
+          ls -lh "$RUNNER_TEMP/litter-upload.jks" "$RUNNER_TEMP/play-service-account.json"
+
+      - name: Resolve Android release inputs
+        env:
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          set -euo pipefail
+          VERSION_CODE="$((200000000 + GITHUB_RUN_NUMBER))"
+          echo "LITTER_VERSION_CODE_OVERRIDE=$VERSION_CODE" >> "$GITHUB_ENV"
+
+      - name: Publish to Google Play
+        env:
+          JAVA_HOME: ${{ env.JAVA_HOME }}
+          ANDROID_SDK_ROOT: ${{ env.ANDROID_HOME }}
+          ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/30.0.14904198
+          RUSTC_WRAPPER: sccache
+          LITTER_UPLOAD_STORE_FILE: ${{ runner.temp }}/litter-upload.jks
+          LITTER_UPLOAD_STORE_PASSWORD: ${{ secrets.LITTER_UPLOAD_STORE_PASSWORD }}
+          LITTER_UPLOAD_KEY_ALIAS: ${{ secrets.LITTER_UPLOAD_KEY_ALIAS }}
+          LITTER_UPLOAD_KEY_PASSWORD: ${{ secrets.LITTER_UPLOAD_KEY_PASSWORD }}
+          LITTER_PLAY_SERVICE_ACCOUNT_JSON: ${{ runner.temp }}/play-service-account.json
+          LITTER_PLAY_TRACK: internal
+          LITTER_VERSION_CODE_OVERRIDE: ${{ env.LITTER_VERSION_CODE_OVERRIDE }}
+        run: make play-release
+
+      - name: Generate checksums
+        run: |
+          set -euo pipefail
+          APK_PATH="apps/android/app/build/outputs/apk/release/app-release.apk"
+          AAB_PATH="apps/android/app/build/outputs/bundle/release/app-release.aab"
+          sha256sum "$APK_PATH" > "${APK_PATH}.sha256"
+          sha256sum "$AAB_PATH" > "${AAB_PATH}.sha256"
+
+      - name: Upload Android release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-play-release-${{ github.run_number }}
+          if-no-files-found: error
+          path: |
+            apps/android/app/build/outputs/apk/release/app-release.apk
+            apps/android/app/build/outputs/apk/release/app-release.apk.sha256
+            apps/android/app/build/outputs/bundle/release/app-release.aab
+            apps/android/app/build/outputs/bundle/release/app-release.aab.sha256

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -2,26 +2,20 @@ name: iOS TestFlight Release
 
 on:
   push:
-    tags:
-      - "v*"
+    branches:
+      - main
+    paths:
+      - Makefile
+      - .github/workflows/ios-testflight.yml
+      - apps/ios/**
+      - shared/rust-bridge/**
+      - patches/codex/**
   workflow_dispatch:
     inputs:
-      scheme:
-        description: "Xcode scheme to archive"
-        required: true
-        default: "Litter"
-        type: choice
-        options:
-          - Litter
-      app_bundle_id:
-        description: "App bundle identifier"
-        required: true
-        default: "com.sigkitten.litter"
-        type: string
-      beta_group_name:
-        description: "TestFlight beta group"
+      beta_group_names:
+        description: "Comma-separated TestFlight beta groups"
         required: false
-        default: "Internal Testers"
+        default: "Internal Testers,External Testers"
         type: string
       wait_for_processing:
         description: "Wait for ASC processing before finishing"
@@ -33,47 +27,7 @@ permissions:
   contents: read
 
 jobs:
-  detect-ios-changes:
-    runs-on: macos-15
-    outputs:
-      run_release: ${{ steps.filter.outputs.run_release }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-
-      - name: Detect iOS-related changes
-        id: filter
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            echo "run_release=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          changed_files="$(git diff-tree --no-commit-id --name-only -r "$GITHUB_SHA" || true)"
-          echo "Changed files:"
-          echo "$changed_files"
-
-          run_release=false
-          while IFS= read -r file; do
-            [[ -z "$file" ]] && continue
-            case "$file" in
-              apps/ios/*|shared/rust-bridge/*|patches/codex/*|.github/workflows/ios-testflight.yml|.github/workflows/ios.yml)
-                run_release=true
-                break
-                ;;
-            esac
-          done <<< "$changed_files"
-
-          echo "run_release=$run_release" >> "$GITHUB_OUTPUT"
-
   upload-testflight:
-    needs: detect-ios-changes
-    if: needs.detect-ios-changes.outputs.run_release == 'true'
     runs-on: macos-15
     timeout-minutes: 90
     environment: release
@@ -185,40 +139,32 @@ jobs:
         run: |
           set -euo pipefail
 
+          SCHEME="Litter"
+          APP_BUNDLE_ID="com.sigkitten.litter"
+          MARKETING_VERSION="1.0.1"
+
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            SCHEME="${{ inputs.scheme }}"
-            APP_BUNDLE_ID="${{ inputs.app_bundle_id }}"
-            BETA_GROUP_NAME="${{ inputs.beta_group_name }}"
+            BETA_GROUP_NAMES="${{ inputs.beta_group_names }}"
             if [[ "${{ inputs.wait_for_processing }}" == "true" ]]; then
               WAIT_FOR_PROCESSING="1"
             else
               WAIT_FOR_PROCESSING="0"
             fi
           else
-            SCHEME="Litter"
-            APP_BUNDLE_ID="com.sigkitten.litter"
-            BETA_GROUP_NAME="Internal Testers"
+            BETA_GROUP_NAMES="Internal Testers,External Testers"
             WAIT_FOR_PROCESSING="1"
           fi
-
-          MARKETING_VERSION="1.0.1"
 
           echo "SCHEME=$SCHEME" >> "$GITHUB_ENV"
           echo "APP_BUNDLE_ID=$APP_BUNDLE_ID" >> "$GITHUB_ENV"
           echo "MARKETING_VERSION=$MARKETING_VERSION" >> "$GITHUB_ENV"
-          echo "BETA_GROUP_NAME=$BETA_GROUP_NAME" >> "$GITHUB_ENV"
+          echo "BETA_GROUP_NAMES=$BETA_GROUP_NAMES" >> "$GITHUB_ENV"
           echo "WAIT_FOR_PROCESSING=$WAIT_FOR_PROCESSING" >> "$GITHUB_ENV"
-
-      - name: Build required iOS frameworks
-        env:
-          RUSTC_WRAPPER: sccache
-        run: |
-          set -euo pipefail
-          ./apps/ios/scripts/download-ios-system.sh
-          ./apps/ios/scripts/build-rust.sh
 
       - name: Upload to TestFlight
         env:
+          RUSTC_WRAPPER: sccache
+          SCHEME: ${{ env.SCHEME }}
           APP_BUNDLE_ID: ${{ env.APP_BUNDLE_ID }}
           APP_STORE_APP_ID: ${{ secrets.IOS_APP_STORE_APP_ID }}
           TEAM_ID: ${{ secrets.IOS_TEAM_ID }}
@@ -226,8 +172,7 @@ jobs:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
           ASC_PRIVATE_KEY_PATH: ${{ env.ASC_PRIVATE_KEY_PATH }}
-          SCHEME: ${{ env.SCHEME }}
           MARKETING_VERSION: ${{ env.MARKETING_VERSION }}
-          BETA_GROUP_NAME: ${{ env.BETA_GROUP_NAME }}
+          BETA_GROUP_NAMES: ${{ env.BETA_GROUP_NAMES }}
           WAIT_FOR_PROCESSING: ${{ env.WAIT_FOR_PROCESSING }}
-        run: ./apps/ios/scripts/testflight-upload.sh
+        run: make testflight

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ $(shell mkdir -p $(STAMPS))
 	sync patch unpatch xcgen ios-frameworks \
 	ios-build ios-build-sim ios-build-sim-fast ios-build-device ios-build-device-fast \
 	test test-rust test-ios test-android \
-	testflight play-upload \
+	testflight play-upload play-release \
 	clean clean-rust clean-ios clean-android \
 	rebuild-bindings tui tui-run help
 
@@ -175,8 +175,11 @@ android-device-run: android-fast
 	} && \
 	adb -s "$$DEVICE" shell am start -n $(ANDROID_PACKAGE)/$(ANDROID_ACTIVITY)
 
-android-release:
-	@$(MAKE) android-fast ANDROID_RUST_PROFILE=release ANDROID_ABIS="$(ANDROID_RELEASE_ABIS)"
+android-release: ANDROID_RUST_PROFILE=release
+android-release: ANDROID_ABIS=$(ANDROID_RELEASE_ABIS)
+android-release: rust-android
+	@echo "==> Building Android release..."
+	@cd $(ANDROID_DIR) && $(ANDROID_ENV) ./gradlew :app:assembleRelease
 
 rust-ios: rust-ios-package
 
@@ -380,11 +383,19 @@ test-android:
 
 testflight: ios
 	@echo "==> Uploading to TestFlight..."
-	@$(IOS_SCRIPTS)/testflight-upload.sh
+	@MARKETING_VERSION=1.0.1 $(IOS_SCRIPTS)/testflight-upload.sh
 
 play-upload: android-release
 	@echo "==> Uploading to Google Play..."
 	@$(ANDROID_DIR)/scripts/play-upload.sh
+
+play-release:
+	@if [ -n "$$LITTER_VERSION_CODE_OVERRIDE" ]; then \
+		echo "==> Using overridden Android versionCode $$LITTER_VERSION_CODE_OVERRIDE"; \
+	else \
+		$(ANDROID_DIR)/scripts/bump-version.sh; \
+	fi
+	@$(MAKE) play-upload
 
 clean: clean-rust clean-ios clean-android
 	@rm -rf $(STAMPS)

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
         applicationId = "com.sigkitten.litter.android"
         minSdk = 26
         targetSdk = 35
-        versionCode = 7
+        versionCode = 8
         versionName = "0.1.0"
         buildConfigField("boolean", "ENABLE_ON_DEVICE_BRIDGE", "true")
         buildConfigField("String", "RUNTIME_STARTUP_MODE", "\"hybrid\"")

--- a/apps/android/app/src/main/java/com/litter/android/state/AppLifecycleController.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/AppLifecycleController.kt
@@ -1,7 +1,7 @@
 package com.litter.android.state
 
 import android.content.Context
-import android.util.Log
+import com.litter.android.util.LLog
 import kotlinx.coroutines.sync.Mutex
 import uniffi.codex_mobile_client.ThreadKey
 import uniffi.codex_mobile_client.AppServerHealth
@@ -29,7 +29,7 @@ class AppLifecycleController {
      */
     suspend fun reconnectSavedServers(context: Context, appModel: AppModel) {
         if (!reconnectMutex.tryLock()) {
-            Log.d("AppLifecycleController", "reconnect already in progress; skipping")
+            LLog.t("AppLifecycleController", "reconnect already in progress; skipping")
             return
         }
         try {
@@ -41,7 +41,11 @@ class AppLifecycleController {
                 .mapTo(mutableSetOf()) { it.serverId }
             for (server in saved) {
                 if (server.id in activeServerIds) {
-                    Log.d("AppLifecycleController", "server already active; skipping reconnect ${server.id}")
+                    LLog.t(
+                        "AppLifecycleController",
+                        "server already active; skipping reconnect",
+                        fields = mapOf("serverId" to server.id),
+                    )
                     continue
                 }
                 try {
@@ -76,13 +80,23 @@ class AppLifecycleController {
                             )
                         }
                         else -> {
-                            Log.d("AppLifecycleController", "skipping reconnect for ${server.id}; no valid saved transport")
+                            LLog.t(
+                                "AppLifecycleController",
+                                "skipping reconnect; no valid saved transport",
+                                fields = mapOf("serverId" to server.id),
+                            )
                             continue
                         }
                     }
                     activeServerIds.add(server.id)
-                } catch (_: Exception) {
+                } catch (e: Exception) {
                     // Best-effort reconnection — server may be offline
+                    LLog.e(
+                        "AppLifecycleController",
+                        "saved server reconnect failed",
+                        e,
+                        fields = mapOf("serverId" to server.id, "host" to server.hostname, "os" to server.os),
+                    )
                 }
             }
             appModel.refreshSnapshot()
@@ -96,6 +110,17 @@ class AppLifecycleController {
         server: SavedServer,
         credential: SavedSshCredential,
     ) {
+        LLog.t(
+            "AppLifecycleController",
+            "reconnecting saved SSH server",
+            fields = mapOf(
+                "serverId" to server.id,
+                "host" to server.hostname,
+                "sshPort" to server.resolvedSshPort,
+                "authMethod" to credential.method.name,
+                "os" to server.os,
+            ),
+        )
         when (credential.method) {
             SshAuthMethod.PASSWORD -> {
                 appModel.ssh.sshConnectRemoteServer(

--- a/apps/android/app/src/main/java/com/litter/android/state/AppModel.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/AppModel.kt
@@ -17,6 +17,7 @@ import uniffi.codex_mobile_client.AppServerRpc
 import uniffi.codex_mobile_client.AppSnapshotRecord
 import uniffi.codex_mobile_client.AppStore
 import uniffi.codex_mobile_client.AppStoreSubscription
+import uniffi.codex_mobile_client.AppThreadSnapshot
 import uniffi.codex_mobile_client.AppStoreUpdateRecord
 import uniffi.codex_mobile_client.DiscoveryBridge
 import uniffi.codex_mobile_client.HandoffManager
@@ -149,9 +150,8 @@ class AppModel private constructor(context: android.content.Context) {
 
     suspend fun refreshSnapshot() {
         try {
-            val snap = applySavedServerNames(store.snapshot())
-            _snapshot.value = snap
-            _lastError.value = null
+            val snap = store.snapshot()
+            applySnapshot(snap)
             val serverSummary = snap.servers.joinToString(separator = " | ") { server ->
                 "${server.serverId}:${server.displayName}:${server.host}:${server.port}:${server.health}"
             }
@@ -162,6 +162,13 @@ class AppModel private constructor(context: android.content.Context) {
             )
         } catch (e: Exception) {
             _lastError.value = e.message
+        }
+    }
+
+    private fun applySnapshot(snapshot: AppSnapshotRecord?) {
+        _snapshot.value = snapshot?.let(::applySavedServerNames)
+        if (snapshot != null) {
+            _lastError.value = null
         }
     }
 
@@ -334,10 +341,74 @@ class AppModel private constructor(context: android.content.Context) {
     // --- Internal event handling ----------------------------------------------
 
     private suspend fun handleUpdate(update: AppStoreUpdateRecord) {
-        // All update types trigger a snapshot refresh.
-        // Rust's AppStore handles fine-grained state management internally.
-        // We could optimize to only refresh affected parts, but snapshot()
-        // is cheap since Rust builds it from in-memory state.
-        refreshSnapshot()
+        when (update) {
+            is AppStoreUpdateRecord.ThreadChanged -> refreshThreadSnapshot(update.key)
+            is AppStoreUpdateRecord.ThreadRemoved -> removeThreadSnapshot(update.key)
+            is AppStoreUpdateRecord.ActiveThreadChanged -> {
+                updateActiveThread(update.key)
+                if (update.key != null && snapshot.value?.threads?.any { it.key == update.key } != true) {
+                    refreshThreadSnapshot(update.key)
+                }
+            }
+            is AppStoreUpdateRecord.PendingApprovalsChanged -> refreshSnapshot()
+            is AppStoreUpdateRecord.PendingUserInputsChanged -> refreshSnapshot()
+            is AppStoreUpdateRecord.ServerChanged -> refreshSnapshot()
+            is AppStoreUpdateRecord.ServerRemoved -> refreshSnapshot()
+            is AppStoreUpdateRecord.FullResync -> refreshSnapshot()
+            is AppStoreUpdateRecord.VoiceSessionChanged -> refreshSnapshot()
+            is AppStoreUpdateRecord.RealtimeTranscriptUpdated -> Unit
+            is AppStoreUpdateRecord.RealtimeHandoffRequested -> Unit
+            is AppStoreUpdateRecord.RealtimeSpeechStarted -> Unit
+            is AppStoreUpdateRecord.RealtimeStarted -> refreshSnapshot()
+            is AppStoreUpdateRecord.RealtimeOutputAudioDelta -> Unit
+            is AppStoreUpdateRecord.RealtimeError -> refreshSnapshot()
+            is AppStoreUpdateRecord.RealtimeClosed -> refreshSnapshot()
+        }
+    }
+
+    private suspend fun refreshThreadSnapshot(key: ThreadKey) {
+        if (_snapshot.value == null) {
+            refreshSnapshot()
+            return
+        }
+
+        try {
+            val threadSnapshot = store.threadSnapshot(key)
+            if (threadSnapshot == null) {
+                removeThreadSnapshot(key)
+                return
+            }
+            applyThreadSnapshot(threadSnapshot)
+        } catch (e: Exception) {
+            _lastError.value = e.message
+            refreshSnapshot()
+        }
+    }
+
+    private fun applyThreadSnapshot(thread: AppThreadSnapshot) {
+        val current = _snapshot.value ?: return
+        val existingIndex = current.threads.indexOfFirst { it.key == thread.key }
+        val updatedThreads = current.threads.toMutableList().apply {
+            if (existingIndex >= 0) {
+                this[existingIndex] = thread
+            } else {
+                add(thread)
+            }
+        }
+        _snapshot.value = current.copy(threads = updatedThreads)
+        _lastError.value = null
+    }
+
+    private fun removeThreadSnapshot(key: ThreadKey) {
+        val current = _snapshot.value ?: return
+        _snapshot.value = current.copy(
+            threads = current.threads.filterNot { it.key == key },
+            activeThread = if (current.activeThread == key) null else current.activeThread,
+        )
+    }
+
+    private fun updateActiveThread(key: ThreadKey?) {
+        val current = _snapshot.value ?: return
+        _snapshot.value = current.copy(activeThread = key)
     }
 }

--- a/apps/android/app/src/main/java/com/litter/android/state/SnapshotExtensions.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/SnapshotExtensions.kt
@@ -8,6 +8,7 @@ import uniffi.codex_mobile_client.AppServerConnectionStepState
 import uniffi.codex_mobile_client.AppServerSnapshot
 import uniffi.codex_mobile_client.AppThreadSnapshot
 import uniffi.codex_mobile_client.HydratedConversationItemContent
+import uniffi.codex_mobile_client.ThreadSummaryStatus
 
 /** Accent green matching iOS theme. */
 private val AccentGreen = Color(0xFF00FF9C)
@@ -87,8 +88,11 @@ val AppServerSnapshot.statusColor: Color
 
 // --- AppThreadSnapshot extensions --------------------------------------------
 
+val ThreadSummaryStatus.isActiveStatus: Boolean
+    get() = this == ThreadSummaryStatus.ACTIVE
+
 val AppThreadSnapshot.hasActiveTurn: Boolean
-    get() = activeTurnId != null
+    get() = activeTurnId?.trim()?.isNotEmpty() == true || info.status.isActiveStatus
 
 val AppThreadSnapshot.resolvedModel: String
     get() = model ?: info.model ?: ""

--- a/apps/android/app/src/main/java/com/litter/android/state/SshSessionStore.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/SshSessionStore.kt
@@ -1,5 +1,6 @@
 package com.litter.android.state
 
+import com.litter.android.util.LLog
 import uniffi.codex_mobile_client.SshBridge
 import java.util.concurrent.ConcurrentHashMap
 
@@ -11,19 +12,23 @@ class SshSessionStore(private val ssh: SshBridge) {
     private val sessions = ConcurrentHashMap<String, String>() // serverId → sessionId
 
     fun record(serverId: String, sessionId: String) {
+        LLog.t("SshSessionStore", "record SSH session", fields = mapOf("serverId" to serverId, "sessionId" to sessionId))
         sessions[serverId] = sessionId
     }
 
     fun clear(serverId: String) {
+        LLog.t("SshSessionStore", "clear SSH session", fields = mapOf("serverId" to serverId))
         sessions.remove(serverId)
     }
 
     suspend fun close(serverId: String) {
         val sessionId = sessions.remove(serverId) ?: return
+        LLog.t("SshSessionStore", "close SSH session", fields = mapOf("serverId" to serverId, "sessionId" to sessionId))
         try {
             ssh.sshClose(sessionId)
-        } catch (_: Exception) {
+        } catch (e: Exception) {
             // Best-effort cleanup
+            LLog.e("SshSessionStore", "failed to close SSH session", e, fields = mapOf("serverId" to serverId, "sessionId" to sessionId))
         }
     }
 

--- a/apps/android/app/src/main/java/com/litter/android/state/VoiceRuntimeController.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/VoiceRuntimeController.kt
@@ -75,6 +75,7 @@ class VoiceRuntimeController {
     private var captureJob: Job? = null
     private var handoffManager: HandoffManager? = null
     private var aecBridge: AecBridge? = null
+    private var stopRequestedThreadKey: ThreadKey? = null
 
     // Audio I/O
     private var audioRecord: AudioRecord? = null
@@ -115,13 +116,34 @@ class VoiceRuntimeController {
 
     suspend fun stopActiveVoiceSession(appModel: AppModel) {
         val session = _activeSession.value ?: return
+        val key = session.threadKey
+        synchronized(sessionLock) {
+            if (stopRequestedThreadKey == key) {
+                return
+            }
+            stopRequestedThreadKey = key
+        }
+        cleanup(clearStopRequest = false)
         try {
             appModel.rpc.threadRealtimeStop(
-                session.threadKey.serverId,
-                ThreadRealtimeStopParams(threadId = session.threadKey.threadId),
+                key.serverId,
+                ThreadRealtimeStopParams(threadId = key.threadId),
             )
         } catch (_: Exception) {}
-        cleanup()
+        synchronized(sessionLock) {
+            if (stopRequestedThreadKey == key) {
+                stopRequestedThreadKey = null
+            }
+        }
+    }
+
+    suspend fun stopVoiceSessionIfActive(appModel: AppModel, threadKey: ThreadKey) {
+        val shouldStop = synchronized(sessionLock) {
+            _activeSession.value?.threadKey == threadKey || stopRequestedThreadKey == threadKey
+        }
+        if (shouldStop) {
+            stopActiveVoiceSession(appModel)
+        }
     }
 
     // ── Audio capture ────────────────────────────────────────────────────────
@@ -213,9 +235,10 @@ class VoiceRuntimeController {
 
         captureJob = scope.launch {
             val buffer = ShortArray(bufferSize / 2)
-            while (isCapturing) {
+            while (shouldContinueCapturing(threadKey)) {
                 val read = recorder.read(buffer, 0, buffer.size)
                 if (read <= 0) continue
+                if (!shouldContinueCapturing(threadKey)) break
 
                 // Compute input level (RMS)
                 val rms = computeRms(buffer, read)
@@ -243,6 +266,7 @@ class VoiceRuntimeController {
                 val base64Data = Base64.encodeToString(pcm16, Base64.NO_WRAP)
 
                 // Send to server
+                if (!shouldContinueCapturing(threadKey)) break
                 try {
                     appModel.rpc.threadRealtimeAppendAudio(
                         threadKey.serverId,
@@ -556,6 +580,7 @@ class VoiceRuntimeController {
             is AppStoreUpdateRecord.RealtimeStarted -> {
                 android.util.Log.i("VoiceRuntime", "RealtimeStarted!")
                 val threadKey = _activeSession.value?.threadKey ?: return
+                if (update.key != threadKey || isStopRequested(threadKey)) return
                 startAudioCapture(appModel, threadKey)
             }
 
@@ -567,7 +592,10 @@ class VoiceRuntimeController {
                     "VoiceSessionChanged: active=${voiceSession?.activeThread != null} phase=${voiceSession?.phase} error=${voiceSession?.lastError}",
                 )
                 // VoiceSessionChanged while CONNECTING means the server accepted and session is live
-                if (session.threadKey == voiceSession?.activeThread && !isCapturing) {
+                if (session.threadKey == voiceSession?.activeThread &&
+                    !isCapturing &&
+                    !isStopRequested(session.threadKey)
+                ) {
                     android.util.Log.i("VoiceRuntime", "Voice session active in snapshot, starting audio")
                     startAudioCapture(appModel, session.threadKey)
                 }
@@ -582,16 +610,22 @@ class VoiceRuntimeController {
                 playOutputAudio(audio.data, audio.sampleRate.toInt())
             }
             is AppStoreUpdateRecord.RealtimeError -> {
+                if (!matchesCurrentSession(update.key)) return
                 android.util.Log.e(
                     "VoiceRuntime",
                     "RealtimeError thread=${update.key.threadId} message=${update.notification.message}",
                 )
+                if (!update.notification.message.contains("active response in progress", ignoreCase = true)) {
+                    cleanupForThread(update.key)
+                }
             }
             is AppStoreUpdateRecord.RealtimeClosed -> {
+                if (!matchesCurrentSession(update.key)) return
                 android.util.Log.i(
                     "VoiceRuntime",
                     "RealtimeClosed thread=${update.key.threadId} reason=${update.notification.reason}",
                 )
+                cleanupForThread(update.key)
             }
             else -> {}
         }
@@ -924,7 +958,30 @@ class VoiceRuntimeController {
 
     // ── Cleanup ──────────────────────────────────────────────────────────────
 
-    private fun cleanup() {
+    private fun shouldContinueCapturing(threadKey: ThreadKey): Boolean {
+        val isSessionCurrent = synchronized(sessionLock) {
+            _activeSession.value?.threadKey == threadKey && stopRequestedThreadKey != threadKey
+        }
+        val captureActive = synchronized(captureLock) {
+            isCapturing
+        }
+        return isSessionCurrent && captureActive
+    }
+
+    private fun isStopRequested(threadKey: ThreadKey): Boolean =
+        synchronized(sessionLock) { stopRequestedThreadKey == threadKey }
+
+    private fun matchesCurrentSession(threadKey: ThreadKey): Boolean =
+        synchronized(sessionLock) {
+            _activeSession.value?.threadKey == threadKey || stopRequestedThreadKey == threadKey
+        }
+
+    private fun cleanupForThread(threadKey: ThreadKey, clearStopRequest: Boolean = true) {
+        if (!matchesCurrentSession(threadKey)) return
+        cleanup(clearStopRequest = clearStopRequest)
+    }
+
+    private fun cleanup(clearStopRequest: Boolean = true) {
         synchronized(captureLock) {
             isCapturing = false
             captureJob?.cancel()
@@ -960,6 +1017,11 @@ class VoiceRuntimeController {
         inputDecayToken = null
         outputDecayToken = null
         captureSampleRate = TARGET_SAMPLE_RATE
+        if (clearStopRequest) {
+            synchronized(sessionLock) {
+                stopRequestedThreadKey = null
+            }
+        }
         _activeSession.value = null
     }
 }

--- a/apps/android/app/src/main/java/com/litter/android/ui/ExperimentalFeatures.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/ExperimentalFeatures.kt
@@ -1,0 +1,74 @@
+package com.litter.android.ui
+
+import android.content.Context
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
+enum class LitterFeature(
+    val id: String,
+    val displayName: String,
+    val description: String,
+    val defaultEnabled: Boolean,
+) {
+    REALTIME_VOICE(
+        id = "realtime_voice",
+        displayName = "Realtime",
+        description = "Show the realtime voice launcher on the home screen.",
+        defaultEnabled = true,
+    ),
+    GENERATIVE_UI(
+        id = "generative_ui",
+        displayName = "Generative UI",
+        description = "Show interactive widgets, diagrams, and charts inline in conversations. Requires starting a new thread.",
+        defaultEnabled = false,
+    ),
+}
+
+object ExperimentalFeatures {
+    private const val PREFS = "litter_ui_prefs"
+    private const val KEY = "litter.experimentalFeatures"
+
+    private var overrides by mutableStateOf<Map<String, Boolean>>(emptyMap())
+
+    fun initialize(context: Context) {
+        @Suppress("UNCHECKED_CAST")
+        overrides = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .getStringSet(KEY, emptySet())
+            ?.mapNotNull { entry ->
+                val separator = entry.indexOf('=')
+                if (separator <= 0 || separator >= entry.lastIndex) {
+                    null
+                } else {
+                    val featureId = entry.substring(0, separator)
+                    val value = entry.substring(separator + 1).toBooleanStrictOrNull() ?: return@mapNotNull null
+                    featureId to value
+                }
+            }
+            ?.toMap()
+            ?: emptyMap()
+    }
+
+    fun isEnabled(feature: LitterFeature): Boolean {
+        return overrides[feature.id] ?: feature.defaultEnabled
+    }
+
+    fun setEnabled(context: Context, feature: LitterFeature, enabled: Boolean) {
+        val next = overrides.toMutableMap()
+        if (enabled == feature.defaultEnabled) {
+            next.remove(feature.id)
+        } else {
+            next[feature.id] = enabled
+        }
+        overrides = next.toMap()
+        persist(context)
+    }
+
+    private fun persist(context: Context) {
+        val encoded = overrides.entries.mapTo(linkedSetOf()) { (key, value) -> "$key=$value" }
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .edit()
+            .putStringSet(KEY, encoded)
+            .apply()
+    }
+}

--- a/apps/android/app/src/main/java/com/litter/android/ui/LitterApp.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/LitterApp.kt
@@ -56,6 +56,7 @@ fun LitterApp(appModel: AppModel) {
     LaunchedEffect(Unit) {
         TextSizePrefs.initialize(context)
         ConversationPrefs.initialize(context)
+        ExperimentalFeatures.initialize(context)
     }
 
     CompositionLocalProvider(

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationScreen.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationScreen.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.unit.sp
 import com.litter.android.state.contextPercent
 import com.litter.android.state.hasActiveTurn
 import com.litter.android.state.isIpcConnected
+import com.litter.android.state.isActiveStatus
 import com.litter.android.ui.ChatWallpaperBackground
 import com.litter.android.ui.ConversationPrefs
 import com.litter.android.ui.LocalAppModel
@@ -100,21 +101,40 @@ fun ConversationScreen(
         snapshot?.servers?.find { it.serverId == threadKey.serverId }
     }
     val items = thread?.hydratedConversationItems ?: emptyList()
-    val isThinking = thread?.hasActiveTurn == true
+    val normalizedActiveTurnId = thread?.activeTurnId?.trim()?.takeIf { it.isNotEmpty() }
+    val isThinking = thread?.info?.status?.isActiveStatus == true
     val collapseTurns = ConversationPrefs.areTurnsCollapsed
     val agentDirectoryVersion = snapshot?.agentDirectoryVersion ?: 0uL
-    val transcriptTurns = remember(items, thread?.activeTurnId, isThinking, collapseTurns) {
+    val transcriptTurns = remember(items, thread?.info?.status, isThinking, collapseTurns) {
         buildTranscriptTurns(
             items = items,
-            activeTurnId = thread?.activeTurnId,
             isStreaming = isThinking,
             expandedRecentTurnCount = if (collapseTurns) 1 else Int.MAX_VALUE,
         )
     }
+    val transcriptContentSignature = remember(items, normalizedActiveTurnId, isThinking) {
+        var hash = 17
+        items.forEach { item ->
+            hash = 31 * hash + item.hashCode()
+        }
+        hash = 31 * hash + (normalizedActiveTurnId?.hashCode() ?: 0)
+        hash = 31 * hash + if (isThinking) 1 else 0
+        hash
+    }
     var expandedTurnIds by remember(threadKey, collapseTurns) { mutableStateOf(setOf<String>()) }
+    var streamingRenderTick by remember(threadKey) { mutableStateOf(0) }
+    var followScrollToken by remember(threadKey) { mutableStateOf(0) }
+    var lastObservedUpdatedAt by remember(threadKey) { mutableStateOf<Long?>(null) }
     LaunchedEffect(transcriptTurns.map { it.id to it.isCollapsedByDefault }) {
         val validIds = transcriptTurns.mapTo(mutableSetOf()) { it.id }
         expandedTurnIds = expandedTurnIds.intersect(validIds)
+    }
+    LaunchedEffect(thread?.info?.updatedAt, isThinking) {
+        val updatedAt = thread?.info?.updatedAt
+        if (updatedAt != null && updatedAt != lastObservedUpdatedAt && isThinking) {
+            followScrollToken += 1
+        }
+        lastObservedUpdatedAt = updatedAt
     }
 
     // Load thread content on first open — resume it so Rust hydrates conversation items
@@ -217,6 +237,24 @@ fun ConversationScreen(
         }
     }
 
+    LaunchedEffect(transcriptContentSignature, isAtBottom, isThinking) {
+        if (isThinking && isAtBottom && transcriptTurns.isNotEmpty()) {
+            listState.scrollToItem(transcriptTurns.size)
+        }
+    }
+
+    LaunchedEffect(followScrollToken, isThinking, isAtBottom) {
+        if (isThinking && isAtBottom && transcriptTurns.isNotEmpty()) {
+            listState.scrollToItem(transcriptTurns.size)
+        }
+    }
+
+    LaunchedEffect(streamingRenderTick, isThinking, isAtBottom) {
+        if (isThinking && isAtBottom && transcriptTurns.isNotEmpty()) {
+            listState.scrollToItem(transcriptTurns.size)
+        }
+    }
+
     val wallpaperVersion = WallpaperManager.version
     val hasWallpaper = remember(threadKey, wallpaperVersion) {
         WallpaperManager.resolvedConfig(threadKey)?.type?.let { it != WallpaperType.NONE } == true
@@ -284,6 +322,15 @@ fun ConversationScreen(
                             key = { it.id },
                         ) { turn ->
                             val isExpanded = !turn.isCollapsedByDefault || expandedTurnIds.contains(turn.id)
+                            val streamingAssistantItemId = remember(turn.items, turn.isActiveTurn) {
+                                if (!turn.isActiveTurn) {
+                                    null
+                                } else {
+                                    turn.items.lastOrNull {
+                                        it.content is HydratedConversationItemContent.Assistant
+                                    }?.id
+                                }
+                            }
                             if (isExpanded) {
                                 val timelineEntries = remember(turn.items, turn.isActiveTurn) {
                                     buildTimelineEntries(turn.items, turn.isActiveTurn)
@@ -297,6 +344,12 @@ fun ConversationScreen(
                                                     serverId = threadKey.serverId,
                                                     agentDirectoryVersion = agentDirectoryVersion,
                                                     isLiveTurn = turn.isActiveTurn,
+                                                    isStreamingMessage = entry.item.id == streamingAssistantItemId,
+                                                    onStreamingSnapshotRendered = if (entry.item.id == streamingAssistantItemId) {
+                                                        { streamingRenderTick += 1 }
+                                                    } else {
+                                                        null
+                                                    },
                                                     onEditMessage = { turnIndex ->
                                                         scope.launch {
                                                             val prefill = appModel.store.editMessage(threadKey, turnIndex)

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationTimeline.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationTimeline.kt
@@ -46,6 +46,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -76,6 +77,7 @@ import uniffi.codex_mobile_client.HydratedConversationItem
 import uniffi.codex_mobile_client.HydratedConversationItemContent
 import uniffi.codex_mobile_client.HydratedPlanStepStatus
 import kotlin.math.roundToInt
+import kotlinx.coroutines.delay
 
 /**
  * Renders a single [HydratedConversationItem] by matching on its content type.
@@ -87,6 +89,8 @@ fun ConversationTimelineItem(
     serverId: String,
     agentDirectoryVersion: ULong,
     isLiveTurn: Boolean = false,
+    isStreamingMessage: Boolean = false,
+    onStreamingSnapshotRendered: (() -> Unit)? = null,
     onEditMessage: ((UInt) -> Unit)? = null,
     onForkFromMessage: ((UInt) -> Unit)? = null,
 ) {
@@ -103,6 +107,8 @@ fun ConversationTimelineItem(
             data = content.v1,
             serverId = serverId,
             agentDirectoryVersion = agentDirectoryVersion,
+            isStreamingMessage = isStreamingMessage,
+            onStreamingSnapshotRendered = onStreamingSnapshotRendered,
         )
 
         is HydratedConversationItemContent.Reasoning -> ReasoningRow(
@@ -255,9 +261,14 @@ private fun AssistantMessageRow(
     data: uniffi.codex_mobile_client.HydratedAssistantMessageData,
     serverId: String,
     agentDirectoryVersion: ULong,
+    isStreamingMessage: Boolean,
+    onStreamingSnapshotRendered: (() -> Unit)?,
 ) {
     val appModel = LocalAppModel.current
-    val segments = remember(itemId, data.text, serverId, agentDirectoryVersion) {
+    val segments = remember(itemId, data.text, serverId, agentDirectoryVersion, isStreamingMessage) {
+        if (isStreamingMessage) {
+            emptyList()
+        } else {
         MessageRenderCache.getSegments(
             key = MessageRenderCache.CacheKey(
                 itemId = itemId,
@@ -267,6 +278,41 @@ private fun AssistantMessageRow(
             parser = appModel.parser,
             text = data.text,
         )
+        }
+    }
+    var renderedText by remember(itemId) { mutableStateOf(data.text) }
+    var pendingText by remember(itemId) { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(itemId) {
+        renderedText = data.text
+        pendingText = null
+        if (isStreamingMessage) {
+            onStreamingSnapshotRendered?.invoke()
+        }
+    }
+
+    LaunchedEffect(data.text, isStreamingMessage) {
+        if (!isStreamingMessage) {
+            renderedText = data.text
+            pendingText = null
+            return@LaunchedEffect
+        }
+        if (data.text == renderedText) return@LaunchedEffect
+        if (renderedText.isEmpty()) {
+            renderedText = data.text
+            onStreamingSnapshotRendered?.invoke()
+        } else {
+            pendingText = data.text
+        }
+    }
+
+    LaunchedEffect(pendingText, isStreamingMessage) {
+        val nextText = pendingText ?: return@LaunchedEffect
+        if (!isStreamingMessage) return@LaunchedEffect
+        delay(60)
+        renderedText = nextText
+        pendingText = null
+        onStreamingSnapshotRendered?.invoke()
     }
 
     Column(
@@ -292,8 +338,8 @@ private fun AssistantMessageRow(
             Spacer(Modifier.height(2.dp))
         }
 
-        if (segments.isEmpty()) {
-            MarkdownText(text = data.text)
+        if (isStreamingMessage || segments.isEmpty()) {
+            MarkdownText(text = renderedText)
         } else {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 segments.forEachIndexed { index, segment ->

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/TurnGrouping.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/TurnGrouping.kt
@@ -93,7 +93,6 @@ data class TranscriptTurn(
  */
 fun buildTranscriptTurns(
     items: List<HydratedConversationItem>,
-    activeTurnId: String?,
     isStreaming: Boolean,
     expandedRecentTurnCount: Int,
 ): List<TranscriptTurn> {
@@ -109,7 +108,7 @@ fun buildTranscriptTurns(
             id = turnIdentifier(turnItems, index),
             turnId = turnId,
             items = turnItems,
-            isActiveTurn = (isStreaming && index == lastIndex) || turnId == activeTurnId,
+            isActiveTurn = isStreaming && index == lastIndex,
             isCollapsedByDefault = index < collapseBoundary,
         )
     }

--- a/apps/android/app/src/main/java/com/litter/android/ui/discovery/DiscoveryScreen.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/discovery/DiscoveryScreen.kt
@@ -1,6 +1,4 @@
 package com.litter.android.ui.discovery
-
-import android.util.Log
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
@@ -69,6 +67,7 @@ import com.litter.android.state.statusColor
 import com.litter.android.state.statusLabel
 import com.litter.android.ui.LitterTheme
 import com.litter.android.ui.LocalAppModel
+import com.litter.android.util.LLog
 import java.net.DatagramPacket
 import java.net.DatagramSocket
 import java.net.InetAddress
@@ -193,7 +192,7 @@ fun DiscoveryScreen(
         try {
             val connected = connectedSnapshot(entry, snapshot?.servers ?: emptyList())
             if (connected?.isConnected == true) {
-                Log.d(logTag, "server already connected: ${entry.id}")
+                LLog.t(logTag, "server already connected", fields = mapOf("serverId" to entry.id))
                 onDismiss()
                 return
             }
@@ -255,7 +254,16 @@ fun DiscoveryScreen(
                 }
             }
         } catch (e: Exception) {
-            Log.e(logTag, "server connect failed for ${entry.id}", e)
+            LLog.e(
+                logTag,
+                "server connect failed",
+                e,
+                fields = mapOf(
+                    "serverId" to entry.id,
+                    "host" to entry.hostname,
+                    "preferredConnectionMode" to entry.preferredConnectionMode,
+                ),
+            )
             connectError = e.message ?: "Unable to connect."
         }
     }
@@ -419,7 +427,17 @@ fun DiscoveryScreen(
                                         appModel.refreshSnapshot()
                                         onDismiss()
                                     } catch (e: Exception) {
-                                        Log.e(logTag, "direct codex connect failed for ${server.id}", e)
+                                        LLog.e(
+                                            logTag,
+                                            "direct codex connect failed",
+                                            e,
+                                            fields = mapOf(
+                                                "serverId" to server.id,
+                                                "host" to server.hostname,
+                                                "codexPort" to port,
+                                                "os" to server.os,
+                                            ),
+                                        )
                                         connectError = e.message ?: "Unable to connect."
                                     }
                                 }
@@ -463,7 +481,17 @@ fun DiscoveryScreen(
             onDismiss = { sshServer = null },
             onConnect = { credential, rememberCredentials ->
                 try {
-                    Log.d(logTag, "starting SSH connect for ${server.id} host=${server.hostname}:${server.resolvedSshPort}")
+                    LLog.t(
+                        logTag,
+                        "starting guided SSH connect",
+                        fields = mapOf(
+                            "serverId" to server.id,
+                            "host" to server.hostname,
+                            "sshPort" to server.resolvedSshPort,
+                            "authMethod" to credential.method.name,
+                            "os" to server.os,
+                        ),
+                    )
                     when (credential.method) {
                         SshAuthMethod.PASSWORD -> {
                             appModel.ssh.sshStartRemoteServerConnect(
@@ -509,11 +537,30 @@ fun DiscoveryScreen(
                     reloadSavedServers()
                     appModel.refreshSnapshot()
                     pendingAutoNavigateServerId = server.id
-                    Log.d(logTag, "SSH bootstrap started for ${server.id}")
+                    LLog.t(
+                        logTag,
+                        "guided SSH bootstrap started",
+                        fields = mapOf(
+                            "serverId" to server.id,
+                            "host" to server.hostname,
+                            "sshPort" to server.resolvedSshPort,
+                        ),
+                    )
                     sshServer = null
                     null
                 } catch (e: Exception) {
-                    Log.e(logTag, "SSH connect failed for ${server.id}", e)
+                    LLog.e(
+                        logTag,
+                        "guided SSH connect failed",
+                        e,
+                        fields = mapOf(
+                            "serverId" to server.id,
+                            "host" to server.hostname,
+                            "sshPort" to server.resolvedSshPort,
+                            "authMethod" to credential.method.name,
+                            "os" to server.os,
+                        ),
+                    )
                     e.message ?: "Unable to connect over SSH."
                 }
             },
@@ -552,6 +599,15 @@ fun DiscoveryScreen(
                 TextButton(
                     onClick = {
                         scope.launch {
+                            LLog.t(
+                                logTag,
+                                "responding to install prompt",
+                                fields = mapOf(
+                                    "serverId" to serverSnapshot.serverId,
+                                    "install" to true,
+                                    "detail" to serverSnapshot.connectionProgressDetail,
+                                ),
+                            )
                             appModel.ssh.sshRespondToInstallPrompt(serverSnapshot.serverId, true)
                         }
                     },
@@ -563,6 +619,15 @@ fun DiscoveryScreen(
                 TextButton(
                     onClick = {
                         scope.launch {
+                            LLog.t(
+                                logTag,
+                                "responding to install prompt",
+                                fields = mapOf(
+                                    "serverId" to serverSnapshot.serverId,
+                                    "install" to false,
+                                    "detail" to serverSnapshot.connectionProgressDetail,
+                                ),
+                            )
                             appModel.ssh.sshRespondToInstallPrompt(serverSnapshot.serverId, false)
                         }
                     },

--- a/apps/android/app/src/main/java/com/litter/android/ui/home/HomeDashboardScreen.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/home/HomeDashboardScreen.kt
@@ -67,6 +67,8 @@ import com.litter.android.state.isIpcConnected
 import com.litter.android.state.statusColor
 import com.litter.android.state.statusLabel
 import com.litter.android.ui.LocalAppModel
+import com.litter.android.ui.ExperimentalFeatures
+import com.litter.android.ui.LitterFeature
 import com.litter.android.ui.LitterTheme
 import kotlinx.coroutines.launch
 import uniffi.codex_mobile_client.AppServerSnapshot
@@ -244,7 +246,11 @@ fun HomeDashboardScreen(
     }
 
     // Voice orb FAB
-    if (onStartVoice != null && servers.isNotEmpty()) {
+    if (
+        onStartVoice != null &&
+            servers.isNotEmpty() &&
+            ExperimentalFeatures.isEnabled(LitterFeature.REALTIME_VOICE)
+    ) {
         val voiceController = remember { com.litter.android.state.VoiceRuntimeController.shared }
         val voiceSession by voiceController.activeVoiceSession.collectAsState()
         val snapshot by appModel.snapshot.collectAsState()

--- a/apps/android/app/src/main/java/com/litter/android/ui/settings/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/settings/SettingsSheet.kt
@@ -85,6 +85,8 @@ import com.litter.android.ui.LocalAppModel
 import com.litter.android.ui.LitterColorThemeType
 import com.litter.android.ui.BerkeleyMono
 import com.litter.android.ui.ConversationPrefs
+import com.litter.android.ui.ExperimentalFeatures
+import com.litter.android.ui.LitterFeature
 import com.litter.android.ui.WallpaperBackdrop
 import com.litter.android.ui.WallpaperManager
 import com.litter.android.ui.LitterTheme
@@ -93,8 +95,6 @@ import com.litter.android.ui.LitterThemeManager
 import kotlinx.coroutines.launch
 import uniffi.codex_mobile_client.Account
 import uniffi.codex_mobile_client.AppServerSnapshot
-import uniffi.codex_mobile_client.ExperimentalFeature
-import uniffi.codex_mobile_client.ExperimentalFeatureListParams
 import uniffi.codex_mobile_client.LoginAccountParams
 
 /**
@@ -526,6 +526,7 @@ private fun AppearanceScreen(onBack: () -> Unit) {
             item {
                 val scale = com.litter.android.ui.ConversationTextSize.fromStep(textSizeStep.toInt()).scale
                 val previewFontSize = (14f * scale).sp
+                val previewCodeFontSize = (13f * scale).sp
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -543,6 +544,7 @@ private fun AppearanceScreen(onBack: () -> Unit) {
                             "Hey, why is prod on fire",
                             color = LitterTheme.textPrimary,
                             fontSize = previewFontSize,
+                            lineHeight = (previewFontSize.value * 1.3f).sp,
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .background(LitterTheme.surface.copy(alpha = 0.5f), RoundedCornerShape(12.dp))
@@ -563,16 +565,48 @@ private fun AppearanceScreen(onBack: () -> Unit) {
                             Text("0.3s", color = LitterTheme.textMuted, fontSize = 10.sp)
                         }
                         // Assistant bubble
-                        Text(
-                            "Found the issue. Someone deployed this:\n\n```python\nif is_friday():\n    yolo_deploy(skip_tests=True)\n```\n\nI'm not mad, just disappointed.",
-                            color = LitterTheme.textBody,
-                            fontSize = previewFontSize,
-                        )
+                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                            Text(
+                                "Found the issue. Someone deployed this:",
+                                color = LitterTheme.textBody,
+                                fontSize = previewFontSize,
+                                lineHeight = (previewFontSize.value * 1.3f).sp,
+                            )
+                            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                                Text(
+                                    "PYTHON",
+                                    color = LitterTheme.textSecondary,
+                                    fontSize = 10.sp,
+                                    fontWeight = FontWeight.Bold,
+                                )
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .background(LitterTheme.codeBackground, RoundedCornerShape(8.dp))
+                                        .padding(10.dp),
+                                ) {
+                                    Text(
+                                        "if is_friday():\n    yolo_deploy(skip_tests=True)",
+                                        color = LitterTheme.textBody,
+                                        fontFamily = LitterTheme.monoFont,
+                                        fontSize = previewCodeFontSize,
+                                        lineHeight = (previewCodeFontSize.value * 1.35f).sp,
+                                    )
+                                }
+                            }
+                            Text(
+                                "I'm not mad, just disappointed.",
+                                color = LitterTheme.textBody,
+                                fontSize = previewFontSize,
+                                lineHeight = (previewFontSize.value * 1.3f).sp,
+                            )
+                        }
                         // User reply
                         Text(
                             "That was you",
                             color = LitterTheme.textPrimary,
                             fontSize = previewFontSize,
+                            lineHeight = (previewFontSize.value * 1.3f).sp,
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .background(LitterTheme.surface.copy(alpha = 0.5f), RoundedCornerShape(12.dp))
@@ -774,22 +808,8 @@ private fun ThemePickerButton(entry: LitterThemeIndexEntry?, onClick: () -> Unit
 
 @Composable
 private fun ExperimentalScreen(onBack: () -> Unit) {
-    val appModel = LocalAppModel.current
-    val snapshot by appModel.snapshot.collectAsState()
-    var features by remember { mutableStateOf<List<ExperimentalFeature>>(emptyList()) }
-    var isLoading by remember { mutableStateOf(true) }
-
-    val serverId = remember(snapshot) { snapshot?.servers?.firstOrNull { it.isConnected }?.serverId }
-
-    LaunchedEffect(serverId) {
-        if (serverId != null) {
-            try {
-                val resp = appModel.rpc.experimentalFeatureList(serverId, ExperimentalFeatureListParams(cursor = null, limit = null))
-                features = resp.data
-            } catch (_: Exception) {}
-        }
-        isLoading = false
-    }
+    val context = LocalContext.current
+    val features = remember { LitterFeature.entries }
 
     Column(
         Modifier
@@ -811,35 +831,30 @@ private fun ExperimentalScreen(onBack: () -> Unit) {
         Spacer(Modifier.height(16.dp))
 
         SectionHeader("Features")
-
-        if (isLoading) {
-            Box(Modifier.fillMaxWidth().padding(32.dp), contentAlignment = Alignment.Center) {
-                CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp, color = LitterTheme.accent)
-            }
-        } else if (features.isEmpty()) {
-            Text("No experimental features available.", color = LitterTheme.textMuted, fontSize = 13.sp, modifier = Modifier.padding(12.dp))
-        } else {
-            Column(
-                Modifier.fillMaxWidth().background(LitterTheme.surface.copy(alpha = 0.6f), RoundedCornerShape(10.dp)),
-            ) {
-                features.forEachIndexed { idx, feature ->
-                    var enabled by remember { mutableStateOf(false) }
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 10.dp),
-                    ) {
-                        Column(Modifier.weight(1f)) {
-                            Text(feature.displayName ?: feature.name, color = LitterTheme.textPrimary, fontSize = 14.sp)
-                            feature.description?.let { Text(it, color = LitterTheme.textSecondary, fontSize = 11.sp) }
-                        }
-                        Switch(checked = enabled, onCheckedChange = { enabled = it }, colors = SwitchDefaults.colors(checkedTrackColor = LitterTheme.accent))
+        Column(
+            Modifier.fillMaxWidth().background(LitterTheme.surface.copy(alpha = 0.6f), RoundedCornerShape(10.dp)),
+        ) {
+            features.forEachIndexed { idx, feature ->
+                val enabled = ExperimentalFeatures.isEnabled(feature)
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 10.dp),
+                ) {
+                    Column(Modifier.weight(1f)) {
+                        Text(feature.displayName, color = LitterTheme.textPrimary, fontSize = 14.sp)
+                        Text(feature.description, color = LitterTheme.textSecondary, fontSize = 11.sp)
                     }
-                    if (idx < features.lastIndex) HorizontalDivider(color = LitterTheme.divider)
+                    Switch(
+                        checked = enabled,
+                        onCheckedChange = { ExperimentalFeatures.setEnabled(context, feature, it) },
+                        colors = SwitchDefaults.colors(checkedTrackColor = LitterTheme.accentStrong),
+                    )
                 }
+                if (idx < features.lastIndex) HorizontalDivider(color = LitterTheme.divider)
             }
-            Spacer(Modifier.height(8.dp))
-            Text("Experimental features may be unstable or change without notice.", color = LitterTheme.textMuted, fontSize = 11.sp, modifier = Modifier.padding(start = 4.dp))
         }
+        Spacer(Modifier.height(8.dp))
+        Text("Experimental features may be unstable or change without notice.", color = LitterTheme.textMuted, fontSize = 11.sp, modifier = Modifier.padding(start = 4.dp))
     }
 }
 

--- a/apps/android/app/src/main/java/com/litter/android/ui/voice/RealtimeVoiceScreen.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/voice/RealtimeVoiceScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -160,6 +161,14 @@ fun RealtimeVoiceScreen(
     LaunchedEffect(transcriptSignature) {
         if (transcriptEntries.isNotEmpty()) {
             transcriptListState.animateScrollToItem(transcriptEntries.lastIndex)
+        }
+    }
+
+    DisposableEffect(threadKey, appModel, voiceController) {
+        onDispose {
+            scope.launch {
+                voiceController.stopVoiceSessionIfActive(appModel, threadKey)
+            }
         }
     }
 

--- a/apps/android/app/src/main/java/com/litter/android/util/LLog.kt
+++ b/apps/android/app/src/main/java/com/litter/android/util/LLog.kt
@@ -47,6 +47,11 @@ object LLog {
         }
     }
 
+    fun t(tag: String, message: String, fields: Map<String, Any?> = emptyMap(), payloadJson: String? = null) {
+        Log.v(tag, message)
+        emit(LogLevel.TRACE, tag, message, fields, payloadJson)
+    }
+
     fun d(tag: String, message: String, fields: Map<String, Any?> = emptyMap(), payloadJson: String? = null) {
         Log.d(tag, message)
         emit(LogLevel.DEBUG, tag, message, fields, payloadJson)

--- a/apps/android/scripts/bump-version.sh
+++ b/apps/android/scripts/bump-version.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BUILD_GRADLE="$SCRIPT_DIR/../app/build.gradle.kts"
+VERSION_CODE_OVERRIDE="${LITTER_VERSION_CODE_OVERRIDE:-}"
+
+# Read current versionCode
+CURRENT=$(grep 'versionCode = ' "$BUILD_GRADLE" | head -1 | sed 's/[^0-9]//g')
+if [[ -z "$CURRENT" ]]; then
+    echo "ERROR: could not find versionCode in $BUILD_GRADLE" >&2
+    exit 1
+fi
+
+if [[ -n "$VERSION_CODE_OVERRIDE" ]]; then
+    if ! [[ "$VERSION_CODE_OVERRIDE" =~ ^[0-9]+$ ]]; then
+        echo "ERROR: LITTER_VERSION_CODE_OVERRIDE must be numeric" >&2
+        exit 1
+    fi
+    NEXT="$VERSION_CODE_OVERRIDE"
+else
+    NEXT=$((CURRENT + 1))
+fi
+
+# Update versionCode
+perl -0pi -e "s/versionCode = $CURRENT/versionCode = $NEXT/" "$BUILD_GRADLE"
+
+if [[ "$CURRENT" == "$NEXT" ]]; then
+    echo "==> versionCode unchanged at $CURRENT"
+else
+    echo "==> Bumped versionCode: $CURRENT -> $NEXT"
+fi

--- a/apps/android/scripts/play-upload.sh
+++ b/apps/android/scripts/play-upload.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 ANDROID_DIR="$REPO_DIR/apps/android"
+GRADLEW="$ANDROID_DIR/gradlew"
 
 VARIANT="${VARIANT:-Release}"
 UPLOAD="${UPLOAD:-1}"
@@ -43,7 +44,7 @@ if [[ "$UPLOAD" == "1" ]]; then
 
     TASK=":app:publish${VARIANT}Bundle"
     echo "==> Publishing $VARIANT bundle to Google Play track '$TRACK'"
-    gradle -p "$ANDROID_DIR" "$TASK" \
+    "$GRADLEW" -p "$ANDROID_DIR" "$TASK" \
         -PLITTER_PLAY_SERVICE_ACCOUNT_JSON="$LITTER_PLAY_SERVICE_ACCOUNT_JSON" \
         -PLITTER_PLAY_TRACK="$TRACK" \
         -PLITTER_UPLOAD_STORE_FILE="$LITTER_UPLOAD_STORE_FILE" \
@@ -53,7 +54,7 @@ if [[ "$UPLOAD" == "1" ]]; then
 else
     TASK=":app:bundle${VARIANT}"
     echo "==> Building local AAB for $VARIANT (no upload)"
-    gradle -p "$ANDROID_DIR" "$TASK"
+    "$GRADLEW" -p "$ANDROID_DIR" "$TASK"
 fi
 
 echo "==> Done"

--- a/apps/ios/Sources/Litter/Models/AppLifecycleController.swift
+++ b/apps/ios/Sources/Litter/Models/AppLifecycleController.swift
@@ -101,6 +101,22 @@ final class AppLifecycleController {
         port: UInt16,
         credentials: SSHCredentials
     ) async throws {
+        let authMethod: String = switch credentials {
+        case .password:
+            "password"
+        case .key:
+            "private_key"
+        }
+        LLog.trace(
+            "lifecycle",
+            "reconnecting saved SSH server",
+            fields: [
+                "serverId": serverId,
+                "host": host,
+                "sshPort": Int(port),
+                "authMethod": authMethod
+            ]
+        )
         switch credentials {
         case .password(let username, let password):
             _ = try await appModel.ssh.sshConnectRemoteServer(

--- a/apps/ios/Sources/Litter/Models/SshSessionStore.swift
+++ b/apps/ios/Sources/Litter/Models/SshSessionStore.swift
@@ -6,15 +6,22 @@ actor SshSessionStore {
     private var sessionIdsByServerId: [String: String] = [:]
 
     func record(sessionId: String, for serverId: String) {
+        LLog.trace("ssh", "record SSH session", fields: ["serverId": serverId, "sessionId": sessionId])
         sessionIdsByServerId[serverId] = sessionId
     }
 
     func clear(serverId: String) {
+        LLog.trace("ssh", "clear SSH session", fields: ["serverId": serverId])
         sessionIdsByServerId.removeValue(forKey: serverId)
     }
 
     func close(serverId: String, ssh: SshBridge) async {
         guard let sessionId = sessionIdsByServerId.removeValue(forKey: serverId) else { return }
-        try? await ssh.sshClose(sessionId: sessionId)
+        LLog.trace("ssh", "close SSH session", fields: ["serverId": serverId, "sessionId": sessionId])
+        do {
+            try await ssh.sshClose(sessionId: sessionId)
+        } catch {
+            LLog.error("ssh", "failed to close SSH session", error: error, fields: ["serverId": serverId, "sessionId": sessionId])
+        }
     }
 }

--- a/apps/ios/Sources/Litter/Views/DiscoveryView.swift
+++ b/apps/ios/Sources/Litter/Views/DiscoveryView.swift
@@ -231,6 +231,15 @@ struct DiscoveryView: View {
         ) { snapshot in
             Button("Install") {
                 Task {
+                    LLog.trace(
+                        "discovery",
+                        "responding to install prompt",
+                        fields: [
+                            "serverId": snapshot.serverId,
+                            "install": true,
+                            "detail": snapshot.connectionProgressDetail ?? ""
+                        ]
+                    )
                     _ = try? await appModel.ssh.sshRespondToInstallPrompt(
                         serverId: snapshot.serverId,
                         install: true
@@ -239,6 +248,15 @@ struct DiscoveryView: View {
             }
             Button("Cancel", role: .cancel) {
                 Task {
+                    LLog.trace(
+                        "discovery",
+                        "responding to install prompt",
+                        fields: [
+                            "serverId": snapshot.serverId,
+                            "install": false,
+                            "detail": snapshot.connectionProgressDetail ?? ""
+                        ]
+                    )
                     _ = try? await appModel.ssh.sshRespondToInstallPrompt(
                         serverId: snapshot.serverId,
                         install: false
@@ -820,6 +838,22 @@ struct DiscoveryView: View {
         credentials: SSHCredentials,
         port: UInt16
     ) async throws -> String {
+        let authMethod: String = switch credentials {
+        case .password:
+            "password"
+        case .key:
+            "private_key"
+        }
+        LLog.trace(
+            "discovery",
+            "starting guided SSH connect",
+            fields: [
+                "serverId": serverId,
+                "host": host,
+                "sshPort": Int(port),
+                "authMethod": authMethod
+            ]
+        )
         switch credentials {
         case .password(let username, let password):
             return try await appModel.ssh.sshStartRemoteServerConnect(

--- a/apps/ios/scripts/testflight-upload.sh
+++ b/apps/ios/scripts/testflight-upload.sh
@@ -14,7 +14,7 @@ APP_STORE_APP_ID="${APP_STORE_APP_ID:-}"
 TEAM_ID="${TEAM_ID:-}"
 PROVISIONING_PROFILE_SPECIFIER="${PROVISIONING_PROFILE_SPECIFIER:-Litter App Store}"
 EXPORT_SIGNING_STYLE="${EXPORT_SIGNING_STYLE:-automatic}"
-MARKETING_VERSION="${MARKETING_VERSION:-}"
+MARKETING_VERSION="${MARKETING_VERSION:-1.0.1}"
 BUILD_NUMBER="${BUILD_NUMBER:-}"
 ASSIGN_BETA_GROUP="${ASSIGN_BETA_GROUP:-1}"
 INTERNAL_BETA_GROUP_NAME="${INTERNAL_BETA_GROUP_NAME:-Internal Testers}"
@@ -65,6 +65,11 @@ fi
 
 mkdir -p "$BUILD_DIR"
 
+if [[ "$MARKETING_VERSION" != "1.0.1" ]]; then
+    echo "TestFlight uploads must use MARKETING_VERSION=1.0.1 (got $MARKETING_VERSION)" >&2
+    exit 1
+fi
+
 trim() {
     local value="$1"
     value="${value#"${value%%[![:space:]]*}"}"
@@ -111,13 +116,6 @@ if [[ -z "$TEAM_ID" ]]; then
     )"
 fi
 
-if [[ -z "$MARKETING_VERSION" ]]; then
-    MARKETING_VERSION="$(
-        xcodebuild -project "$PROJECT_PATH" -scheme "$SCHEME" -configuration "$CONFIGURATION" -showBuildSettings |
-            awk -F' = ' '/ MARKETING_VERSION = / {print $2; exit}'
-    )"
-fi
-
 if [[ -z "$TEAM_ID" && "$EXPORT_SIGNING_STYLE" == "manual" ]]; then
     TEAM_ID="$(resolve_team_from_profile "$PROVISIONING_PROFILE_SPECIFIER" || true)"
 fi
@@ -130,12 +128,6 @@ fi
 if [[ -z "$TEAM_ID" ]]; then
     echo "Unable to resolve DEVELOPMENT_TEAM for signing." >&2
     echo "Set TEAM_ID explicitly or ensure the project build settings or provisioning profile can resolve it." >&2
-    exit 1
-fi
-
-if [[ -z "$MARKETING_VERSION" ]]; then
-    echo "Unable to resolve MARKETING_VERSION for release." >&2
-    echo "Set MARKETING_VERSION explicitly or ensure the project build settings define it." >&2
     exit 1
 fi
 

--- a/shared/rust-bridge/codex-mobile-client/src/ffi/ssh.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/ffi/ssh.rs
@@ -13,7 +13,7 @@ use std::sync::Mutex;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use tokio::sync::oneshot;
-use tracing::warn;
+use tracing::{debug, info, trace, warn};
 
 #[derive(Clone)]
 pub(crate) struct ManagedSshSession {
@@ -88,6 +88,15 @@ impl SshBridge {
     ) -> Result<FfiSshConnectionResult, ClientError> {
         let normalized_host = normalize_ssh_host(&host);
         let auth = ssh_auth(password, private_key_pem, passphrase)?;
+        info!(
+            "SshBridge: ssh_connect_and_bootstrap start host={} normalized_host={} ssh_port={} username={} auth={} working_dir={}",
+            host.as_str(),
+            normalized_host.as_str(),
+            port,
+            username.as_str(),
+            ssh_auth_kind(&auth),
+            working_dir.as_deref().unwrap_or("<none>")
+        );
         let credentials = SshCredentials {
             host: normalized_host.clone(),
             port,
@@ -108,6 +117,11 @@ impl SshBridge {
         })
         .await
         .map_err(|e| ClientError::Rpc(format!("task join error: {e}")))??;
+        info!(
+            "SshBridge: ssh_connect_and_bootstrap connected normalized_host={} ssh_port={}",
+            normalized_host.as_str(),
+            port
+        );
 
         let session = Arc::new(session);
         let bootstrap = {
@@ -130,6 +144,12 @@ impl SshBridge {
         let bootstrap = match bootstrap {
             Ok(result) => result,
             Err(error) => {
+                warn!(
+                    "SshBridge: ssh_connect_and_bootstrap bootstrap failed normalized_host={} ssh_port={} error={}",
+                    normalized_host.as_str(),
+                    port,
+                    error
+                );
                 let session = Arc::clone(&session);
                 let rt = Arc::clone(&self.rt);
                 let _ = tokio::task::spawn_blocking(move || {
@@ -164,6 +184,15 @@ impl SshBridge {
                 shell,
             },
         );
+        info!(
+            "SshBridge: ssh_connect_and_bootstrap succeeded normalized_host={} ssh_port={} session_id={} remote_port={} local_tunnel_port={} pid={:?}",
+            normalized_host.as_str(),
+            port,
+            session_id,
+            bootstrap.server_port,
+            bootstrap.tunnel_local_port,
+            bootstrap.pid
+        );
 
         Ok(FfiSshConnectionResult {
             session_id,
@@ -177,6 +206,7 @@ impl SshBridge {
     }
 
     pub async fn ssh_close(&self, session_id: String) -> Result<(), ClientError> {
+        debug!("SshBridge: ssh_close session_id={}", session_id);
         let session = self
             .ssh_sessions_lock()
             .remove(&session_id)
@@ -200,6 +230,7 @@ impl SshBridge {
         })
         .await
         .map_err(|e| ClientError::Rpc(format!("task join error: {e}")))?;
+        debug!("SshBridge: ssh_close completed session_id={}", session_id);
         Ok(())
     }
 
@@ -219,6 +250,17 @@ impl SshBridge {
     ) -> Result<String, ClientError> {
         let normalized_host = normalize_ssh_host(&host);
         let auth = ssh_auth(password, private_key_pem, passphrase)?;
+        info!(
+            "SshBridge: ssh_connect_remote_server start server_id={} host={} normalized_host={} ssh_port={} username={} auth={} working_dir={} ipc_socket_path_override={}",
+            server_id,
+            host.as_str(),
+            normalized_host.as_str(),
+            port,
+            username.as_str(),
+            ssh_auth_kind(&auth),
+            working_dir.as_deref().unwrap_or("<none>"),
+            ipc_socket_path_override.as_deref().unwrap_or("<none>")
+        );
         let credentials = SshCredentials {
             host: normalized_host.clone(),
             port,
@@ -236,6 +278,7 @@ impl SshBridge {
         };
         let mobile_client = shared_mobile_client();
         let (tx, rx) = oneshot::channel();
+        let task_server_id = config.server_id.clone();
 
         // Run the full SSH bootstrap on Tokio and only surface the final
         // completion back through UniFFI. Polling the full bootstrap future
@@ -252,6 +295,17 @@ impl SshBridge {
                 )
                 .await
                 .map_err(|e| ClientError::Transport(e.to_string()));
+            match &result {
+                Ok(server_id) => info!(
+                    "SshBridge: ssh_connect_remote_server completed server_id={}",
+                    server_id
+                ),
+                Err(error) => warn!(
+                    "SshBridge: ssh_connect_remote_server failed server_id={} error={}",
+                    task_server_id,
+                    error
+                ),
+            }
             let _ = tx.send(result);
         });
 
@@ -275,6 +329,17 @@ impl SshBridge {
     ) -> Result<String, ClientError> {
         let normalized_host = normalize_ssh_host(&host);
         let auth = ssh_auth(password, private_key_pem, passphrase)?;
+        info!(
+            "SshBridge: ssh_start_remote_server_connect start server_id={} host={} normalized_host={} ssh_port={} username={} auth={} working_dir={} ipc_socket_path_override={}",
+            server_id,
+            host.as_str(),
+            normalized_host.as_str(),
+            port,
+            username.as_str(),
+            ssh_auth_kind(&auth),
+            working_dir.as_deref().unwrap_or("<none>"),
+            ipc_socket_path_override.as_deref().unwrap_or("<none>")
+        );
         let credentials = SshCredentials {
             host: normalized_host.clone(),
             port,
@@ -294,6 +359,10 @@ impl SshBridge {
         {
             let mut flows = self.bootstrap_flows.lock().await;
             if flows.contains_key(&server_id) {
+                debug!(
+                    "SshBridge: ssh_start_remote_server_connect reusing existing bootstrap flow server_id={}",
+                    server_id
+                );
                 return Ok(server_id);
             }
             flows.insert(
@@ -318,6 +387,11 @@ impl SshBridge {
         let task_host = credentials.host.clone();
         tokio::spawn(async move {
             let mut progress = initial_progress;
+            trace!(
+                "SshBridge: guided ssh connect task spawned server_id={} host={}",
+                task_server_id,
+                task_host
+            );
             let task_result = run_guided_ssh_connect(
                 Arc::clone(&mobile_client),
                 Arc::clone(&flows),
@@ -330,7 +404,7 @@ impl SshBridge {
             )
             .await;
 
-            if let Err(error) = task_result {
+            if let Err(ref error) = task_result {
                 warn!(
                     "guided ssh connect failed server_id={} host={} error={}",
                     task_server_id, task_host, error
@@ -344,6 +418,14 @@ impl SshBridge {
                     .update_server_connection_progress(&task_server_id, Some(progress));
             }
 
+            if task_result.is_ok() {
+                info!(
+                    "SshBridge: guided ssh connect completed server_id={} host={}",
+                    task_server_id,
+                    task_host
+                );
+            }
+
             flows.lock().await.remove(&task_server_id);
         });
 
@@ -355,6 +437,11 @@ impl SshBridge {
         server_id: String,
         install: bool,
     ) -> Result<(), ClientError> {
+        info!(
+            "SshBridge: ssh_respond_to_install_prompt server_id={} install={}",
+            server_id,
+            install
+        );
         let sender = {
             let mut flows = self.bootstrap_flows.lock().await;
             flows
@@ -368,6 +455,13 @@ impl SshBridge {
         sender
             .send(install)
             .map_err(|_| ClientError::EventClosed("install prompt already closed".to_string()))
+    }
+}
+
+fn ssh_auth_kind(auth: &SshAuth) -> &'static str {
+    match auth {
+        SshAuth::Password(_) => "password",
+        SshAuth::PrivateKey { .. } => "private_key",
     }
 }
 
@@ -422,6 +516,14 @@ async fn run_guided_ssh_connect(
     progress: &mut ServerConnectionProgressSnapshot,
 ) -> Result<(), ClientError> {
     let server_id = config.server_id.clone();
+    info!(
+        "guided ssh connect start server_id={} host={} ssh_port={} working_dir={} ipc_socket_path_override={}",
+        server_id,
+        credentials.host.as_str(),
+        credentials.port,
+        working_dir.as_deref().unwrap_or("<none>"),
+        ipc_socket_path_override.as_deref().unwrap_or("<none>")
+    );
     let ssh_client = Arc::new(
         SshClient::connect(
             credentials.clone(),
@@ -430,10 +532,16 @@ async fn run_guided_ssh_connect(
         .await
         .map_err(map_ssh_error)?,
     );
+    info!(
+        "guided ssh connect connected to ssh server_id={} host={} ssh_port={}",
+        server_id,
+        credentials.host.as_str(),
+        credentials.port
+    );
     progress.update_step(
         ServerConnectionStepKind::ConnectingToSsh,
         ServerConnectionStepState::Completed,
-        Some(format!("Connected to {}", credentials.host)),
+        Some(format!("Connected to {}", credentials.host.as_str())),
     );
     progress.update_step(
         ServerConnectionStepKind::FindingCodex,
@@ -445,12 +553,22 @@ async fn run_guided_ssh_connect(
         .update_server_connection_progress(&server_id, Some(progress.clone()));
 
     let remote_shell = ssh_client.detect_remote_shell().await;
+    info!(
+        "guided ssh connect detected shell server_id={} shell={:?}",
+        server_id,
+        remote_shell
+    );
     let codex_binary = match ssh_client
         .resolve_codex_binary_optional_with_shell(Some(remote_shell))
         .await
         .map_err(map_ssh_error)?
     {
         Some(binary) => {
+            info!(
+                "guided ssh connect found codex server_id={} path={}",
+                server_id,
+                binary.path()
+            );
             progress.update_step(
                 ServerConnectionStepKind::FindingCodex,
                 ServerConnectionStepState::Completed,
@@ -467,6 +585,11 @@ async fn run_guided_ssh_connect(
             binary
         }
         None => {
+            info!(
+                "guided ssh connect missing codex server_id={} host={}; awaiting install decision",
+                server_id,
+                credentials.host.as_str()
+            );
             progress.pending_install = true;
             progress.update_step(
                 ServerConnectionStepKind::FindingCodex,
@@ -486,6 +609,11 @@ async fn run_guided_ssh_connect(
             }
 
             let should_install = rx.await.unwrap_or(false);
+            info!(
+                "guided ssh connect install decision server_id={} install={}",
+                server_id,
+                should_install
+            );
             progress.pending_install = false;
             if !should_install {
                 progress.update_step(
@@ -527,10 +655,20 @@ async fn run_guided_ssh_connect(
                 .detect_remote_platform_with_shell(Some(remote_shell))
                 .await
                 .map_err(map_ssh_error)?;
+            info!(
+                "guided ssh connect install platform server_id={} platform={:?}",
+                server_id,
+                platform
+            );
             let installed_binary = ssh_client
                 .install_latest_stable_codex(platform)
                 .await
                 .map_err(map_ssh_error)?;
+            info!(
+                "guided ssh connect install completed server_id={} path={}",
+                server_id,
+                installed_binary.path()
+            );
             progress.update_step(
                 ServerConnectionStepKind::InstallingCodex,
                 ServerConnectionStepState::Completed,
@@ -552,6 +690,11 @@ async fn run_guided_ssh_connect(
         .app_store
         .update_server_connection_progress(&server_id, Some(progress.clone()));
 
+    info!(
+        "guided ssh connect bootstrapping app server server_id={} host={}",
+        server_id,
+        credentials.host.as_str()
+    );
     let bootstrap = ssh_client
         .bootstrap_codex_server_with_binary(
             &codex_binary,
@@ -560,6 +703,13 @@ async fn run_guided_ssh_connect(
         )
         .await
         .map_err(map_ssh_error)?;
+    info!(
+        "guided ssh connect bootstrap completed server_id={} remote_port={} local_tunnel_port={} pid={:?}",
+        server_id,
+        bootstrap.server_port,
+        bootstrap.tunnel_local_port,
+        bootstrap.pid
+    );
 
     progress.update_step(
         ServerConnectionStepKind::StartingAppServer,
@@ -580,6 +730,7 @@ async fn run_guided_ssh_connect(
         .app_store
         .update_server_connection_progress(&server_id, Some(progress.clone()));
 
+    let host = credentials.host.clone();
     mobile_client
         .finish_connect_remote_over_ssh(
             config,
@@ -595,6 +746,11 @@ async fn run_guided_ssh_connect(
         )
         .await
         .map_err(|error| ClientError::Transport(error.to_string()))?;
+    info!(
+        "guided ssh connect attached remote session server_id={} host={}",
+        server_id,
+        host.as_str()
+    );
 
     progress.update_step(
         ServerConnectionStepKind::Connected,

--- a/shared/rust-bridge/codex-mobile-client/src/mobile_client_impl.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/mobile_client_impl.rs
@@ -6,7 +6,7 @@ use std::future::Future;
 use std::panic::AssertUnwindSafe;
 use std::sync::{Arc, RwLock};
 use tokio::sync::{Mutex, broadcast};
-use tracing::{debug, info, warn};
+use tracing::{debug, info, trace, warn};
 use url::Url;
 
 use crate::discovery::{DiscoveredServer, DiscoveryConfig, DiscoveryService, MdnsSeed};
@@ -228,7 +228,7 @@ impl MobileClient {
         info!(
             "MobileClient: connect_remote_over_ssh start server_id={} host={} ssh_port={} accept_unknown_host={} working_dir={}",
             server_id,
-            ssh_credentials.host,
+            ssh_credentials.host.as_str(),
             ssh_credentials.port,
             accept_unknown_host,
             working_dir.as_deref().unwrap_or("<none>")
@@ -249,7 +249,7 @@ impl MobileClient {
         );
         info!(
             "MobileClient: SSH transport established server_id={} host={} ssh_port={}",
-            config.server_id, ssh_credentials.host, ssh_credentials.port
+            config.server_id, ssh_credentials.host.as_str(), ssh_credentials.port
         );
 
         let use_ipv6 = config.host.contains(':');
@@ -265,7 +265,7 @@ impl MobileClient {
                 );
                 warn!(
                     "MobileClient: remote ssh bootstrap failed server_id={} host={} error={}",
-                    config.server_id, ssh_credentials.host, error
+                    config.server_id, ssh_credentials.host.as_str(), error
                 );
                 ssh_client.disconnect().await;
                 return Err(map_ssh_transport_error(error));
@@ -274,7 +274,7 @@ impl MobileClient {
         info!(
             "MobileClient: remote ssh bootstrap succeeded server_id={} host={} remote_port={} local_tunnel_port={} pid={:?}",
             config.server_id,
-            ssh_credentials.host,
+            ssh_credentials.host.as_str(),
             bootstrap.server_port,
             bootstrap.tunnel_local_port,
             bootstrap.pid
@@ -299,6 +299,15 @@ impl MobileClient {
         ipc_socket_path_override: Option<String>,
     ) -> Result<String, TransportError> {
         let server_id = config.server_id.clone();
+        trace!(
+            "MobileClient: finish_connect_remote_over_ssh start server_id={} host={} bootstrap_remote_port={} bootstrap_local_port={} pid={:?} ipc_socket_path_override={}",
+            server_id,
+            ssh_credentials.host.as_str(),
+            bootstrap.server_port,
+            bootstrap.tunnel_local_port,
+            bootstrap.pid,
+            ipc_socket_path_override.as_deref().unwrap_or("<none>")
+        );
 
         config.port = bootstrap.server_port;
         config.websocket_url = Some(format!("ws://127.0.0.1:{}", bootstrap.tunnel_local_port));
@@ -308,6 +317,11 @@ impl MobileClient {
         let ipc_ssh_client = None;
         let ipc_bridge_pid = None;
 
+        #[cfg(target_os = "android")]
+        trace!(
+            "MobileClient: finish_connect_remote_over_ssh attaching IPC over SSH server_id={}",
+            server_id
+        );
         #[cfg(target_os = "android")]
         let ipc_client = match AssertUnwindSafe(attach_ipc_client_via_ssh(
             &ssh_client,
@@ -328,12 +342,22 @@ impl MobileClient {
         };
 
         #[cfg(not(target_os = "android"))]
+        trace!(
+            "MobileClient: finish_connect_remote_over_ssh attaching IPC over SSH server_id={}",
+            server_id
+        );
+        #[cfg(not(target_os = "android"))]
         let ipc_client = attach_ipc_client_via_ssh(
             &ssh_client,
             config.server_id.as_str(),
             ipc_socket_path_override.as_deref(),
         )
         .await;
+        trace!(
+            "MobileClient: finish_connect_remote_over_ssh IPC attach result server_id={} attached={}",
+            server_id,
+            ipc_client.is_some()
+        );
 
         let session = match ServerSession::connect_remote_with_resources(
             config,
@@ -355,7 +379,7 @@ impl MobileClient {
                 );
                 warn!(
                     "MobileClient: remote ssh session connect failed server_id={} host={} error={}",
-                    server_id, ssh_credentials.host, error
+                    server_id, ssh_credentials.host.as_str(), error
                 );
                 ssh_client.disconnect().await;
                 return Err(error);
@@ -364,6 +388,11 @@ impl MobileClient {
 
         self.app_store
             .upsert_server(session.config(), ServerHealthSnapshot::Connected);
+        trace!(
+            "MobileClient: finish_connect_remote_over_ssh session connected server_id={} websocket_url={}",
+            server_id,
+            session.config().websocket_url.as_deref().unwrap_or("<none>")
+        );
         if session.has_ipc() {
             self.app_store
                 .update_server_ipc_state(server_id.as_str(), true);
@@ -379,6 +408,10 @@ impl MobileClient {
         if let Err(error) = self.sync_server_account(server_id.as_str()).await {
             warn!("MobileClient: failed to sync account for {server_id}: {error}");
         }
+        trace!(
+            "MobileClient: finish_connect_remote_over_ssh account sync completed server_id={}",
+            server_id
+        );
         if let Err(error) = refresh_thread_list_from_app_server(
             Arc::clone(&session),
             Arc::clone(&self.app_store),
@@ -388,6 +421,10 @@ impl MobileClient {
         {
             warn!("MobileClient: failed to refresh thread list for {server_id}: {error}");
         }
+        trace!(
+            "MobileClient: finish_connect_remote_over_ssh thread refresh completed server_id={}",
+            server_id
+        );
 
         info!("MobileClient: connected remote SSH server {server_id}");
         Ok(server_id)

--- a/shared/rust-bridge/codex-mobile-client/src/ssh.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/ssh.rs
@@ -21,7 +21,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 use tokio_tungstenite::connect_async;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::logging::{LogLevelName, log_rust};
 use base64::Engine;
@@ -36,6 +36,24 @@ fn append_android_debug_log(line: &str) {
 
 fn append_bridge_info_log(line: &str) {
     append_bridge_log(LogLevelName::Info, line);
+}
+
+fn remote_shell_name(shell: RemoteShell) -> &'static str {
+    match shell {
+        RemoteShell::Posix => "posix",
+        RemoteShell::PowerShell => "powershell",
+    }
+}
+
+fn remote_platform_name(platform: RemotePlatform) -> &'static str {
+    match platform {
+        RemotePlatform::MacosArm64 => "macos-arm64",
+        RemotePlatform::MacosX64 => "macos-x64",
+        RemotePlatform::LinuxArm64 => "linux-arm64",
+        RemotePlatform::LinuxX64 => "linux-x64",
+        RemotePlatform::WindowsX64 => "windows-x64",
+        RemotePlatform::WindowsArm64 => "windows-arm64",
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -721,6 +739,13 @@ printf '%s/codex-ipc/ipc-%s.sock' "$tmp" "$uid""#;
         prefer_ipv6: bool,
         shell: RemoteShell,
     ) -> Result<SshBootstrapResult, SshError> {
+        info!(
+            "ssh bootstrap begin binary={} shell={} prefer_ipv6={} working_dir={}",
+            codex_binary.path(),
+            remote_shell_name(shell),
+            prefer_ipv6,
+            working_dir.unwrap_or("<none>")
+        );
         // --- 2. Try candidate ports until one works ---------------------
         let cd_prefix = match (shell, working_dir) {
             (RemoteShell::Posix, Some(dir)) => format!("cd {} && ", shell_quote(dir)),
@@ -732,6 +757,12 @@ printf '%s/codex-ipc/ipc-%s.sock' "$tmp" "$uid""#;
 
         for offset in 0..PORT_CANDIDATES {
             let port = DEFAULT_REMOTE_PORT + offset;
+            trace!(
+                "ssh bootstrap port candidate shell={} port={} attempt={}",
+                remote_shell_name(shell),
+                port,
+                offset + 1
+            );
             append_bridge_info_log(&format!(
                 "ssh_bootstrap_candidate port={} attempt={}",
                 port,
@@ -835,6 +866,14 @@ printf '%s/codex-ipc/ipc-%s.sock' "$tmp" "$uid""#;
 
             let launch_result = self.exec_shell(&launch_cmd, shell).await?;
             let pid: Option<u32> = launch_result.stdout.trim().parse().ok();
+            info!(
+                "ssh bootstrap launched shell={} port={} pid={:?} stdout_len={} stderr_len={}",
+                remote_shell_name(shell),
+                port,
+                pid,
+                launch_result.stdout.trim().len(),
+                launch_result.stderr.trim().len()
+            );
             append_bridge_info_log(&format!(
                 "ssh_bootstrap_launch_result port={} pid={:?} stdout={} stderr={}",
                 port,
@@ -862,8 +901,21 @@ printf '%s/codex-ipc/ipc-%s.sock' "$tmp" "$uid""#;
                             )
                             .await;
                         if tail.to_ascii_lowercase().contains("address already in use") {
+                            info!(
+                                "ssh bootstrap process exited due to occupied port shell={} port={} pid={:?}",
+                                remote_shell_name(shell),
+                                port,
+                                pid
+                            );
                             break; // try next port
                         }
+                        warn!(
+                            "ssh bootstrap process exited before listen shell={} port={} pid={:?} tail={}",
+                            remote_shell_name(shell),
+                            port,
+                            pid,
+                            tail
+                        );
                         return Err(SshError::ExecFailed {
                             exit_code: 1,
                             stderr: if tail.is_empty() {
@@ -883,8 +935,19 @@ printf '%s/codex-ipc/ipc-%s.sock' "$tmp" "$uid""#;
                     .fetch_process_log_tail_shell(&log_path, stderr_log_path.as_deref(), shell)
                     .await;
                 if tail.to_ascii_lowercase().contains("address already in use") {
+                    info!(
+                        "ssh bootstrap listen timeout due to occupied port shell={} port={}",
+                        remote_shell_name(shell),
+                        port
+                    );
                     continue; // try next port
                 }
+                warn!(
+                    "ssh bootstrap timed out waiting for listen shell={} port={} tail={}",
+                    remote_shell_name(shell),
+                    port,
+                    tail
+                );
                 if offset == PORT_CANDIDATES - 1 {
                     return Err(SshError::ExecFailed {
                         exit_code: 1,
@@ -943,6 +1006,14 @@ printf '%s/codex-ipc/ipc-%s.sock' "$tmp" "$uid""#;
             let version = self
                 .read_server_version_shell(codex_binary.path(), shell)
                 .await;
+            info!(
+                "ssh bootstrap complete shell={} remote_port={} local_port={} pid={:?} version={}",
+                remote_shell_name(shell),
+                port,
+                local_port,
+                pid,
+                version.clone().unwrap_or_else(|| "<unknown>".to_string())
+            );
             append_bridge_info_log(&format!(
                 "ssh_bootstrap_success port={} local_port={} pid={:?} version={}",
                 port,
@@ -1007,6 +1078,10 @@ printf '%s/codex-ipc/ipc-%s.sock' "$tmp" "$uid""#;
             Some(s) => s,
             None => self.detect_remote_shell().await,
         };
+        trace!(
+            "ssh resolve codex binary shell={}",
+            remote_shell_name(shell)
+        );
 
         let script = match shell {
             RemoteShell::PowerShell => resolve_codex_binary_script_powershell(),
@@ -1016,14 +1091,33 @@ printf '%s/codex-ipc/ipc-%s.sock' "$tmp" "$uid""#;
         let result = self.exec_shell(&script, shell).await?;
         let raw = result.stdout.trim();
         if raw.is_empty() {
+            info!(
+                "ssh resolve codex binary missing shell={}",
+                remote_shell_name(shell)
+            );
             return Ok(None);
         }
         if let Some(path) = raw.strip_prefix("codex:") {
+            info!(
+                "ssh resolve codex binary found selector=codex shell={} path={}",
+                remote_shell_name(shell),
+                path
+            );
             return Ok(Some(RemoteCodexBinary::Codex(path.to_string())));
         }
         if let Some(path) = raw.strip_prefix("app-server:") {
+            info!(
+                "ssh resolve codex binary found selector=app-server shell={} path={}",
+                remote_shell_name(shell),
+                path
+            );
             return Ok(Some(RemoteCodexBinary::AppServer(path.to_string())));
         }
+        warn!(
+            "ssh resolve codex binary unexpected selector shell={} raw={}",
+            remote_shell_name(shell),
+            raw
+        );
         Err(SshError::ExecFailed {
             exit_code: 1,
             stderr: format!("unexpected remote codex binary selector: {raw}"),
@@ -1276,6 +1370,7 @@ fi"#
                 out, result.exit_code
             ));
             if out == "Windows_NT" {
+                info!("ssh detect shell result=powershell via=cmd_probe");
                 return RemoteShell::PowerShell;
             }
         }
@@ -1287,10 +1382,12 @@ fi"#
                 out, result.exit_code
             ));
             if out.contains("Windows") {
+                info!("ssh detect shell result=powershell via=ps_probe");
                 return RemoteShell::PowerShell;
             }
         }
         append_bridge_info_log("ssh_detect_shell result=Posix");
+        info!("ssh detect shell result=posix");
         RemoteShell::Posix
     }
 
@@ -1302,6 +1399,11 @@ fi"#
         command: &str,
         shell: RemoteShell,
     ) -> Result<ExecResult, SshError> {
+        trace!(
+            "ssh exec shell={} command_len={}",
+            remote_shell_name(shell),
+            command.len()
+        );
         match shell {
             RemoteShell::Posix => self.exec(command).await,
             RemoteShell::PowerShell => {
@@ -1339,6 +1441,10 @@ fi"#
             Some(s) => s,
             None => self.detect_remote_shell().await,
         };
+        info!(
+            "ssh detect platform start shell={}",
+            remote_shell_name(shell)
+        );
 
         match shell {
             RemoteShell::PowerShell => {
@@ -1351,7 +1457,7 @@ fi"#
                 let mut lines = result.stdout.lines();
                 let os = lines.next().unwrap_or_default().trim();
                 let arch = lines.next().unwrap_or_default().trim();
-                match (os, arch) {
+                let platform = match (os, arch) {
                     ("Windows_NT", "AMD64") | ("Windows_NT", "x86_64") => {
                         Ok(RemotePlatform::WindowsX64)
                     }
@@ -1362,7 +1468,15 @@ fi"#
                         exit_code: 1,
                         stderr: format!("unsupported Windows platform: os={os} arch={arch}"),
                     }),
-                }
+                }?;
+                info!(
+                    "ssh detect platform result shell={} os={} arch={} platform={}",
+                    remote_shell_name(shell),
+                    os,
+                    arch,
+                    remote_platform_name(platform)
+                );
+                Ok(platform)
             }
             RemoteShell::Posix => {
                 let result = self
@@ -1371,7 +1485,7 @@ fi"#
                 let mut lines = result.stdout.lines();
                 let os = lines.next().unwrap_or_default().trim();
                 let arch = lines.next().unwrap_or_default().trim();
-                match (os, arch) {
+                let platform = match (os, arch) {
                     ("Darwin", "arm64") | ("Darwin", "aarch64") => Ok(RemotePlatform::MacosArm64),
                     ("Darwin", "x86_64") | ("Darwin", "amd64") => Ok(RemotePlatform::MacosX64),
                     ("Linux", "aarch64") | ("Linux", "arm64") => Ok(RemotePlatform::LinuxArm64),
@@ -1380,7 +1494,15 @@ fi"#
                         exit_code: 1,
                         stderr: format!("unsupported remote platform: os={os} arch={arch}"),
                     }),
-                }
+                }?;
+                info!(
+                    "ssh detect platform result shell={} os={} arch={} platform={}",
+                    remote_shell_name(shell),
+                    os,
+                    arch,
+                    remote_platform_name(platform)
+                );
+                Ok(platform)
             }
         }
     }
@@ -1389,10 +1511,24 @@ fi"#
         &self,
         platform: RemotePlatform,
     ) -> Result<RemoteCodexBinary, SshError> {
+        info!(
+            "ssh install codex start platform={}",
+            remote_platform_name(platform)
+        );
         if platform.is_windows() {
+            info!(
+                "ssh install codex using npm platform={}",
+                remote_platform_name(platform)
+            );
             return self.install_codex_via_npm(RemoteShell::PowerShell).await;
         }
         let release = fetch_latest_stable_codex_release(platform).await?;
+        info!(
+            "ssh install codex using release platform={} tag={} asset={}",
+            remote_platform_name(platform),
+            release.tag_name,
+            release.asset_name
+        );
         let install_script = format!(
             r#"set -e
 tag={tag}
@@ -1450,6 +1586,11 @@ printf '%s' "$stable_bin""#,
             });
         }
         let installed_path = result.stdout.trim();
+        info!(
+            "ssh install codex completed platform={} path={}",
+            remote_platform_name(platform),
+            if installed_path.is_empty() { "$HOME/.litter/bin/codex" } else { installed_path }
+        );
         Ok(RemoteCodexBinary::Codex(if installed_path.is_empty() {
             "$HOME/.litter/bin/codex".to_string()
         } else {
@@ -1463,6 +1604,10 @@ printf '%s' "$stable_bin""#,
         &self,
         shell: RemoteShell,
     ) -> Result<RemoteCodexBinary, SshError> {
+        info!(
+            "ssh npm install codex start shell={}",
+            remote_shell_name(shell)
+        );
         let script = match shell {
             RemoteShell::PowerShell => {
                 r#"$ErrorActionPreference = 'Stop'
@@ -1492,6 +1637,12 @@ if [ -x "$bin" ]; then printf 'CODEX_PATH:%s' "$bin"; else echo "codex not found
 
         let result = self.exec_shell(&script, shell).await?;
         if result.exit_code != 0 {
+            warn!(
+                "ssh npm install codex failed shell={} exit_code={} stderr={}",
+                remote_shell_name(shell),
+                result.exit_code,
+                result.stderr.trim()
+            );
             return Err(SshError::ExecFailed {
                 exit_code: result.exit_code,
                 stderr: if result.stderr.trim().is_empty() {
@@ -1507,7 +1658,14 @@ if [ -x "$bin" ]; then printf 'CODEX_PATH:%s' "$bin"; else echo "codex not found
             .find_map(|line| line.trim().strip_prefix("CODEX_PATH:"))
             .map(|p| p.trim().to_string());
         match installed_path {
-            Some(path) if !path.is_empty() => Ok(RemoteCodexBinary::Codex(path)),
+            Some(path) if !path.is_empty() => {
+                info!(
+                    "ssh npm install codex completed shell={} path={}",
+                    remote_shell_name(shell),
+                    path
+                );
+                Ok(RemoteCodexBinary::Codex(path))
+            }
             _ => {
                 append_bridge_info_log(&format!(
                     "ssh_npm_install_no_path stdout={:?} stderr={:?}",


### PR DESCRIPTION
## Summary
- fix Android conversation/realtime/runtime parity issues and restore local experimental feature handling
- add shared SSH/Windows bootstrap trace logging across Rust, Android, and iOS paths using the existing mobile logger stack
- automate mobile releases from `main` with `make testflight` and `make play-release`, keeping TestFlight pinned to marketing version `1.0.1` and uploading Android APK/AAB artifacts

## Verification
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./apps/android/gradlew -p apps/android :app:compileDebugKotlin`
- `bash -n apps/android/scripts/bump-version.sh apps/android/scripts/play-upload.sh apps/ios/scripts/testflight-upload.sh`
- `ruby -e 'require "yaml"; [".github/workflows/ios-testflight.yml", ".github/workflows/android-play-release.yml"].each { |p| YAML.load_file(p) }'`
- `git diff --check`

## Follow-up
- add the `LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64` secret to the GitHub `release` environment before relying on the Android main-push Play workflow