### PR TITLE
ci: avoid linux bindgen in android releases

### DIFF
--- a/.github/workflows/android-apk-release.yml
+++ b/.github/workflows/android-apk-release.yml
@@ -48,8 +48,69 @@ jobs:
 
           echo "run_release=$run_release" >> "$GITHUB_OUTPUT"
 
-  release-apk:
+  shared-prep:
     needs: detect-android-changes
+    if: needs.detect-android-changes.outputs.run_release == 'true'
+    runs-on: macos-26
+    timeout-minutes: 60
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      SCCACHE_BUCKET: rust-cache
+      SCCACHE_ENDPOINT: ${{ secrets.SCCACHE_R2_ENDPOINT }}
+      SCCACHE_REGION: auto
+      SCCACHE_S3_USE_SSL: "true"
+      SCCACHE_S3_KEY_PREFIX: ci/android-release-prep
+      AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.3'
+
+      - name: Install build dependencies
+        run: brew install meson ninja
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Generate shared mobile bindings
+        env:
+          RUSTC_WRAPPER: sccache
+          CARGO_INCREMENTAL: "0"
+        run: |
+          ./apps/ios/scripts/sync-codex.sh --preserve-current
+          cd shared/rust-bridge
+          ./generate-bindings.sh --kotlin-only
+
+      - name: Package shared prep artifact
+        run: |
+          mkdir -p .ci-prep/shared
+          tar -czf .ci-prep/shared/generated-mobile-sources.tgz -C . \
+            shared/rust-bridge/generated \
+            shared/rust-bridge/codex-mobile-client/src/types/codegen_types.generated.rs \
+            shared/rust-bridge/codex-mobile-client/src/rpc/generated_client.generated.rs \
+            shared/rust-bridge/codex-mobile-client/src/ffi/rpc.generated.rs
+
+      - name: Upload shared prep artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: shared-prep
+          path: .ci-prep/shared
+          if-no-files-found: error
+
+  release-apk:
+    needs: [detect-android-changes, shared-prep]
     if: needs.detect-android-changes.outputs.run_release == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 90
@@ -95,6 +156,25 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
 
+      - name: Download shared prep artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: shared-prep
+          path: .ci-prep/shared
+
+      - name: Restore shared prep
+        run: |
+          ./apps/ios/scripts/sync-codex.sh --preserve-current
+
+          SHARED_PREP_ROOT=.ci-prep/shared
+          if [ -d "$SHARED_PREP_ROOT/shared" ]; then
+            SHARED_PREP_ROOT="$SHARED_PREP_ROOT/shared"
+          fi
+
+          tar -xzf "$SHARED_PREP_ROOT/generated-mobile-sources.tgz" -C .
+          mkdir -p .build-stamps
+          touch .build-stamps/sync .build-stamps/bindings-kotlin
+
       - name: Install cargo-ndk
         run: cargo install cargo-ndk
 
@@ -103,9 +183,6 @@ jobs:
           ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/30.0.14904198
           RUSTC_WRAPPER: sccache
         run: make rust-android
-
-      - name: Generate UniFFI Kotlin bindings
-        run: make bindings-kotlin
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/android-play-release.yml
+++ b/.github/workflows/android-play-release.yml
@@ -17,7 +17,67 @@ permissions:
   contents: read
 
 jobs:
+  shared-prep:
+    runs-on: macos-26
+    timeout-minutes: 60
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      SCCACHE_BUCKET: rust-cache
+      SCCACHE_ENDPOINT: ${{ secrets.SCCACHE_R2_ENDPOINT }}
+      SCCACHE_REGION: auto
+      SCCACHE_S3_USE_SSL: "true"
+      SCCACHE_S3_KEY_PREFIX: ci/android-release-prep
+      AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.3'
+
+      - name: Install build dependencies
+        run: brew install meson ninja
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Generate shared mobile bindings
+        env:
+          RUSTC_WRAPPER: sccache
+          CARGO_INCREMENTAL: "0"
+        run: |
+          ./apps/ios/scripts/sync-codex.sh --preserve-current
+          cd shared/rust-bridge
+          ./generate-bindings.sh --kotlin-only
+
+      - name: Package shared prep artifact
+        run: |
+          mkdir -p .ci-prep/shared
+          tar -czf .ci-prep/shared/generated-mobile-sources.tgz -C . \
+            shared/rust-bridge/generated \
+            shared/rust-bridge/codex-mobile-client/src/types/codegen_types.generated.rs \
+            shared/rust-bridge/codex-mobile-client/src/rpc/generated_client.generated.rs \
+            shared/rust-bridge/codex-mobile-client/src/ffi/rpc.generated.rs
+
+      - name: Upload shared prep artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: shared-prep
+          path: .ci-prep/shared
+          if-no-files-found: error
+
   play-release:
+    needs: shared-prep
     runs-on: ubuntu-latest
     timeout-minutes: 90
     environment: release
@@ -84,6 +144,25 @@ jobs:
           SCCACHE_S3_KEY_PREFIX: ci/android
           AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
+
+      - name: Download shared prep artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: shared-prep
+          path: .ci-prep/shared
+
+      - name: Restore shared prep
+        run: |
+          ./apps/ios/scripts/sync-codex.sh --preserve-current
+
+          SHARED_PREP_ROOT=.ci-prep/shared
+          if [ -d "$SHARED_PREP_ROOT/shared" ]; then
+            SHARED_PREP_ROOT="$SHARED_PREP_ROOT/shared"
+          fi
+
+          tar -xzf "$SHARED_PREP_ROOT/generated-mobile-sources.tgz" -C .
+          mkdir -p .build-stamps
+          touch .build-stamps/sync .build-stamps/bindings-kotlin
 
       - name: Install cargo-ndk
         run: cargo install cargo-ndk


### PR DESCRIPTION
## Summary
- move Android release Kotlin binding generation to a macOS shared-prep job
- restore generated bindings on Ubuntu release runners and mark the bindgen stamp ready
- avoid the Linux host `libcodex_mobile_client.so` bindgen path that reintroduces the V8 linker failure

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/android-play-release.yml"); YAML.load_file(".github/workflows/android-apk-release.yml"); puts "yaml ok"'`
- confirmed Android release workflows no longer run Ubuntu-side `make bindings-kotlin`
