### PR TITLE
ci: install release runner deps

### DIFF
--- a/.github/workflows/android-apk-release.yml
+++ b/.github/workflows/android-apk-release.yml
@@ -76,6 +76,9 @@ jobs:
           yes | sdkmanager --licenses
           sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0" "ndk;30.0.14904198"
 
+      - name: Install system deps
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libcap-dev clang cmake
+
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/android-play-release.yml
+++ b/.github/workflows/android-play-release.yml
@@ -66,6 +66,9 @@ jobs:
           yes | sdkmanager --licenses
           sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0" "ndk;30.0.14904198"
 
+      - name: Install system deps
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libcap-dev clang cmake
+
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Install build dependencies
         run: |
           set -euo pipefail
-          brew install xcodegen jq asc
+          brew install xcodegen jq asc meson ninja
           xcodebuild -version
           asc --version
 

--- a/shared/third_party/webrtc-audio-processing-sys/build.rs
+++ b/shared/third_party/webrtc-audio-processing-sys/build.rs
@@ -292,7 +292,10 @@ mod webrtc {
                 "aarch64-apple-ios-sim" | "x86_64-apple-ios" => {
                     format!("-mios-simulator-version-min={}", ios_deployment_target())
                 }
-                target => panic!("unsupported iOS target for webrtc-audio-processing: {target}"),
+                target => panic!(
+                    "unsupported iOS target for webrtc-audio-processing: {}",
+                    target
+                ),
             };
             std::fs::write(
                 &cross_file,


### PR DESCRIPTION
## Summary
- install Linux system dependencies needed by Android release/play workflows so `pkg-config` can resolve `libcap`
- install `meson` and `ninja` for the iOS TestFlight runner so `webrtc-audio-processing-sys` can build
- fix the stale non-format `panic!` in `webrtc-audio-processing-sys/build.rs`

## Verification
- `git diff --check`
- verified the Android CI failure matched missing `libcap.pc` on the release runner
- verified the iOS CI failure matched missing `meson` on the TestFlight runner