### PR TITLE
mobile: land android follow-ups and ci cache fixes

### DIFF
--- a/.github/workflows/android-apk-release.yml
+++ b/.github/workflows/android-apk-release.yml
@@ -115,6 +115,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     environment: release
+    env:
+      SCCACHE_BUCKET: rust-cache
+      SCCACHE_ENDPOINT: ${{ secrets.SCCACHE_R2_ENDPOINT }}
+      SCCACHE_REGION: auto
+      SCCACHE_S3_USE_SSL: "true"
+      SCCACHE_S3_KEY_PREFIX: ci/android
+      AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
 
     steps:
       - name: Checkout
@@ -147,14 +155,6 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
-        env:
-          SCCACHE_BUCKET: rust-cache
-          SCCACHE_ENDPOINT: ${{ secrets.SCCACHE_R2_ENDPOINT }}
-          SCCACHE_REGION: auto
-          SCCACHE_S3_USE_SSL: "true"
-          SCCACHE_S3_KEY_PREFIX: ci/android
-          AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
 
       - name: Download shared prep artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/android-play-release.yml
+++ b/.github/workflows/android-play-release.yml
@@ -81,6 +81,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     environment: release
+    env:
+      SCCACHE_BUCKET: rust-cache
+      SCCACHE_ENDPOINT: ${{ secrets.SCCACHE_R2_ENDPOINT }}
+      SCCACHE_REGION: auto
+      SCCACHE_S3_USE_SSL: "true"
+      SCCACHE_S3_KEY_PREFIX: ci/android
+      AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
 
     steps:
       - name: Checkout
@@ -136,14 +144,6 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
-        env:
-          SCCACHE_BUCKET: rust-cache
-          SCCACHE_ENDPOINT: ${{ secrets.SCCACHE_R2_ENDPOINT }}
-          SCCACHE_REGION: auto
-          SCCACHE_S3_USE_SSL: "true"
-          SCCACHE_S3_KEY_PREFIX: ci/android
-          AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
 
       - name: Download shared prep artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -33,6 +33,13 @@ jobs:
     environment: release
     env:
       HOMEBREW_NO_AUTO_UPDATE: "1"
+      SCCACHE_BUCKET: rust-cache
+      SCCACHE_ENDPOINT: ${{ secrets.SCCACHE_R2_ENDPOINT }}
+      SCCACHE_REGION: auto
+      SCCACHE_S3_USE_SSL: "true"
+      SCCACHE_S3_KEY_PREFIX: ci/ios
+      AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
 
     steps:
       - name: Checkout
@@ -84,14 +91,6 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
-        env:
-          SCCACHE_BUCKET: rust-cache
-          SCCACHE_ENDPOINT: ${{ secrets.SCCACHE_R2_ENDPOINT }}
-          SCCACHE_REGION: auto
-          SCCACHE_S3_USE_SSL: "true"
-          SCCACHE_S3_KEY_PREFIX: ci/ios
-          AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
 
       - name: Decode App Store Connect API key
         env:

--- a/apps/android/app/src/main/java/com/litter/android/state/AppModel.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/AppModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -27,6 +28,7 @@ import uniffi.codex_mobile_client.ServerBridge
 import uniffi.codex_mobile_client.SshBridge
 import uniffi.codex_mobile_client.ThreadKey
 import uniffi.codex_mobile_client.ThreadListParams
+import uniffi.codex_mobile_client.ThreadReadParams
 
 /**
  * Central app state singleton. Thin wrapper over Rust [AppStore] — all business
@@ -336,6 +338,81 @@ class AppModel private constructor(context: android.content.Context) {
             _lastError.value = e.message
             throw e
         }
+    }
+
+    suspend fun ensureThreadLoaded(
+        key: ThreadKey,
+        maxAttempts: Int = 5,
+    ): ThreadKey? {
+        if (_snapshot.value?.threads?.any { it.key == key } == true) {
+            return key
+        }
+
+        var currentKey = key
+        repeat(maxAttempts) { attempt ->
+            var readSucceeded = false
+            try {
+                val response = rpc.threadRead(
+                    currentKey.serverId,
+                    ThreadReadParams(
+                        threadId = currentKey.threadId,
+                        includeTurns = true,
+                    ),
+                )
+                currentKey = ThreadKey(
+                    serverId = currentKey.serverId,
+                    threadId = response.thread.id,
+                )
+                store.setActiveThread(currentKey)
+                readSucceeded = true
+            } catch (e: Exception) {
+                _lastError.value = e.message
+            }
+
+            refreshSnapshot()
+            if (_snapshot.value?.threads?.any { it.key == currentKey } == true) {
+                return currentKey
+            }
+
+            if (!readSucceeded) {
+                try {
+                    rpc.threadList(
+                        currentKey.serverId,
+                        ThreadListParams(
+                            cursor = null,
+                            limit = null,
+                            sortKey = null,
+                            modelProviders = null,
+                            sourceKinds = null,
+                            archived = null,
+                            cwd = null,
+                            searchTerm = null,
+                        ),
+                    )
+                } catch (e: Exception) {
+                    _lastError.value = e.message
+                }
+
+                refreshSnapshot()
+                if (_snapshot.value?.threads?.any { it.key == currentKey } == true) {
+                    return currentKey
+                }
+            }
+
+            if (attempt + 1 < maxAttempts) {
+                delay(250)
+            }
+        }
+
+        val activeKey = _snapshot.value?.activeThread
+        if (activeKey != null &&
+            activeKey.serverId == currentKey.serverId &&
+            _snapshot.value?.threads?.any { it.key == activeKey } == true
+        ) {
+            return activeKey
+        }
+
+        return null
     }
 
     // --- Internal event handling ----------------------------------------------

--- a/apps/android/app/src/main/java/com/litter/android/state/VoiceTranscriptionManager.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/VoiceTranscriptionManager.kt
@@ -19,6 +19,7 @@ import java.net.URL
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import kotlin.math.sqrt
+import uniffi.codex_mobile_client.AuthMode
 
 /**
  * Records microphone input and transcribes via ChatGPT/OpenAI API.
@@ -91,7 +92,7 @@ class VoiceTranscriptionManager {
         }.also { it.start() }
     }
 
-    suspend fun stopAndTranscribe(authToken: String, useOpenAI: Boolean = false): String? {
+    suspend fun stopAndTranscribe(authMethod: AuthMode?, authToken: String?): String? {
         _isRecording.value = false
         audioRecord?.stop()
         audioRecord?.release()
@@ -119,6 +120,12 @@ class VoiceTranscriptionManager {
             return null
         }
 
+        val token = authToken?.trim().orEmpty()
+        if (token.isEmpty()) {
+            _error.value = "Not logged in."
+            return null
+        }
+
         // Resample to 24kHz
         val targetRate = 24000
         val resampled = resample(allSamples, deviceSampleRate, targetRate)
@@ -128,10 +135,10 @@ class VoiceTranscriptionManager {
         _isTranscribing.value = true
         return try {
             withContext(Dispatchers.IO) {
-                if (useOpenAI) {
-                    transcribeOpenAI(wav, authToken)
+                if (authMethod == AuthMode.API_KEY) {
+                    transcribeOpenAI(wav, token)
                 } else {
-                    transcribeChatGPT(wav, authToken)
+                    transcribeChatGPT(wav, token)
                 }
             }
         } catch (e: Exception) {
@@ -259,7 +266,7 @@ class VoiceTranscriptionManager {
 
         // Parse transcript from JSON response
         return try {
-            org.json.JSONObject(response).optString("text", null)
+            org.json.JSONObject(response).optString("text").takeIf { it.isNotBlank() }
         } catch (_: Exception) {
             response.takeIf { it.isNotBlank() }
         }

--- a/apps/android/app/src/main/java/com/litter/android/ui/LitterApp.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/LitterApp.kt
@@ -108,10 +108,13 @@ fun LitterApp(appModel: AppModel) {
                 serverId,
                 appModel.launchState.threadStartParams(cwd),
             )
-            val key = ThreadKey(serverId = serverId, threadId = response.thread.id)
-            appModel.store.setActiveThread(key)
+            val startedKey = ThreadKey(serverId = serverId, threadId = response.thread.id)
+            appModel.store.setActiveThread(startedKey)
             appModel.refreshSnapshot()
-            navigateToConversation(key)
+            val resolvedKey = appModel.ensureThreadLoaded(startedKey)
+                ?: appModel.snapshot.value?.threads?.firstOrNull { it.key == startedKey }?.key
+                ?: startedKey
+            navigateToConversation(resolvedKey)
         }
 
         fun openDirectoryPicker(preferredServerId: String? = null) {

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ComposerBar.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ComposerBar.kt
@@ -67,6 +67,7 @@ import com.litter.android.state.VoiceTranscriptionManager
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import uniffi.codex_mobile_client.FuzzyFileSearchParams
+import uniffi.codex_mobile_client.GetAuthStatusParams
 import uniffi.codex_mobile_client.PendingUserInputAnswer
 import uniffi.codex_mobile_client.PendingUserInputRequest
 import uniffi.codex_mobile_client.ReasoningEffort
@@ -205,15 +206,20 @@ fun ComposerBar(
             "fork" -> scope.launch {
                 try {
                     val cwd = appModel.snapshot.value?.threads?.find { it.key == threadKey }?.info?.cwd
-                    appModel.store.forkThreadFromMessage(
-                        threadKey,
-                        0u,
+                    val response = appModel.rpc.threadFork(
+                        threadKey.serverId,
                         appModel.launchState.threadForkParams(
                             sourceThreadId = threadKey.threadId,
                             cwdOverride = cwd,
                             modelOverride = appModel.launchState.snapshot.value.selectedModel.trim().ifEmpty { null },
                         ),
                     )
+                    val newKey = ThreadKey(
+                        serverId = threadKey.serverId,
+                        threadId = response.thread.id,
+                    )
+                    appModel.store.setActiveThread(newKey)
+                    appModel.refreshSnapshot()
                 } catch (e: Exception) {
                     onSlashError?.invoke(e.message ?: "Failed to fork conversation")
                 }
@@ -376,17 +382,19 @@ fun ComposerBar(
                 onClick = {
                     if (isRecording) {
                         scope.launch {
-                            // Get auth token from server account
-                            val snap = appModel.snapshot.value
-                            val server = snap?.servers?.firstOrNull { it.serverId == threadKey.serverId }
-                            // Extract auth token from server account
-                            val account = snap?.servers?.firstOrNull { it.serverId == threadKey.serverId }?.account
-                            val token = when (account) {
-                                is uniffi.codex_mobile_client.Account.Chatgpt -> "" // ChatGPT uses cookies, not bearer
-                                is uniffi.codex_mobile_client.Account.ApiKey -> "" // No direct token access
-                                else -> ""
-                            }
-                            val transcript = transcriptionManager.stopAndTranscribe(token)
+                            val auth = runCatching {
+                                appModel.rpc.getAuthStatus(
+                                    threadKey.serverId,
+                                    GetAuthStatusParams(
+                                        includeToken = true,
+                                        refreshToken = false,
+                                    ),
+                                )
+                            }.getOrNull()
+                            val transcript = transcriptionManager.stopAndTranscribe(
+                                authMethod = auth?.authMethod,
+                                authToken = auth?.authToken,
+                            )
                             transcript?.let { text = if (text.isBlank()) it else "$text $it" }
                         }
                     } else {

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationInfoScreen.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationInfoScreen.kt
@@ -169,17 +169,19 @@ fun ConversationInfoScreen(
                                 val t = thread ?: return@launch
                                 val tk = threadKey ?: return@launch
                                 try {
-                                    val newKey = appModel.store.forkThreadFromMessage(
-                                        tk,
-                                        0u,
+                                    val response = appModel.rpc.threadFork(
+                                        tk.serverId,
                                         appModel.launchState.threadForkParams(
-                                            tk.threadId,
+                                            sourceThreadId = tk.threadId,
                                             cwdOverride = t.info.cwd,
                                         ),
                                     )
+                                    val newKey = ThreadKey(
+                                        serverId = tk.serverId,
+                                        threadId = response.thread.id,
+                                    )
                                     appModel.store.setActiveThread(newKey)
                                     appModel.refreshSnapshot()
-                                    onBack()
                                 } catch (_: Exception) {}
                             }
                         },

--- a/apps/android/app/src/main/java/com/litter/android/ui/home/HomeDashboardScreen.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/home/HomeDashboardScreen.kt
@@ -1,8 +1,10 @@
 package com.litter.android.ui.home
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -379,6 +381,7 @@ fun HomeDashboardScreen(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun SessionCard(
     session: AppSessionSummary,
@@ -392,7 +395,10 @@ private fun SessionCard(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(LitterTheme.surface, RoundedCornerShape(10.dp))
-                .clickable(onClick = onClick)
+                .combinedClickable(
+                    onClick = onClick,
+                    onLongClick = { showMenu = true },
+                )
                 .padding(12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -444,6 +450,18 @@ private fun SessionCard(
                         fontSize = 10.sp,
                     )
                 }
+            }
+
+            Spacer(Modifier.width(4.dp))
+            IconButton(
+                onClick = { showMenu = true },
+                modifier = Modifier.size(28.dp),
+            ) {
+                Icon(
+                    Icons.Default.MoreVert,
+                    contentDescription = "Session actions",
+                    tint = LitterTheme.textSecondary,
+                )
             }
         }
 

--- a/apps/android/app/src/main/java/com/litter/android/ui/sessions/SessionsScreen.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/sessions/SessionsScreen.kt
@@ -93,6 +93,7 @@ fun SessionsScreen(
     var searchQuery by remember { mutableStateOf("") }
     var showSortMenu by remember { mutableStateOf(false) }
     var isLoading by remember { mutableStateOf(false) }
+    var isForkingActiveThread by remember { mutableStateOf(false) }
     var hasLoadedInitialSessions by remember { mutableStateOf(false) }
     var pendingActiveSessionScroll by remember { mutableStateOf(false) }
     val derived = remember(
@@ -176,6 +177,30 @@ fun SessionsScreen(
         }
     }
 
+    suspend fun forkThread(summary: uniffi.codex_mobile_client.AppSessionSummary) {
+        if (isForkingActiveThread) return
+        isForkingActiveThread = true
+        try {
+            val response = appModel.rpc.threadFork(
+                summary.key.serverId,
+                appModel.launchState.threadForkParams(
+                    sourceThreadId = summary.key.threadId,
+                    cwdOverride = summary.cwd,
+                ),
+            )
+            val newKey = ThreadKey(
+                serverId = summary.key.serverId,
+                threadId = response.thread.id,
+            )
+            appModel.store.setActiveThread(newKey)
+            appModel.refreshSnapshot()
+            appModel.launchState.updateCurrentCwd(summary.cwd)
+            onOpenConversation(newKey)
+        } finally {
+            isForkingActiveThread = false
+        }
+    }
+
     LaunchedEffect(connectedServerIds) {
         if (connectedServerIds.isEmpty()) {
             isLoading = false
@@ -233,6 +258,25 @@ fun SessionsScreen(
                 color = LitterTheme.textMuted,
                 fontSize = 12.sp,
             )
+            val activeSummary = snapshot?.activeThread?.let { activeKey ->
+                snapshot?.sessionSummaries?.firstOrNull { it.key == activeKey }
+            }
+            if (activeSummary != null) {
+                TextButton(
+                    onClick = { scope.launch { forkThread(activeSummary) } },
+                    enabled = !isForkingActiveThread && !activeSummary.hasActiveTurn,
+                ) {
+                    if (isForkingActiveThread) {
+                        CircularProgressIndicator(
+                            color = LitterTheme.accent,
+                            strokeWidth = 2.dp,
+                            modifier = Modifier.size(14.dp),
+                        )
+                    } else {
+                        Text("Fork", color = LitterTheme.accent, fontSize = 12.sp)
+                    }
+                }
+            }
             IconButton(
                 onClick = { scope.launch { loadSessions(force = true) } },
                 enabled = !isLoading && connectedServerIds.isNotEmpty(),
@@ -413,6 +457,9 @@ fun SessionsScreen(
                                 appModel.launchState.updateCurrentCwd(node.summary.cwd)
                                 onOpenConversation(node.summary.key)
                             },
+                            onFork = {
+                                scope.launch { forkThread(node.summary) }
+                            },
                         )
                     }
                 }
@@ -431,6 +478,7 @@ private fun SessionNodeRow(
     isCollapsed: Boolean,
     onToggleCollapse: () -> Unit,
     onClick: () -> Unit,
+    onFork: () -> Unit,
 ) {
     val appModel = LocalAppModel.current
     val scope = rememberCoroutineScope()
@@ -520,6 +568,13 @@ private fun SessionNodeRow(
         }
 
         DropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }) {
+            DropdownMenuItem(
+                text = { Text("Fork") },
+                onClick = {
+                    showMenu = false
+                    onFork()
+                },
+            )
             DropdownMenuItem(
                 text = { Text("Rename") },
                 onClick = { showMenu = false; showRenameDialog = true },

--- a/apps/android/app/src/main/java/com/litter/android/ui/settings/AccountSheet.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/settings/AccountSheet.kt
@@ -40,6 +40,7 @@ import com.litter.android.ui.LocalAppModel
 import com.litter.android.ui.LitterTheme
 import kotlinx.coroutines.launch
 import uniffi.codex_mobile_client.Account
+import uniffi.codex_mobile_client.GetAccountParams
 import uniffi.codex_mobile_client.LoginAccountParams
 
 /**
@@ -100,6 +101,19 @@ fun AccountSheet(
 
     androidx.compose.runtime.LaunchedEffect(serverId, account) {
         hasStoredApiKey = apiKeyStore.hasStoredKey()
+    }
+
+    androidx.compose.runtime.LaunchedEffect(serverId) {
+        runCatching {
+            appModel.rpc.getAccount(
+                serverId,
+                GetAccountParams(refreshToken = false),
+            )
+            appModel.refreshSnapshot()
+            error = null
+        }.onFailure { throwable ->
+            error = throwable.localizedMessage ?: throwable.message
+        }
     }
 
     Column(


### PR DESCRIPTION
## Summary
- land Android follow-ups for thread loading, session fork actions, conversation fork flows, account refresh, and voice transcription auth handling
- carry the Android release bindgen workaround into the release workflows
- move release workflow sccache backend env to job scope so compile steps actually use the remote cache

## Verification
- `ruby -e 'require "yaml"; %w[.github/workflows/ios-testflight.yml .github/workflows/android-play-release.yml .github/workflows/android-apk-release.yml].each { |f| YAML.load_file(f) }; puts "yaml ok"'`
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./apps/android/gradlew -p apps/android :app:compileDebugKotlin`
- `git diff --check`
