### PR TITLE
[codex] mobile runtime and tooling followups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,7 @@ rust-host-dev: rust-check rust-test
 
 log-collector:
 	@echo "==> Starting local mobile log collector on $(LOG_COLLECTOR_BIND)..."
+	@echo "==> Web tail UI will be available at /tail on that server."
 	@cd $(ROOT) && cargo run --manifest-path $(RUST_DIR)/Cargo.toml -p mobile-log-collector -- serve --bind $(LOG_COLLECTOR_BIND) --data-dir $(LOG_COLLECTOR_DATA_DIR)
 
 rust-android: $(STAMP_RUST_ANDROID)
@@ -230,7 +231,7 @@ help:
 		'make android-emulator-run  fast emulator build + install + launch on emulator' \
 		'make android-device-run    fast Android dev build + install + launch on connected device (override ANDROID_DEVICE_SERIAL; set ANDROID_REINSTALL_ON_SIGNATURE_MISMATCH=0 to keep installed app)' \
 		'make android-release    Android build using release Rust profile and multi-ABI output' \
-		'make log-collector     start local log collector (override LOG_COLLECTOR_BIND / LOG_COLLECTOR_DATA_DIR)' \
+		'make log-collector     start local log collector + web tail UI (override LOG_COLLECTOR_BIND / LOG_COLLECTOR_DATA_DIR)' \
 		'make rust-check         host cargo check for shared crates' \
 		'make rust-test          host cargo test for shared crates'
 

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
         applicationId = "com.sigkitten.litter.android"
         minSdk = 26
         targetSdk = 35
-        versionCode = 8
+        versionCode = 11
         versionName = "0.1.0"
         buildConfigField("boolean", "ENABLE_ON_DEVICE_BRIDGE", "true")
         buildConfigField("String", "RUNTIME_STARTUP_MODE", "\"hybrid\"")

--- a/apps/android/app/src/main/java/com/litter/android/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/litter/android/MainActivity.kt
@@ -20,6 +20,7 @@ import com.litter.android.state.AppModel
 import com.litter.android.state.OpenAIApiKeyStore
 import com.litter.android.state.TurnForegroundService
 import com.litter.android.ui.AnimatedSplashScreen
+import com.litter.android.ui.ExperimentalFeatures
 import com.litter.android.ui.LitterApp
 import com.litter.android.ui.LitterAppTheme
 import com.litter.android.ui.WallpaperManager
@@ -36,6 +37,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)
         OpenAIApiKeyStore(applicationContext).applyToEnvironment()
+        ExperimentalFeatures.initialize(applicationContext)
 
         try {
             appModel = AppModel.init(this)

--- a/apps/android/app/src/main/java/com/litter/android/state/AppLifecycleController.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/AppLifecycleController.kt
@@ -1,6 +1,7 @@
 package com.litter.android.state
 
 import android.content.Context
+import com.litter.android.ui.ExperimentalFeatures
 import com.litter.android.util.LLog
 import kotlinx.coroutines.sync.Mutex
 import uniffi.codex_mobile_client.ThreadKey
@@ -33,6 +34,7 @@ class AppLifecycleController {
             return
         }
         try {
+            ExperimentalFeatures.initialize(context.applicationContext)
             val saved = SavedServerStore.load(context)
             val sshCredentials = SshCredentialStore(context)
             val activeServerIds = appModel.store.snapshot()
@@ -121,6 +123,7 @@ class AppLifecycleController {
                 "os" to server.os,
             ),
         )
+        val ipcSocketPathOverride = ExperimentalFeatures.ipcSocketPathOverride()
         when (credential.method) {
             SshAuthMethod.PASSWORD -> {
                 appModel.ssh.sshConnectRemoteServer(
@@ -134,7 +137,7 @@ class AppLifecycleController {
                     passphrase = null,
                     acceptUnknownHost = true,
                     workingDir = null,
-                    ipcSocketPathOverride = null,
+                    ipcSocketPathOverride = ipcSocketPathOverride,
                 )
             }
             SshAuthMethod.KEY -> {
@@ -149,7 +152,7 @@ class AppLifecycleController {
                     passphrase = credential.passphrase,
                     acceptUnknownHost = true,
                     workingDir = null,
-                    ipcSocketPathOverride = null,
+                    ipcSocketPathOverride = ipcSocketPathOverride,
                 )
             }
         }

--- a/apps/android/app/src/main/java/com/litter/android/ui/ExperimentalFeatures.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/ExperimentalFeatures.kt
@@ -17,6 +17,12 @@ enum class LitterFeature(
         description = "Show the realtime voice launcher on the home screen.",
         defaultEnabled = true,
     ),
+    IPC(
+        id = "ipc",
+        displayName = "IPC",
+        description = "Attach to desktop IPC over SSH for faster sync, approvals, and resume. Requires reconnecting the server.",
+        defaultEnabled = false,
+    ),
     GENERATIVE_UI(
         id = "generative_ui",
         displayName = "Generative UI",
@@ -62,6 +68,14 @@ object ExperimentalFeatures {
         }
         overrides = next.toMap()
         persist(context)
+    }
+
+    fun ipcSocketPathOverride(): String? {
+        return if (isEnabled(LitterFeature.IPC)) {
+            null
+        } else {
+            ""
+        }
     }
 
     private fun persist(context: Context) {

--- a/apps/android/app/src/main/java/com/litter/android/ui/discovery/DiscoveryScreen.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/discovery/DiscoveryScreen.kt
@@ -1,4 +1,5 @@
 package com.litter.android.ui.discovery
+
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
@@ -65,6 +66,7 @@ import com.litter.android.state.isIpcConnected
 import com.litter.android.state.isConnected
 import com.litter.android.state.statusColor
 import com.litter.android.state.statusLabel
+import com.litter.android.ui.ExperimentalFeatures
 import com.litter.android.ui.LitterTheme
 import com.litter.android.ui.LocalAppModel
 import com.litter.android.util.LLog
@@ -505,7 +507,7 @@ fun DiscoveryScreen(
                                 passphrase = null,
                                 acceptUnknownHost = true,
                                 workingDir = null,
-                                ipcSocketPathOverride = null,
+                                ipcSocketPathOverride = ExperimentalFeatures.ipcSocketPathOverride(),
                             )
                         }
 
@@ -521,7 +523,7 @@ fun DiscoveryScreen(
                                 passphrase = credential.passphrase,
                                 acceptUnknownHost = true,
                                 workingDir = null,
-                                ipcSocketPathOverride = null,
+                                ipcSocketPathOverride = ExperimentalFeatures.ipcSocketPathOverride(),
                             )
                         }
                     }

--- a/apps/ios/Sources/Litter/Models/AppLifecycleController.swift
+++ b/apps/ios/Sources/Litter/Models/AppLifecycleController.swift
@@ -117,6 +117,7 @@ final class AppLifecycleController {
                 "authMethod": authMethod
             ]
         )
+        let ipcSocketPathOverride = ExperimentalFeatures.shared.ipcSocketPathOverride()
         switch credentials {
         case .password(let username, let password):
             _ = try await appModel.ssh.sshConnectRemoteServer(
@@ -130,7 +131,7 @@ final class AppLifecycleController {
                 passphrase: nil,
                 acceptUnknownHost: true,
                 workingDir: nil,
-                ipcSocketPathOverride: nil
+                ipcSocketPathOverride: ipcSocketPathOverride
             )
         case .key(let username, let privateKey, let passphrase):
             _ = try await appModel.ssh.sshConnectRemoteServer(
@@ -144,7 +145,7 @@ final class AppLifecycleController {
                 passphrase: passphrase,
                 acceptUnknownHost: true,
                 workingDir: nil,
-                ipcSocketPathOverride: nil
+                ipcSocketPathOverride: ipcSocketPathOverride
             )
         }
     }

--- a/apps/ios/Sources/Litter/Models/ExperimentalFeatures.swift
+++ b/apps/ios/Sources/Litter/Models/ExperimentalFeatures.swift
@@ -3,6 +3,7 @@ import Observation
 
 enum LitterFeature: String, CaseIterable, Identifiable {
     case realtimeVoice = "realtime_voice"
+    case ipc = "ipc"
     case generativeUI = "generative_ui"
 
     var id: String { rawValue }
@@ -10,6 +11,7 @@ enum LitterFeature: String, CaseIterable, Identifiable {
     var displayName: String {
         switch self {
         case .realtimeVoice: return "Realtime"
+        case .ipc: return "IPC"
         case .generativeUI: return "Generative UI"
         }
     }
@@ -17,6 +19,7 @@ enum LitterFeature: String, CaseIterable, Identifiable {
     var description: String {
         switch self {
         case .realtimeVoice: return "Show the realtime voice launcher on the home screen."
+        case .ipc: return "Attach to desktop IPC over SSH for faster sync, approvals, and resume. Requires reconnecting the server."
         case .generativeUI: return "Show interactive widgets, diagrams, and charts inline in conversations. Requires starting a new thread."
         }
     }
@@ -24,6 +27,7 @@ enum LitterFeature: String, CaseIterable, Identifiable {
     var defaultEnabled: Bool {
         switch self {
         case .realtimeVoice: return true
+        case .ipc: return false
         case .generativeUI: return false
         }
     }
@@ -57,5 +61,9 @@ final class ExperimentalFeatures {
         }
         overrides = map
         persistOverrides()
+    }
+
+    func ipcSocketPathOverride() -> String? {
+        isEnabled(.ipc) ? nil : ""
     }
 }

--- a/apps/ios/Sources/Litter/Views/DiscoveryView.swift
+++ b/apps/ios/Sources/Litter/Views/DiscoveryView.swift
@@ -854,6 +854,7 @@ struct DiscoveryView: View {
                 "authMethod": authMethod
             ]
         )
+        let ipcSocketPathOverride = ExperimentalFeatures.shared.ipcSocketPathOverride()
         switch credentials {
         case .password(let username, let password):
             return try await appModel.ssh.sshStartRemoteServerConnect(
@@ -867,7 +868,7 @@ struct DiscoveryView: View {
                 passphrase: nil,
                 acceptUnknownHost: true,
                 workingDir: nil,
-                ipcSocketPathOverride: nil
+                ipcSocketPathOverride: ipcSocketPathOverride
             )
         case .key(let username, let privateKey, let passphrase):
             return try await appModel.ssh.sshStartRemoteServerConnect(
@@ -881,7 +882,7 @@ struct DiscoveryView: View {
                 passphrase: passphrase,
                 acceptUnknownHost: true,
                 workingDir: nil,
-                ipcSocketPathOverride: nil
+                ipcSocketPathOverride: ipcSocketPathOverride
             )
         }
     }

--- a/shared/rust-bridge/codex-ipc/src/conversation_state.rs
+++ b/shared/rust-bridge/codex-ipc/src/conversation_state.rs
@@ -1,0 +1,1343 @@
+use std::path::{Path, PathBuf};
+
+use codex_app_server_protocol as upstream;
+use serde::Deserialize;
+use serde_json::Value;
+use thiserror::Error;
+
+use crate::protocol::params::{
+    ImmerOp, ImmerPatch, ImmerPathSegment, StreamChange, ThreadStreamStateChangedParams,
+};
+
+const MY_REQUEST_HEADER: &str = "## My request for Codex:";
+const COMMAND_APPROVAL_METHOD: &str = "item/commandExecution/requestApproval";
+const FILE_CHANGE_APPROVAL_METHOD: &str = "item/fileChange/requestApproval";
+const PERMISSIONS_APPROVAL_METHOD: &str = "item/permissions/requestApproval";
+const USER_INPUT_METHOD: &str = "item/tool/requestUserInput";
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProjectedConversationState {
+    pub thread: upstream::Thread,
+    pub latest_model: Option<String>,
+    pub latest_reasoning_effort: Option<String>,
+    pub active_turn_id: Option<String>,
+    pub pending_approvals: Vec<ProjectedApprovalRequest>,
+    pub pending_user_inputs: Vec<ProjectedUserInputRequest>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProjectedApprovalKind {
+    Command,
+    FileChange,
+    Permissions,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectedApprovalRequest {
+    pub id: String,
+    pub kind: ProjectedApprovalKind,
+    pub method: String,
+    pub thread_id: Option<String>,
+    pub turn_id: Option<String>,
+    pub item_id: Option<String>,
+    pub command: Option<String>,
+    pub path: Option<String>,
+    pub grant_root: Option<String>,
+    pub cwd: Option<String>,
+    pub reason: Option<String>,
+    pub raw_params_json: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectedUserInputOption {
+    pub label: String,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectedUserInputQuestion {
+    pub id: String,
+    pub header: Option<String>,
+    pub question: String,
+    pub is_other_allowed: bool,
+    pub is_secret: bool,
+    pub options: Vec<ProjectedUserInputOption>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectedUserInputRequest {
+    pub id: String,
+    pub thread_id: String,
+    pub turn_id: String,
+    pub item_id: String,
+    pub questions: Vec<ProjectedUserInputQuestion>,
+    pub requester_agent_nickname: Option<String>,
+    pub requester_agent_role: Option<String>,
+}
+
+#[derive(Debug, Error)]
+pub enum ConversationProjectionError {
+    #[error("deserialize desktop conversation state: {0}")]
+    ConversationState(#[source] serde_json::Error),
+    #[error("deserialize desktop turn item '{item_type}': {source}")]
+    TurnItem {
+        item_type: String,
+        #[source]
+        source: serde_json::Error,
+    },
+}
+
+#[derive(Debug, Error)]
+pub enum ConversationStreamPatchError {
+    #[error("path segment {segment:?} not found")]
+    PathNotFound { segment: String },
+    #[error("array index {index} out of bounds (len={len})")]
+    IndexOutOfBounds { index: usize, len: usize },
+    #[error("expected object or array, got {kind}")]
+    UnexpectedType { kind: &'static str },
+    #[error("add/replace operation missing value")]
+    MissingValue,
+}
+
+#[derive(Debug, Error)]
+pub enum ConversationStreamApplyError {
+    #[error("no cached state")]
+    NoCachedState,
+    #[error("version gap (expected {expected}, got {actual})")]
+    VersionGap { expected: u32, actual: u32 },
+    #[error("patch apply failed: {0}")]
+    PatchFailed(#[from] ConversationStreamPatchError),
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DesktopConversationState {
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    cwd: Option<String>,
+    #[serde(default)]
+    rollout_path: Option<String>,
+    #[serde(default)]
+    source: Option<upstream::SessionSource>,
+    #[serde(default)]
+    git_info: Option<upstream::GitInfo>,
+    #[serde(default)]
+    turns: Vec<DesktopTurn>,
+    #[serde(default)]
+    created_at: Option<Value>,
+    #[serde(default)]
+    updated_at: Option<Value>,
+    #[serde(default)]
+    thread_runtime_status: Option<upstream::ThreadStatus>,
+    #[serde(default)]
+    resume_state: Option<String>,
+    #[serde(default)]
+    ephemeral: Option<bool>,
+    #[serde(default)]
+    model_provider: Option<String>,
+    #[serde(default)]
+    latest_model: Option<String>,
+    #[serde(default)]
+    latest_reasoning_effort: Option<String>,
+    #[serde(default)]
+    cli_version: Option<String>,
+    #[serde(default)]
+    agent_nickname: Option<String>,
+    #[serde(default)]
+    agent_role: Option<String>,
+    #[serde(default)]
+    requests: Vec<DesktopPendingRequest>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DesktopTurn {
+    #[serde(default)]
+    turn_id: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    error: Option<upstream::TurnError>,
+    #[serde(default)]
+    items: Vec<Value>,
+    #[serde(default)]
+    params: DesktopTurnParams,
+    #[serde(default)]
+    interrupted_command_execution_item_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DesktopTurnParams {
+    #[serde(default)]
+    input: Vec<upstream::UserInput>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DesktopPendingRequest {
+    #[serde(default)]
+    id: Value,
+    #[serde(default)]
+    method: String,
+    #[serde(default)]
+    params: Value,
+    #[serde(default)]
+    completed: Option<bool>,
+}
+
+impl ThreadStreamStateChangedParams {
+    pub fn project_snapshot_state(
+        &self,
+    ) -> Result<Option<ProjectedConversationState>, ConversationProjectionError> {
+        match &self.change {
+            StreamChange::Snapshot { conversation_state } => Ok(Some(project_conversation_state(
+                &self.conversation_id,
+                conversation_state,
+            )?)),
+            StreamChange::Patches { .. } => Ok(None),
+        }
+    }
+
+    pub fn project_snapshot_thread(
+        &self,
+    ) -> Result<Option<upstream::Thread>, ConversationProjectionError> {
+        Ok(self
+            .project_snapshot_state()?
+            .map(|projection| projection.thread))
+    }
+}
+
+pub fn project_conversation_state_to_thread(
+    conversation_id: &str,
+    conversation_state: &Value,
+) -> Result<upstream::Thread, ConversationProjectionError> {
+    Ok(project_conversation_state(conversation_id, conversation_state)?.thread)
+}
+
+pub fn project_conversation_state(
+    conversation_id: &str,
+    conversation_state: &Value,
+) -> Result<ProjectedConversationState, ConversationProjectionError> {
+    let conversation: DesktopConversationState = serde_json::from_value(conversation_state.clone())
+        .map_err(ConversationProjectionError::ConversationState)?;
+
+    let turns = conversation
+        .turns
+        .iter()
+        .enumerate()
+        .map(|(turn_index, turn)| project_turn(turn, turn_index))
+        .collect::<Result<Vec<_>, _>>()?;
+    let pending_approvals = project_pending_approvals(&conversation.requests);
+    let pending_user_inputs = project_pending_user_inputs(
+        &conversation.requests,
+        conversation.agent_nickname.clone(),
+        conversation.agent_role.clone(),
+    );
+    let active_flags = derive_active_flags(&pending_approvals, &pending_user_inputs);
+    let active_turn_id = active_turn_id(&conversation.turns);
+    let status = resolve_thread_status(&conversation, active_flags);
+    let path = conversation
+        .rollout_path
+        .as_deref()
+        .and_then(non_empty)
+        .map(PathBuf::from);
+    let cwd = PathBuf::from(infer_cwd(&conversation));
+
+    let thread = upstream::Thread {
+        id: conversation_id.to_string(),
+        preview: thread_preview(&turns).unwrap_or_default(),
+        ephemeral: conversation.ephemeral.unwrap_or(false),
+        model_provider: conversation.model_provider.unwrap_or_default(),
+        created_at: conversation
+            .created_at
+            .as_ref()
+            .and_then(parse_unix_seconds)
+            .unwrap_or_default(),
+        updated_at: conversation
+            .updated_at
+            .as_ref()
+            .and_then(parse_unix_seconds)
+            .unwrap_or_default(),
+        status,
+        path,
+        cwd,
+        cli_version: conversation.cli_version.unwrap_or_default(),
+        source: conversation.source.unwrap_or_default(),
+        agent_nickname: conversation.agent_nickname.and_then(non_empty_option_owned),
+        agent_role: conversation.agent_role.and_then(non_empty_option_owned),
+        git_info: conversation.git_info,
+        name: conversation.title.and_then(non_empty_option_owned),
+        turns,
+    };
+
+    Ok(ProjectedConversationState {
+        thread,
+        latest_model: conversation.latest_model.and_then(non_empty_option_owned),
+        latest_reasoning_effort: conversation
+            .latest_reasoning_effort
+            .and_then(non_empty_option_owned),
+        active_turn_id,
+        pending_approvals,
+        pending_user_inputs,
+    })
+}
+
+pub fn seed_conversation_state_from_thread(thread: &upstream::Thread) -> Value {
+    serde_json::json!({
+        "title": thread.name.clone(),
+        "cwd": path_to_string(thread.cwd.clone()),
+        "rolloutPath": thread.path.clone().map(path_to_string),
+        "source": thread.source.clone(),
+        "gitInfo": thread.git_info.clone(),
+        "turns": thread
+            .turns
+            .iter()
+            .map(seed_desktop_turn_from_thread)
+            .collect::<Vec<_>>(),
+        "createdAt": thread.created_at,
+        "updatedAt": thread.updated_at,
+        "threadRuntimeStatus": thread.status.clone(),
+        "ephemeral": thread.ephemeral,
+        "modelProvider": thread.model_provider.clone(),
+        "cliVersion": thread.cli_version.clone(),
+        "agentNickname": thread.agent_nickname.clone(),
+        "agentRole": thread.agent_role.clone(),
+        "requests": [],
+    })
+}
+
+pub fn apply_stream_change_to_conversation_state(
+    cached_state: &mut Option<(u32, Value)>,
+    params: &ThreadStreamStateChangedParams,
+) -> Result<(), ConversationStreamApplyError> {
+    match &params.change {
+        StreamChange::Snapshot { conversation_state } => {
+            *cached_state = Some((params.version, conversation_state.clone()));
+            Ok(())
+        }
+        StreamChange::Patches { patches } => {
+            let Some((cached_version, cached_json)) = cached_state.as_mut() else {
+                return Err(ConversationStreamApplyError::NoCachedState);
+            };
+
+            let expected = *cached_version + 1;
+            if params.version != expected {
+                return Err(ConversationStreamApplyError::VersionGap {
+                    expected,
+                    actual: params.version,
+                });
+            }
+
+            apply_immer_patches(cached_json, patches)?;
+            *cached_version = params.version;
+            Ok(())
+        }
+    }
+}
+
+fn project_turn(
+    turn: &DesktopTurn,
+    turn_index: usize,
+) -> Result<upstream::Turn, ConversationProjectionError> {
+    let turn_id = turn
+        .turn_id
+        .clone()
+        .unwrap_or_else(|| format!("ipc-turn-{turn_index}"));
+    let mut items = Vec::new();
+
+    if !turn.params.input.is_empty() {
+        items.push(upstream::ThreadItem::UserMessage {
+            id: format!("{turn_id}:input"),
+            content: turn.params.input.clone(),
+        });
+    }
+
+    for raw_item in &turn.items {
+        let Some(item_type) = raw_item.get("type").and_then(Value::as_str) else {
+            continue;
+        };
+
+        if !is_supported_turn_item(item_type) {
+            continue;
+        }
+
+        let mut normalized_item = raw_item.clone();
+        if item_type == "commandExecution" {
+            normalize_command_execution_status(
+                &mut normalized_item,
+                turn.status.as_deref(),
+                &turn.interrupted_command_execution_item_ids,
+            );
+        }
+
+        let item =
+            serde_json::from_value::<upstream::ThreadItem>(normalized_item).map_err(|source| {
+                ConversationProjectionError::TurnItem {
+                    item_type: item_type.to_string(),
+                    source,
+                }
+            })?;
+
+        if let upstream::ThreadItem::UserMessage { content, .. } = &item {
+            if *content == turn.params.input {
+                continue;
+            }
+        }
+
+        items.push(item);
+    }
+
+    Ok(upstream::Turn {
+        id: turn_id,
+        items,
+        status: parse_turn_status(turn.status.as_deref()),
+        error: turn.error.clone(),
+    })
+}
+
+fn normalize_command_execution_status(
+    raw_item: &mut Value,
+    turn_status: Option<&str>,
+    interrupted_item_ids: &[String],
+) {
+    let is_interrupted_turn = matches!(turn_status, Some("interrupted"));
+    let item_id = raw_item.get("id").and_then(Value::as_str);
+    let is_interrupted_item = item_id
+        .map(|item_id| interrupted_item_ids.iter().any(|id| id == item_id))
+        .unwrap_or(false);
+
+    if !(is_interrupted_turn || is_interrupted_item) {
+        return;
+    }
+
+    if raw_item.get("status").and_then(Value::as_str) == Some("inProgress") {
+        raw_item["status"] = Value::String("failed".to_string());
+    }
+}
+
+fn seed_desktop_turn_from_thread(turn: &upstream::Turn) -> Value {
+    let (params_input, item_offset) = match turn.items.first() {
+        Some(upstream::ThreadItem::UserMessage { content, .. }) => (content.clone(), 1),
+        _ => (Vec::new(), 0),
+    };
+
+    let items = turn
+        .items
+        .iter()
+        .skip(item_offset)
+        .filter(|item| is_supported_thread_item(item))
+        .filter_map(|item| serde_json::to_value(item).ok())
+        .collect::<Vec<_>>();
+
+    serde_json::json!({
+        "turnId": turn.id.clone(),
+        "status": serialize_turn_status(turn.status.clone()),
+        "error": turn.error.clone(),
+        "items": items,
+        "params": { "input": params_input },
+        "interruptedCommandExecutionItemIds": [],
+    })
+}
+
+fn is_supported_turn_item(item_type: &str) -> bool {
+    matches!(
+        item_type,
+        "userMessage"
+            | "hookPrompt"
+            | "agentMessage"
+            | "plan"
+            | "reasoning"
+            | "commandExecution"
+            | "fileChange"
+            | "mcpToolCall"
+            | "dynamicToolCall"
+            | "collabAgentToolCall"
+            | "webSearch"
+            | "imageView"
+            | "imageGeneration"
+            | "enteredReviewMode"
+            | "exitedReviewMode"
+            | "contextCompaction"
+    )
+}
+
+fn is_supported_thread_item(item: &upstream::ThreadItem) -> bool {
+    matches!(
+        item,
+        upstream::ThreadItem::UserMessage { .. }
+            | upstream::ThreadItem::HookPrompt { .. }
+            | upstream::ThreadItem::AgentMessage { .. }
+            | upstream::ThreadItem::Plan { .. }
+            | upstream::ThreadItem::Reasoning { .. }
+            | upstream::ThreadItem::CommandExecution { .. }
+            | upstream::ThreadItem::FileChange { .. }
+            | upstream::ThreadItem::McpToolCall { .. }
+            | upstream::ThreadItem::DynamicToolCall { .. }
+            | upstream::ThreadItem::CollabAgentToolCall { .. }
+            | upstream::ThreadItem::WebSearch { .. }
+            | upstream::ThreadItem::ImageView { .. }
+            | upstream::ThreadItem::ImageGeneration { .. }
+            | upstream::ThreadItem::EnteredReviewMode { .. }
+            | upstream::ThreadItem::ExitedReviewMode { .. }
+            | upstream::ThreadItem::ContextCompaction { .. }
+    )
+}
+
+fn project_pending_approvals(requests: &[DesktopPendingRequest]) -> Vec<ProjectedApprovalRequest> {
+    requests
+        .iter()
+        .filter(|request| !request.completed.unwrap_or(false))
+        .filter_map(|request| match request.method.as_str() {
+            COMMAND_APPROVAL_METHOD => {
+                let request_id = request_id_string(&request.id)?;
+                let params = serde_json::from_value::<
+                    upstream::CommandExecutionRequestApprovalParams,
+                >(request.params.clone())
+                .ok()?;
+                Some(ProjectedApprovalRequest {
+                    id: request_id,
+                    kind: ProjectedApprovalKind::Command,
+                    method: request.method.clone(),
+                    thread_id: Some(params.thread_id),
+                    turn_id: Some(params.turn_id),
+                    item_id: Some(params.item_id),
+                    command: params.command,
+                    path: None,
+                    grant_root: None,
+                    cwd: params.cwd.map(path_to_string),
+                    reason: params.reason,
+                    raw_params_json: request.params.to_string(),
+                })
+            }
+            FILE_CHANGE_APPROVAL_METHOD => {
+                let request_id = request_id_string(&request.id)?;
+                let params = serde_json::from_value::<upstream::FileChangeRequestApprovalParams>(
+                    request.params.clone(),
+                )
+                .ok()?;
+                Some(ProjectedApprovalRequest {
+                    id: request_id,
+                    kind: ProjectedApprovalKind::FileChange,
+                    method: request.method.clone(),
+                    thread_id: Some(params.thread_id),
+                    turn_id: Some(params.turn_id),
+                    item_id: Some(params.item_id),
+                    command: None,
+                    path: None,
+                    grant_root: params.grant_root.map(path_to_string),
+                    cwd: None,
+                    reason: params.reason,
+                    raw_params_json: request.params.to_string(),
+                })
+            }
+            PERMISSIONS_APPROVAL_METHOD => {
+                let request_id = request_id_string(&request.id)?;
+                let params = serde_json::from_value::<upstream::PermissionsRequestApprovalParams>(
+                    request.params.clone(),
+                )
+                .ok()?;
+                Some(ProjectedApprovalRequest {
+                    id: request_id,
+                    kind: ProjectedApprovalKind::Permissions,
+                    method: request.method.clone(),
+                    thread_id: Some(params.thread_id),
+                    turn_id: Some(params.turn_id),
+                    item_id: Some(params.item_id),
+                    command: None,
+                    path: None,
+                    grant_root: None,
+                    cwd: None,
+                    reason: params.reason,
+                    raw_params_json: request.params.to_string(),
+                })
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+fn project_pending_user_inputs(
+    requests: &[DesktopPendingRequest],
+    requester_agent_nickname: Option<String>,
+    requester_agent_role: Option<String>,
+) -> Vec<ProjectedUserInputRequest> {
+    let requester_agent_nickname = requester_agent_nickname.and_then(non_empty_option_owned);
+    let requester_agent_role = requester_agent_role.and_then(non_empty_option_owned);
+
+    requests
+        .iter()
+        .filter(|request| !request.completed.unwrap_or(false))
+        .filter(|request| request.method == USER_INPUT_METHOD)
+        .filter_map(|request| {
+            let request_id = request_id_string(&request.id)?;
+            let params = serde_json::from_value::<upstream::ToolRequestUserInputParams>(
+                request.params.clone(),
+            )
+            .ok()?;
+            let questions = params
+                .questions
+                .into_iter()
+                .map(|question| ProjectedUserInputQuestion {
+                    id: question.id,
+                    header: non_empty(question.header.as_str()).map(ToOwned::to_owned),
+                    question: question.question,
+                    is_other_allowed: question.is_other,
+                    is_secret: question.is_secret,
+                    options: question
+                        .options
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(|option| ProjectedUserInputOption {
+                            label: option.label,
+                            description: non_empty(option.description.as_str())
+                                .map(ToOwned::to_owned),
+                        })
+                        .collect(),
+                })
+                .collect::<Vec<_>>();
+            if questions.is_empty() {
+                return None;
+            }
+            Some(ProjectedUserInputRequest {
+                id: request_id,
+                thread_id: params.thread_id,
+                turn_id: params.turn_id,
+                item_id: params.item_id,
+                questions,
+                requester_agent_nickname: requester_agent_nickname.clone(),
+                requester_agent_role: requester_agent_role.clone(),
+            })
+        })
+        .collect()
+}
+
+fn resolve_thread_status(
+    conversation: &DesktopConversationState,
+    derived_active_flags: Vec<upstream::ThreadActiveFlag>,
+) -> upstream::ThreadStatus {
+    match conversation.thread_runtime_status.clone() {
+        Some(upstream::ThreadStatus::Active { active_flags }) => upstream::ThreadStatus::Active {
+            active_flags: merge_active_flags(active_flags, derived_active_flags),
+        },
+        Some(status) => status,
+        None => derive_thread_status(conversation, derived_active_flags),
+    }
+}
+
+fn derive_thread_status(
+    conversation: &DesktopConversationState,
+    active_flags: Vec<upstream::ThreadActiveFlag>,
+) -> upstream::ThreadStatus {
+    if conversation.resume_state.as_deref() == Some("needs_resume") && conversation.turns.is_empty()
+    {
+        return upstream::ThreadStatus::NotLoaded;
+    }
+
+    if active_turn_id(&conversation.turns).is_some() || !active_flags.is_empty() {
+        return upstream::ThreadStatus::Active { active_flags };
+    }
+
+    if conversation
+        .turns
+        .iter()
+        .rev()
+        .any(|turn| matches!(turn.status.as_deref(), Some("failed")))
+    {
+        return upstream::ThreadStatus::SystemError;
+    }
+
+    upstream::ThreadStatus::Idle
+}
+
+fn derive_active_flags(
+    pending_approvals: &[ProjectedApprovalRequest],
+    pending_user_inputs: &[ProjectedUserInputRequest],
+) -> Vec<upstream::ThreadActiveFlag> {
+    let mut flags = Vec::new();
+    if !pending_approvals.is_empty() {
+        flags.push(upstream::ThreadActiveFlag::WaitingOnApproval);
+    }
+    if !pending_user_inputs.is_empty() {
+        flags.push(upstream::ThreadActiveFlag::WaitingOnUserInput);
+    }
+    flags
+}
+
+fn merge_active_flags(
+    existing: Vec<upstream::ThreadActiveFlag>,
+    derived: Vec<upstream::ThreadActiveFlag>,
+) -> Vec<upstream::ThreadActiveFlag> {
+    let mut merged = existing;
+    for flag in derived {
+        if !merged.iter().any(|existing_flag| existing_flag == &flag) {
+            merged.push(flag);
+        }
+    }
+    merged
+}
+
+fn active_turn_id(turns: &[DesktopTurn]) -> Option<String> {
+    turns
+        .iter()
+        .rev()
+        .find(|turn| matches!(turn.status.as_deref(), Some("inProgress")))
+        .and_then(|turn| turn.turn_id.clone())
+}
+
+fn thread_preview(turns: &[upstream::Turn]) -> Option<String> {
+    turns.iter().find_map(|turn| {
+        turn.items.iter().find_map(|item| match item {
+            upstream::ThreadItem::UserMessage { content, .. } => render_preview_text(content),
+            _ => None,
+        })
+    })
+}
+
+fn render_preview_text(content: &[upstream::UserInput]) -> Option<String> {
+    let text = content
+        .iter()
+        .filter_map(|item| match item {
+            upstream::UserInput::Text { text, .. } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let text = strip_request_wrapper(text.trim());
+    if text.is_empty() { None } else { Some(text) }
+}
+
+fn strip_request_wrapper(text: &str) -> String {
+    let mut parts = text.split(MY_REQUEST_HEADER);
+    let had_wrapper = parts.next().is_some() && text.contains(MY_REQUEST_HEADER);
+    let last = text.rsplit(MY_REQUEST_HEADER).next().unwrap_or(text);
+    if !had_wrapper {
+        text.trim().to_string()
+    } else {
+        last.trim().to_string()
+    }
+}
+
+fn infer_cwd(conversation: &DesktopConversationState) -> String {
+    if let Some(cwd) = conversation.cwd.as_deref().and_then(non_empty) {
+        return cwd.to_string();
+    }
+
+    if let Some(path) = conversation.rollout_path.as_deref().and_then(non_empty) {
+        if let Some(parent) = Path::new(path).parent() {
+            return parent.to_string_lossy().to_string();
+        }
+    }
+
+    String::new()
+}
+
+fn parse_turn_status(value: Option<&str>) -> upstream::TurnStatus {
+    match value {
+        Some("completed") => upstream::TurnStatus::Completed,
+        Some("interrupted") => upstream::TurnStatus::Interrupted,
+        Some("failed") => upstream::TurnStatus::Failed,
+        Some("inProgress") => upstream::TurnStatus::InProgress,
+        _ => upstream::TurnStatus::Completed,
+    }
+}
+
+fn serialize_turn_status(status: upstream::TurnStatus) -> &'static str {
+    match status {
+        upstream::TurnStatus::Completed => "completed",
+        upstream::TurnStatus::Interrupted => "interrupted",
+        upstream::TurnStatus::Failed => "failed",
+        upstream::TurnStatus::InProgress => "inProgress",
+    }
+}
+
+fn parse_unix_seconds(value: &Value) -> Option<i64> {
+    parse_timestamp(value).map(|timestamp| {
+        if timestamp >= 1_000_000_000_000 {
+            timestamp / 1000
+        } else {
+            timestamp
+        }
+    })
+}
+
+fn parse_timestamp(value: &Value) -> Option<i64> {
+    match value {
+        Value::Number(number) => number
+            .as_i64()
+            .or_else(|| number.as_f64().map(|value| value as i64)),
+        Value::String(text) => text
+            .parse::<i64>()
+            .ok()
+            .or_else(|| text.parse::<f64>().ok().map(|value| value as i64)),
+        _ => None,
+    }
+}
+
+fn request_id_string(value: &Value) -> Option<String> {
+    match value {
+        Value::String(text) => Some(text.clone()),
+        Value::Number(number) => Some(number.to_string()),
+        _ => None,
+    }
+}
+
+fn path_to_string(path: PathBuf) -> String {
+    path.to_string_lossy().to_string()
+}
+
+fn non_empty(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+fn non_empty_option_owned(value: String) -> Option<String> {
+    non_empty(&value).map(ToOwned::to_owned)
+}
+
+fn apply_immer_patches(
+    target: &mut Value,
+    patches: &[ImmerPatch],
+) -> Result<(), ConversationStreamPatchError> {
+    for patch in patches {
+        apply_one_immer_patch(target, patch)?;
+    }
+    Ok(())
+}
+
+fn apply_one_immer_patch(
+    target: &mut Value,
+    patch: &ImmerPatch,
+) -> Result<(), ConversationStreamPatchError> {
+    if patch.path.is_empty() {
+        match patch.op {
+            ImmerOp::Replace | ImmerOp::Add => {
+                *target = patch
+                    .value
+                    .clone()
+                    .ok_or(ConversationStreamPatchError::MissingValue)?;
+            }
+            ImmerOp::Remove => *target = Value::Null,
+        }
+        return Ok(());
+    }
+
+    let (parent_path, last_segment) = patch.path.split_at(patch.path.len() - 1);
+    let parent = navigate_to_path(target, parent_path)?;
+    let last = &last_segment[0];
+
+    match patch.op {
+        ImmerOp::Replace => {
+            let value = patch
+                .value
+                .clone()
+                .ok_or(ConversationStreamPatchError::MissingValue)?;
+            set_path_value(parent, last, value)
+        }
+        ImmerOp::Add => {
+            let value = patch
+                .value
+                .clone()
+                .ok_or(ConversationStreamPatchError::MissingValue)?;
+            add_path_value(parent, last, value)
+        }
+        ImmerOp::Remove => remove_path_value(parent, last),
+    }
+}
+
+fn navigate_to_path<'a>(
+    root: &'a mut Value,
+    path: &[ImmerPathSegment],
+) -> Result<&'a mut Value, ConversationStreamPatchError> {
+    let mut current = root;
+    for segment in path {
+        let kind = value_kind(current);
+        current = match segment {
+            ImmerPathSegment::Key(key) => {
+                let object = current
+                    .as_object_mut()
+                    .ok_or(ConversationStreamPatchError::UnexpectedType { kind })?;
+                object
+                    .get_mut(key)
+                    .ok_or_else(|| ConversationStreamPatchError::PathNotFound {
+                        segment: key.clone(),
+                    })?
+            }
+            ImmerPathSegment::Index(index) => {
+                let array = current
+                    .as_array_mut()
+                    .ok_or(ConversationStreamPatchError::UnexpectedType { kind })?;
+                let len = array.len();
+                array
+                    .get_mut(*index)
+                    .ok_or(ConversationStreamPatchError::IndexOutOfBounds { index: *index, len })?
+            }
+        };
+    }
+    Ok(current)
+}
+
+fn set_path_value(
+    parent: &mut Value,
+    segment: &ImmerPathSegment,
+    value: Value,
+) -> Result<(), ConversationStreamPatchError> {
+    let kind = value_kind(parent);
+    match segment {
+        ImmerPathSegment::Key(key) => {
+            let object = parent
+                .as_object_mut()
+                .ok_or(ConversationStreamPatchError::UnexpectedType { kind })?;
+            object.insert(key.clone(), value);
+            Ok(())
+        }
+        ImmerPathSegment::Index(index) => {
+            let array = parent
+                .as_array_mut()
+                .ok_or(ConversationStreamPatchError::UnexpectedType { kind })?;
+            let len = array.len();
+            if *index >= len {
+                return Err(ConversationStreamPatchError::IndexOutOfBounds { index: *index, len });
+            }
+            array[*index] = value;
+            Ok(())
+        }
+    }
+}
+
+fn add_path_value(
+    parent: &mut Value,
+    segment: &ImmerPathSegment,
+    value: Value,
+) -> Result<(), ConversationStreamPatchError> {
+    let kind = value_kind(parent);
+    match segment {
+        ImmerPathSegment::Key(key) => {
+            let object = parent
+                .as_object_mut()
+                .ok_or(ConversationStreamPatchError::UnexpectedType { kind })?;
+            object.insert(key.clone(), value);
+            Ok(())
+        }
+        ImmerPathSegment::Index(index) => {
+            let array = parent
+                .as_array_mut()
+                .ok_or(ConversationStreamPatchError::UnexpectedType { kind })?;
+            let len = array.len();
+            if *index > len {
+                return Err(ConversationStreamPatchError::IndexOutOfBounds { index: *index, len });
+            }
+            array.insert(*index, value);
+            Ok(())
+        }
+    }
+}
+
+fn remove_path_value(
+    parent: &mut Value,
+    segment: &ImmerPathSegment,
+) -> Result<(), ConversationStreamPatchError> {
+    let kind = value_kind(parent);
+    match segment {
+        ImmerPathSegment::Key(key) => {
+            let object = parent
+                .as_object_mut()
+                .ok_or(ConversationStreamPatchError::UnexpectedType { kind })?;
+            object
+                .remove(key)
+                .ok_or_else(|| ConversationStreamPatchError::PathNotFound {
+                    segment: key.clone(),
+                })?;
+            Ok(())
+        }
+        ImmerPathSegment::Index(index) => {
+            let array = parent
+                .as_array_mut()
+                .ok_or(ConversationStreamPatchError::UnexpectedType { kind })?;
+            let len = array.len();
+            if *index >= len {
+                return Err(ConversationStreamPatchError::IndexOutOfBounds { index: *index, len });
+            }
+            array.remove(*index);
+            Ok(())
+        }
+    }
+}
+
+fn value_kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use codex_app_server_protocol as upstream;
+    use serde_json::json;
+
+    use super::{
+        ProjectedApprovalKind, apply_stream_change_to_conversation_state,
+        project_conversation_state, project_conversation_state_to_thread,
+        seed_conversation_state_from_thread,
+    };
+    use crate::protocol::params::{StreamChange, ThreadStreamStateChangedParams};
+
+    #[test]
+    fn projects_core_transcript_items_into_upstream_thread() {
+        let conversation_state = json!({
+            "title": "IPC Thread",
+            "cwd": "/repo",
+            "rolloutPath": "/repo/.codex/session.jsonl",
+            "createdAt": 1710000000000i64,
+            "updatedAt": 1710000005000i64,
+            "threadRuntimeStatus": { "type": "active", "activeFlags": [] },
+            "source": "vscode",
+            "turns": [
+                {
+                    "turnId": "turn-1",
+                    "status": "completed",
+                    "params": {
+                        "input": [
+                            { "type": "text", "text": "## My request for Codex:\nshow me the logs", "textElements": [] }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "user-1",
+                            "type": "userMessage",
+                            "content": [
+                                { "type": "text", "text": "## My request for Codex:\nshow me the logs", "textElements": [] }
+                            ]
+                        },
+                        { "id": "assistant-1", "type": "agentMessage", "text": "Here are the logs." },
+                        { "id": "reason-1", "type": "reasoning", "summary": ["Thinking through it"], "content": ["Inspecting the stream state."] },
+                        {
+                            "id": "exec-1",
+                            "type": "commandExecution",
+                            "status": "completed",
+                            "command": "ls",
+                            "cwd": "/repo",
+                            "source": "agent",
+                            "commandActions": [
+                                { "type": "unknown", "command": "ls" }
+                            ],
+                            "aggregatedOutput": "file.txt\n",
+                            "exitCode": 0,
+                            "durationMs": 42
+                        },
+                        {
+                            "id": "mcp-1",
+                            "type": "mcpToolCall",
+                            "status": "completed",
+                            "server": "search",
+                            "tool": "query",
+                            "arguments": { "q": "logs" },
+                            "result": {
+                                "content": [
+                                    { "type": "text", "text": "found it" }
+                                ],
+                                "structuredContent": { "count": 1 }
+                            }
+                        },
+                        { "id": "todo-1", "type": "todo-list", "plan": [] }
+                    ]
+                }
+            ]
+        });
+
+        let thread =
+            project_conversation_state_to_thread("conversation-1", &conversation_state).unwrap();
+
+        assert_eq!(thread.id, "conversation-1");
+        assert_eq!(thread.preview, "show me the logs");
+        assert_eq!(thread.created_at, 1710000000);
+        assert_eq!(thread.updated_at, 1710000005);
+        assert_eq!(thread.cwd, PathBuf::from("/repo"));
+        assert_eq!(
+            thread.path,
+            Some(PathBuf::from("/repo/.codex/session.jsonl"))
+        );
+        assert!(matches!(
+            thread.status,
+            upstream::ThreadStatus::Active { .. }
+        ));
+        assert_eq!(thread.turns.len(), 1);
+        assert_eq!(thread.turns[0].items.len(), 5);
+        assert!(matches!(
+            &thread.turns[0].items[0],
+            upstream::ThreadItem::UserMessage { .. }
+        ));
+        assert!(matches!(
+            &thread.turns[0].items[1],
+            upstream::ThreadItem::AgentMessage { .. }
+        ));
+        assert!(matches!(
+            &thread.turns[0].items[2],
+            upstream::ThreadItem::Reasoning { .. }
+        ));
+        assert!(matches!(
+            &thread.turns[0].items[3],
+            upstream::ThreadItem::CommandExecution { .. }
+        ));
+        assert!(matches!(
+            &thread.turns[0].items[4],
+            upstream::ThreadItem::McpToolCall { .. }
+        ));
+    }
+
+    #[test]
+    fn projects_request_state_and_active_turn_metadata() {
+        let conversation_state = json!({
+            "latestModel": "gpt-5.4",
+            "latestReasoningEffort": "medium",
+            "agentNickname": "Scout",
+            "agentRole": "reviewer",
+            "turns": [
+                {
+                    "turnId": "turn-1",
+                    "status": "inProgress",
+                    "params": {
+                        "input": [
+                            { "type": "text", "text": "hello", "textElements": [] }
+                        ]
+                    },
+                    "items": [
+                        { "id": "assistant-1", "type": "agentMessage", "text": "streaming..." }
+                    ]
+                }
+            ],
+            "requests": [
+                {
+                    "id": "approval-1",
+                    "method": "item/commandExecution/requestApproval",
+                    "params": {
+                        "threadId": "conversation-1",
+                        "turnId": "turn-1",
+                        "itemId": "exec-1",
+                        "command": "ls",
+                        "cwd": "/repo",
+                        "reason": "Need approval"
+                    }
+                },
+                {
+                    "id": "input-1",
+                    "method": "item/tool/requestUserInput",
+                    "params": {
+                        "threadId": "conversation-1",
+                        "turnId": "turn-1",
+                        "itemId": "tool-1",
+                        "questions": [
+                            {
+                                "id": "q1",
+                                "header": "Env",
+                                "question": "Pick one",
+                                "isOther": false,
+                                "options": [
+                                    { "label": "Prod", "description": "Production" }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        });
+
+        let projected = project_conversation_state("conversation-1", &conversation_state).unwrap();
+
+        assert_eq!(projected.latest_model.as_deref(), Some("gpt-5.4"));
+        assert_eq!(projected.latest_reasoning_effort.as_deref(), Some("medium"));
+        assert_eq!(projected.active_turn_id.as_deref(), Some("turn-1"));
+        assert_eq!(projected.pending_approvals.len(), 1);
+        assert_eq!(
+            projected.pending_approvals[0].kind,
+            ProjectedApprovalKind::Command
+        );
+        assert_eq!(projected.pending_user_inputs.len(), 1);
+        assert_eq!(
+            projected.pending_user_inputs[0]
+                .requester_agent_nickname
+                .as_deref(),
+            Some("Scout")
+        );
+        assert_eq!(
+            projected.pending_user_inputs[0]
+                .requester_agent_role
+                .as_deref(),
+            Some("reviewer")
+        );
+
+        match projected.thread.status {
+            upstream::ThreadStatus::Active { active_flags } => {
+                assert!(active_flags.contains(&upstream::ThreadActiveFlag::WaitingOnApproval));
+                assert!(active_flags.contains(&upstream::ThreadActiveFlag::WaitingOnUserInput));
+            }
+            other => panic!("expected active thread status, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn projects_snapshot_helper_and_derives_active_status_without_runtime_state() {
+        let params = ThreadStreamStateChangedParams {
+            conversation_id: "conversation-1".to_string(),
+            change: StreamChange::Snapshot {
+                conversation_state: json!({
+                    "turns": [
+                        {
+                            "turnId": "turn-1",
+                            "status": "inProgress",
+                            "params": {
+                                "input": [
+                                    { "type": "text", "text": "hello", "textElements": [] }
+                                ]
+                            },
+                            "items": [
+                                {
+                                    "id": "assistant-1",
+                                    "type": "agentMessage",
+                                    "text": "streaming..."
+                                }
+                            ]
+                        }
+                    ]
+                }),
+            },
+            version: 5,
+        };
+
+        let projection = params.project_snapshot_state().unwrap().unwrap();
+        assert!(matches!(
+            projection.thread.status,
+            upstream::ThreadStatus::Active { .. }
+        ));
+        assert_eq!(projection.thread.turns[0].id, "turn-1");
+        assert_eq!(projection.thread.preview, "hello");
+        assert_eq!(projection.active_turn_id.as_deref(), Some("turn-1"));
+    }
+
+    #[test]
+    fn maps_interrupted_command_execution_to_failed_status() {
+        let conversation_state = json!({
+            "turns": [
+                {
+                    "turnId": "turn-1",
+                    "status": "interrupted",
+                    "interruptedCommandExecutionItemIds": ["exec-1"],
+                    "items": [
+                        {
+                            "id": "exec-1",
+                            "type": "commandExecution",
+                            "status": "inProgress",
+                            "command": "sleep 10",
+                            "cwd": "/repo",
+                            "source": "agent",
+                            "commandActions": [
+                                { "type": "unknown", "command": "sleep 10" }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        });
+
+        let thread =
+            project_conversation_state_to_thread("conversation-1", &conversation_state).unwrap();
+
+        match &thread.turns[0].items[0] {
+            upstream::ThreadItem::CommandExecution { status, .. } => {
+                assert_eq!(*status, upstream::CommandExecutionStatus::Failed);
+            }
+            other => panic!("expected command execution item, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn seeds_upstream_thread_into_patchable_conversation_state() {
+        let thread = upstream::Thread {
+            id: "conversation-1".to_string(),
+            preview: "hello".to_string(),
+            ephemeral: false,
+            model_provider: "openai".to_string(),
+            created_at: 1,
+            updated_at: 2,
+            status: upstream::ThreadStatus::Active {
+                active_flags: Vec::new(),
+            },
+            path: Some(PathBuf::from("/repo/.codex/session.jsonl")),
+            cwd: PathBuf::from("/repo"),
+            cli_version: "1.0.0".to_string(),
+            source: upstream::SessionSource::default(),
+            agent_nickname: None,
+            agent_role: None,
+            git_info: None,
+            name: Some("IPC Thread".to_string()),
+            turns: vec![upstream::Turn {
+                id: "turn-1".to_string(),
+                status: upstream::TurnStatus::InProgress,
+                error: None,
+                items: vec![
+                    upstream::ThreadItem::UserMessage {
+                        id: "user-1".to_string(),
+                        content: vec![upstream::UserInput::Text {
+                            text: "hello".to_string(),
+                            text_elements: Vec::new(),
+                        }],
+                    },
+                    upstream::ThreadItem::AgentMessage {
+                        id: "assistant-1".to_string(),
+                        text: "hel".to_string(),
+                        phase: None,
+                        memory_citation: None,
+                    },
+                ],
+            }],
+        };
+
+        let mut cached_state = Some((1, seed_conversation_state_from_thread(&thread)));
+        let seeded_state = &cached_state.as_ref().unwrap().1;
+        assert_eq!(
+            seeded_state["turns"][0]["params"]["input"][0]["text"],
+            "hello"
+        );
+        assert_eq!(seeded_state["turns"][0]["items"][0]["type"], "agentMessage");
+
+        let text_patch = ThreadStreamStateChangedParams {
+            conversation_id: "conversation-1".to_string(),
+            version: 2,
+            change: StreamChange::Patches {
+                patches: vec![crate::protocol::params::ImmerPatch {
+                    op: crate::protocol::params::ImmerOp::Replace,
+                    path: vec![
+                        crate::protocol::params::ImmerPathSegment::Key("turns".to_string()),
+                        crate::protocol::params::ImmerPathSegment::Index(0),
+                        crate::protocol::params::ImmerPathSegment::Key("items".to_string()),
+                        crate::protocol::params::ImmerPathSegment::Index(0),
+                        crate::protocol::params::ImmerPathSegment::Key("text".to_string()),
+                    ],
+                    value: Some(json!("hello")),
+                }],
+            },
+        };
+        apply_stream_change_to_conversation_state(&mut cached_state, &text_patch).unwrap();
+
+        let projected =
+            project_conversation_state("conversation-1", &cached_state.as_ref().unwrap().1)
+                .unwrap();
+        assert_eq!(projected.active_turn_id.as_deref(), Some("turn-1"));
+        match &projected.thread.turns[0].items[1] {
+            upstream::ThreadItem::AgentMessage { text, .. } => assert_eq!(text, "hello"),
+            other => panic!("expected agent message, got {other:?}"),
+        }
+    }
+}

--- a/shared/rust-bridge/codex-ipc/src/lib.rs
+++ b/shared/rust-bridge/codex-ipc/src/lib.rs
@@ -18,6 +18,7 @@
 //! - **ClientDiscovery** — router probes to find a handler for a request
 
 pub mod client;
+pub mod conversation_state;
 pub mod error;
 pub mod handler;
 pub mod protocol;
@@ -25,6 +26,7 @@ pub mod transport;
 
 pub use client::handle::{IpcClient, IpcClientConfig};
 pub use client::reconnect::{ReconnectPolicy, ReconnectingIpcClient};
+pub use conversation_state::*;
 pub use error::{IpcError, RequestError, TransportError};
 pub use handler::RequestHandler;
 pub use protocol::envelope::*;

--- a/shared/rust-bridge/codex-mobile-client/src/conversation.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/conversation.rs
@@ -501,9 +501,12 @@ fn convert_thread_item(
             duration_ms,
             ..
         } => {
-            if let Some(widget) =
-                widget_data_from_dynamic_tool_call(tool, arguments, status, content_items.as_deref())
-            {
+            if let Some(widget) = widget_data_from_dynamic_tool_call(
+                tool,
+                arguments,
+                status,
+                content_items.as_deref(),
+            ) {
                 return Some(ConversationItem {
                     id: item_id.to_string(),
                     content: ConversationItemContent::Widget(widget),

--- a/shared/rust-bridge/codex-mobile-client/src/ffi/ssh.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/ffi/ssh.rs
@@ -302,8 +302,7 @@ impl SshBridge {
                 ),
                 Err(error) => warn!(
                     "SshBridge: ssh_connect_remote_server failed server_id={} error={}",
-                    task_server_id,
-                    error
+                    task_server_id, error
                 ),
             }
             let _ = tx.send(result);
@@ -389,8 +388,7 @@ impl SshBridge {
             let mut progress = initial_progress;
             trace!(
                 "SshBridge: guided ssh connect task spawned server_id={} host={}",
-                task_server_id,
-                task_host
+                task_server_id, task_host
             );
             let task_result = run_guided_ssh_connect(
                 Arc::clone(&mobile_client),
@@ -421,8 +419,7 @@ impl SshBridge {
             if task_result.is_ok() {
                 info!(
                     "SshBridge: guided ssh connect completed server_id={} host={}",
-                    task_server_id,
-                    task_host
+                    task_server_id, task_host
                 );
             }
 
@@ -439,8 +436,7 @@ impl SshBridge {
     ) -> Result<(), ClientError> {
         info!(
             "SshBridge: ssh_respond_to_install_prompt server_id={} install={}",
-            server_id,
-            install
+            server_id, install
         );
         let sender = {
             let mut flows = self.bootstrap_flows.lock().await;
@@ -555,8 +551,7 @@ async fn run_guided_ssh_connect(
     let remote_shell = ssh_client.detect_remote_shell().await;
     info!(
         "guided ssh connect detected shell server_id={} shell={:?}",
-        server_id,
-        remote_shell
+        server_id, remote_shell
     );
     let codex_binary = match ssh_client
         .resolve_codex_binary_optional_with_shell(Some(remote_shell))
@@ -611,8 +606,7 @@ async fn run_guided_ssh_connect(
             let should_install = rx.await.unwrap_or(false);
             info!(
                 "guided ssh connect install decision server_id={} install={}",
-                server_id,
-                should_install
+                server_id, should_install
             );
             progress.pending_install = false;
             if !should_install {
@@ -657,8 +651,7 @@ async fn run_guided_ssh_connect(
                 .map_err(map_ssh_error)?;
             info!(
                 "guided ssh connect install platform server_id={} platform={:?}",
-                server_id,
-                platform
+                server_id, platform
             );
             let installed_binary = ssh_client
                 .install_latest_stable_codex(platform)
@@ -705,10 +698,7 @@ async fn run_guided_ssh_connect(
         .map_err(map_ssh_error)?;
     info!(
         "guided ssh connect bootstrap completed server_id={} remote_port={} local_tunnel_port={} pid={:?}",
-        server_id,
-        bootstrap.server_port,
-        bootstrap.tunnel_local_port,
-        bootstrap.pid
+        server_id, bootstrap.server_port, bootstrap.tunnel_local_port, bootstrap.pid
     );
 
     progress.update_step(

--- a/shared/rust-bridge/codex-mobile-client/src/mobile_client_impl.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/mobile_client_impl.rs
@@ -24,11 +24,13 @@ use crate::types::{
 };
 use codex_app_server_protocol as upstream;
 use codex_ipc::{
-    ClientStatus, CommandExecutionApprovalDecision, ExternalResumeThreadParams,
-    FileChangeApprovalDecision, IpcClient, IpcClientConfig, StreamChange,
+    ClientStatus, CommandExecutionApprovalDecision, ConversationStreamApplyError,
+    ExternalResumeThreadParams, FileChangeApprovalDecision, IpcClient, IpcClientConfig,
+    ProjectedApprovalKind, ProjectedApprovalRequest, ProjectedUserInputRequest, StreamChange,
     ThreadFollowerCommandApprovalDecisionParams, ThreadFollowerFileApprovalDecisionParams,
     ThreadFollowerStartTurnParams, ThreadFollowerSubmitUserInputParams,
-    ThreadStreamStateChangedParams, TypedBroadcast,
+    ThreadStreamStateChangedParams, TypedBroadcast, apply_stream_change_to_conversation_state,
+    project_conversation_state, seed_conversation_state_from_thread,
 };
 
 /// Top-level entry point for platform code (iOS / Android).
@@ -249,7 +251,9 @@ impl MobileClient {
         );
         info!(
             "MobileClient: SSH transport established server_id={} host={} ssh_port={}",
-            config.server_id, ssh_credentials.host.as_str(), ssh_credentials.port
+            config.server_id,
+            ssh_credentials.host.as_str(),
+            ssh_credentials.port
         );
 
         let use_ipv6 = config.host.contains(':');
@@ -265,7 +269,9 @@ impl MobileClient {
                 );
                 warn!(
                     "MobileClient: remote ssh bootstrap failed server_id={} host={} error={}",
-                    config.server_id, ssh_credentials.host.as_str(), error
+                    config.server_id,
+                    ssh_credentials.host.as_str(),
+                    error
                 );
                 ssh_client.disconnect().await;
                 return Err(map_ssh_transport_error(error));
@@ -379,7 +385,9 @@ impl MobileClient {
                 );
                 warn!(
                     "MobileClient: remote ssh session connect failed server_id={} host={} error={}",
-                    server_id, ssh_credentials.host.as_str(), error
+                    server_id,
+                    ssh_credentials.host.as_str(),
+                    error
                 );
                 ssh_client.disconnect().await;
                 return Err(error);
@@ -391,7 +399,11 @@ impl MobileClient {
         trace!(
             "MobileClient: finish_connect_remote_over_ssh session connected server_id={} websocket_url={}",
             server_id,
-            session.config().websocket_url.as_deref().unwrap_or("<none>")
+            session
+                .config()
+                .websocket_url
+                .as_deref()
+                .unwrap_or("<none>")
         );
         if session.has_ipc() {
             self.app_store
@@ -1076,39 +1088,43 @@ impl MobileClient {
                             Ok(()) => {}
                             Err(StreamHandleError::VersionGap) => {
                                 debug!(
-                                    "IPC: version gap for thread={}, falling back to RPC",
+                                    "IPC: version gap for thread={}, reseeding stream cache from RPC",
                                     params.conversation_id
                                 );
                                 stream_cache.remove(&params.conversation_id);
-                                if let Err(e) = refresh_thread_snapshot_from_app_server(
+                                if let Err(e) = recover_ipc_stream_cache_from_app_server(
                                     Arc::clone(&session),
                                     Arc::clone(&app_store),
+                                    &mut stream_cache,
                                     &loop_server_id,
                                     &params.conversation_id,
+                                    params.version,
                                 )
                                 .await
                                 {
                                     warn!(
-                                        "IPC: RPC fallback failed for thread {}: {}",
+                                        "IPC: RPC cache recovery failed for thread {}: {}",
                                         params.conversation_id, e
                                     );
                                 }
                             }
                             Err(StreamHandleError::NoCachedState) => {
                                 debug!(
-                                    "IPC: no cached state for thread={}, falling back to RPC",
+                                    "IPC: no cached state for thread={}, seeding stream cache from RPC",
                                     params.conversation_id
                                 );
-                                if let Err(e) = refresh_thread_snapshot_from_app_server(
+                                if let Err(e) = recover_ipc_stream_cache_from_app_server(
                                     Arc::clone(&session),
                                     Arc::clone(&app_store),
+                                    &mut stream_cache,
                                     &loop_server_id,
                                     &params.conversation_id,
+                                    params.version,
                                 )
                                 .await
                                 {
                                     warn!(
-                                        "IPC: RPC fallback failed for thread {}: {}",
+                                        "IPC: RPC cache recovery failed for thread {}: {}",
                                         params.conversation_id, e
                                     );
                                 }
@@ -1119,16 +1135,18 @@ impl MobileClient {
                                     params.conversation_id, msg
                                 );
                                 stream_cache.remove(&params.conversation_id);
-                                if let Err(e) = refresh_thread_snapshot_from_app_server(
+                                if let Err(e) = recover_ipc_stream_cache_from_app_server(
                                     Arc::clone(&session),
                                     Arc::clone(&app_store),
+                                    &mut stream_cache,
                                     &loop_server_id,
                                     &params.conversation_id,
+                                    params.version,
                                 )
                                 .await
                                 {
                                     warn!(
-                                        "IPC: RPC fallback failed for thread {}: {}",
+                                        "IPC: RPC cache recovery failed for thread {}: {}",
                                         params.conversation_id, e
                                     );
                                 }
@@ -1139,16 +1157,18 @@ impl MobileClient {
                                     params.conversation_id, msg
                                 );
                                 stream_cache.remove(&params.conversation_id);
-                                if let Err(e) = refresh_thread_snapshot_from_app_server(
+                                if let Err(e) = recover_ipc_stream_cache_from_app_server(
                                     Arc::clone(&session),
                                     Arc::clone(&app_store),
+                                    &mut stream_cache,
                                     &loop_server_id,
                                     &params.conversation_id,
+                                    params.version,
                                 )
                                 .await
                                 {
                                     warn!(
-                                        "IPC: RPC fallback failed for thread {}: {}",
+                                        "IPC: RPC cache recovery failed for thread {}: {}",
                                         params.conversation_id, e
                                     );
                                 }
@@ -1898,13 +1918,13 @@ pub fn thread_snapshot_from_generated_thread(
 ) -> Result<ThreadSnapshot, String> {
     let upstream_thread: upstream::Thread =
         crate::rpc::convert_generated_field(thread).map_err(|e| e.to_string())?;
-    let info = ThreadInfo::from(upstream_thread.clone());
-    let items = crate::conversation::hydrate_turns(&upstream_thread.turns, &Default::default());
-    let mut snapshot = ThreadSnapshot::from_info(server_id, info);
-    snapshot.items = items;
-    snapshot.model = model;
-    snapshot.reasoning_effort = reasoning_effort;
-    Ok(snapshot)
+    Ok(thread_snapshot_from_upstream_thread_state(
+        server_id,
+        upstream_thread,
+        model,
+        reasoning_effort,
+        None,
+    ))
 }
 
 pub fn copy_thread_runtime_fields(source: &ThreadSnapshot, target: &mut ThreadSnapshot) {
@@ -2070,6 +2090,38 @@ async fn refresh_thread_snapshot_from_app_server(
     server_id: &str,
     thread_id: &str,
 ) -> Result<(), RpcError> {
+    let thread = read_thread_from_app_server(session, thread_id).await?;
+    upsert_thread_snapshot_from_app_server_thread(&app_store, server_id, thread);
+    Ok(())
+}
+
+async fn read_thread_from_app_server(
+    session: Arc<ServerSession>,
+    thread_id: &str,
+) -> Result<upstream::Thread, RpcError> {
+    let response = session
+        .request(
+            "thread/read",
+            serde_json::json!({ "threadId": thread_id, "includeTurns": true }),
+        )
+        .await?;
+    response
+        .get("thread")
+        .cloned()
+        .ok_or_else(|| RpcError::Deserialization("thread/read response missing thread".to_string()))
+        .and_then(|value| {
+            serde_json::from_value::<upstream::Thread>(value).map_err(|error| {
+                RpcError::Deserialization(format!("deserialize thread/read response: {error}"))
+            })
+        })
+}
+
+fn upsert_thread_snapshot_from_app_server_thread(
+    app_store: &AppStoreReducer,
+    server_id: &str,
+    thread: upstream::Thread,
+) {
+    let thread_id = thread.id.clone();
     let existing = app_store
         .snapshot()
         .threads
@@ -2078,26 +2130,54 @@ async fn refresh_thread_snapshot_from_app_server(
             thread_id: thread_id.to_string(),
         })
         .cloned();
-    let response = session
-        .request(
-            "thread/read",
-            serde_json::json!({ "threadId": thread_id, "includeTurns": true }),
-        )
-        .await?;
-    let thread = response
-        .get("thread")
-        .cloned()
-        .ok_or_else(|| RpcError::Deserialization("thread/read response missing thread".to_string()))
-        .and_then(|value| {
-            serde_json::from_value::<upstream::Thread>(value).map_err(|error| {
-                RpcError::Deserialization(format!("deserialize thread/read response: {error}"))
-            })
-        })?;
     let mut snapshot = thread_snapshot_from_upstream_thread(server_id, thread);
     if let Some(existing) = existing.as_ref() {
         copy_thread_runtime_fields(existing, &mut snapshot);
     }
     app_store.upsert_thread_snapshot(snapshot);
+}
+
+async fn recover_ipc_stream_cache_from_app_server(
+    session: Arc<ServerSession>,
+    app_store: Arc<AppStoreReducer>,
+    cache: &mut HashMap<String, (u32, serde_json::Value)>,
+    server_id: &str,
+    thread_id: &str,
+    version: u32,
+) -> Result<(), RpcError> {
+    let key = ThreadKey {
+        server_id: server_id.to_string(),
+        thread_id: thread_id.to_string(),
+    };
+    let app_snapshot = app_store.snapshot();
+    let existing_thread = app_snapshot.threads.get(&key).cloned();
+    let pending_approvals = app_snapshot
+        .pending_approvals
+        .iter()
+        .filter(|approval| {
+            approval.server_id == server_id && approval.thread_id.as_deref() == Some(thread_id)
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let pending_user_inputs = app_snapshot
+        .pending_user_inputs
+        .iter()
+        .filter(|request| request.server_id == server_id && request.thread_id == thread_id)
+        .cloned()
+        .collect::<Vec<_>>();
+    drop(app_snapshot);
+
+    let thread = read_thread_from_app_server(session, thread_id).await?;
+    upsert_thread_snapshot_from_app_server_thread(&app_store, server_id, thread.clone());
+
+    let mut conversation_state = seed_conversation_state_from_thread(&thread);
+    hydrate_seeded_ipc_conversation_state(
+        &mut conversation_state,
+        existing_thread.as_ref(),
+        &pending_approvals,
+        &pending_user_inputs,
+    );
+    cache.insert(thread_id.to_string(), (version, conversation_state));
     Ok(())
 }
 
@@ -2105,24 +2185,311 @@ fn thread_snapshot_from_upstream_thread(
     server_id: &str,
     thread: upstream::Thread,
 ) -> ThreadSnapshot {
+    thread_snapshot_from_upstream_thread_state(server_id, thread, None, None, None)
+}
+
+fn thread_snapshot_from_upstream_thread_state(
+    server_id: &str,
+    thread: upstream::Thread,
+    model: Option<String>,
+    reasoning_effort: Option<String>,
+    active_turn_id: Option<String>,
+) -> ThreadSnapshot {
     let info = ThreadInfo::from(thread.clone());
     let items = crate::conversation::hydrate_turns(&thread.turns, &Default::default());
     let mut snapshot = ThreadSnapshot::from_info(server_id, info);
     snapshot.items = items;
+    snapshot.model = model;
+    snapshot.reasoning_effort = reasoning_effort;
+    snapshot.active_turn_id = active_turn_id.or_else(|| active_turn_id_from_turns(&thread.turns));
     snapshot
 }
 
-fn thread_snapshot_from_conversation_json(
+fn active_turn_id_from_turns(turns: &[upstream::Turn]) -> Option<String> {
+    turns
+        .iter()
+        .rev()
+        .find(|turn| matches!(turn.status, upstream::TurnStatus::InProgress))
+        .map(|turn| turn.id.clone())
+}
+
+struct ThreadProjection {
+    snapshot: ThreadSnapshot,
+    pending_approvals: Vec<PendingApproval>,
+    pending_user_inputs: Vec<PendingUserInputRequest>,
+}
+
+fn thread_projection_from_conversation_json(
     server_id: &str,
+    conversation_id: &str,
     conversation_state: &serde_json::Value,
-) -> Result<ThreadSnapshot, String> {
-    let thread: upstream::Thread = serde_json::from_value(conversation_state.clone())
-        .map_err(|e| format!("deserialize conversation_state: {e}"))?;
-    Ok(thread_snapshot_from_upstream_thread(server_id, thread))
+) -> Result<ThreadProjection, String> {
+    project_conversation_state(conversation_id, conversation_state)
+        .map(|projection| ThreadProjection {
+            snapshot: thread_snapshot_from_upstream_thread_state(
+                server_id,
+                projection.thread,
+                projection.latest_model,
+                projection.latest_reasoning_effort,
+                projection.active_turn_id,
+            ),
+            pending_approvals: projection
+                .pending_approvals
+                .into_iter()
+                .map(|approval| pending_approval_from_ipc_projection(server_id, approval))
+                .collect(),
+            pending_user_inputs: projection
+                .pending_user_inputs
+                .into_iter()
+                .map(|request| pending_user_input_from_ipc_projection(server_id, request))
+                .collect(),
+        })
+        .or_else(|ipc_error| {
+            let thread: upstream::Thread = serde_json::from_value(conversation_state.clone())
+                .map_err(|error| {
+                    format!(
+                        "deserialize desktop conversation_state: {ipc_error}; deserialize upstream thread: {error}"
+                    )
+                })?;
+            Ok(ThreadProjection {
+                snapshot: thread_snapshot_from_upstream_thread(server_id, thread),
+                pending_approvals: Vec::new(),
+                pending_user_inputs: Vec::new(),
+            })
+        })
+}
+
+fn pending_approval_from_ipc_projection(
+    server_id: &str,
+    approval: ProjectedApprovalRequest,
+) -> PendingApproval {
+    PendingApproval {
+        id: approval.id,
+        server_id: server_id.to_string(),
+        kind: match approval.kind {
+            ProjectedApprovalKind::Command => crate::types::ApprovalKind::Command,
+            ProjectedApprovalKind::FileChange => crate::types::ApprovalKind::FileChange,
+            ProjectedApprovalKind::Permissions => crate::types::ApprovalKind::Permissions,
+        },
+        thread_id: approval.thread_id,
+        turn_id: approval.turn_id,
+        item_id: approval.item_id,
+        command: approval.command,
+        path: approval.path,
+        grant_root: approval.grant_root,
+        cwd: approval.cwd,
+        reason: approval.reason,
+        method: approval.method,
+        raw_params_json: approval.raw_params_json,
+    }
+}
+
+fn pending_user_input_from_ipc_projection(
+    server_id: &str,
+    request: ProjectedUserInputRequest,
+) -> PendingUserInputRequest {
+    PendingUserInputRequest {
+        id: request.id,
+        server_id: server_id.to_string(),
+        thread_id: request.thread_id,
+        turn_id: request.turn_id,
+        item_id: request.item_id,
+        questions: request
+            .questions
+            .into_iter()
+            .map(|question| crate::types::PendingUserInputQuestion {
+                id: question.id,
+                header: question.header,
+                question: question.question,
+                is_other_allowed: question.is_other_allowed,
+                is_secret: question.is_secret,
+                options: question
+                    .options
+                    .into_iter()
+                    .map(|option| crate::types::PendingUserInputOption {
+                        label: option.label,
+                        description: option.description,
+                    })
+                    .collect(),
+            })
+            .collect(),
+        requester_agent_nickname: request.requester_agent_nickname,
+        requester_agent_role: request.requester_agent_role,
+    }
+}
+
+fn sync_ipc_thread_requests(
+    app_store: &AppStoreReducer,
+    server_id: &str,
+    thread_id: &str,
+    pending_approvals: Vec<PendingApproval>,
+    pending_user_inputs: Vec<PendingUserInputRequest>,
+) {
+    let snapshot = app_store.snapshot();
+
+    let mut merged_approvals = snapshot
+        .pending_approvals
+        .into_iter()
+        .filter(|approval| {
+            !(approval.server_id == server_id && approval.thread_id.as_deref() == Some(thread_id))
+        })
+        .collect::<Vec<_>>();
+    merged_approvals.extend(pending_approvals);
+    app_store.replace_pending_approvals(merged_approvals);
+
+    let mut merged_user_inputs = snapshot
+        .pending_user_inputs
+        .into_iter()
+        .filter(|request| !(request.server_id == server_id && request.thread_id == thread_id))
+        .collect::<Vec<_>>();
+    merged_user_inputs.extend(pending_user_inputs);
+    app_store.replace_pending_user_inputs(merged_user_inputs);
+}
+
+fn hydrate_seeded_ipc_conversation_state(
+    conversation_state: &mut serde_json::Value,
+    existing_thread: Option<&ThreadSnapshot>,
+    pending_approvals: &[PendingApproval],
+    pending_user_inputs: &[PendingUserInputRequest],
+) {
+    let Some(object) = conversation_state.as_object_mut() else {
+        return;
+    };
+
+    if let Some(thread) = existing_thread {
+        if let Some(model) = thread.model.as_ref() {
+            object.insert(
+                "latestModel".to_string(),
+                serde_json::Value::String(model.clone()),
+            );
+        }
+        if let Some(reasoning_effort) = thread.reasoning_effort.as_ref() {
+            object.insert(
+                "latestReasoningEffort".to_string(),
+                serde_json::Value::String(reasoning_effort.clone()),
+            );
+        }
+    }
+
+    if !object.contains_key("agentNickname")
+        && let Some(agent_nickname) = pending_user_inputs
+            .iter()
+            .find_map(|request| request.requester_agent_nickname.clone())
+    {
+        object.insert(
+            "agentNickname".to_string(),
+            serde_json::Value::String(agent_nickname),
+        );
+    }
+
+    if !object.contains_key("agentRole")
+        && let Some(agent_role) = pending_user_inputs
+            .iter()
+            .find_map(|request| request.requester_agent_role.clone())
+    {
+        object.insert(
+            "agentRole".to_string(),
+            serde_json::Value::String(agent_role),
+        );
+    }
+
+    let requests = pending_approvals
+        .iter()
+        .filter_map(seed_ipc_approval_request)
+        .chain(pending_user_inputs.iter().map(seed_ipc_user_input_request))
+        .collect::<Vec<_>>();
+    if !requests.is_empty() {
+        object.insert("requests".to_string(), serde_json::Value::Array(requests));
+    }
+}
+
+fn seed_ipc_approval_request(approval: &PendingApproval) -> Option<serde_json::Value> {
+    if matches!(approval.kind, crate::types::ApprovalKind::McpElicitation) {
+        return None;
+    }
+
+    let params = if approval.raw_params_json.trim().is_empty() {
+        seed_ipc_approval_request_params(approval)?
+    } else {
+        serde_json::from_str(&approval.raw_params_json)
+            .ok()
+            .or_else(|| seed_ipc_approval_request_params(approval))?
+    };
+
+    Some(serde_json::json!({
+        "id": approval.id,
+        "method": approval.method,
+        "params": params,
+    }))
+}
+
+fn seed_ipc_approval_request_params(approval: &PendingApproval) -> Option<serde_json::Value> {
+    let thread_id = approval.thread_id.clone()?;
+    let turn_id = approval.turn_id.clone()?;
+    let item_id = approval.item_id.clone()?;
+
+    match approval.kind {
+        crate::types::ApprovalKind::Command => Some(serde_json::json!({
+            "threadId": thread_id,
+            "turnId": turn_id,
+            "itemId": item_id,
+            "command": approval.command,
+            "cwd": approval.cwd,
+            "reason": approval.reason,
+        })),
+        crate::types::ApprovalKind::FileChange => Some(serde_json::json!({
+            "threadId": thread_id,
+            "turnId": turn_id,
+            "itemId": item_id,
+            "grantRoot": approval.grant_root,
+            "reason": approval.reason,
+        })),
+        crate::types::ApprovalKind::Permissions => Some(serde_json::json!({
+            "threadId": thread_id,
+            "turnId": turn_id,
+            "itemId": item_id,
+            "reason": approval.reason,
+        })),
+        crate::types::ApprovalKind::McpElicitation => None,
+    }
+}
+
+fn seed_ipc_user_input_request(request: &PendingUserInputRequest) -> serde_json::Value {
+    serde_json::json!({
+        "id": request.id,
+        "method": "item/tool/requestUserInput",
+        "params": {
+            "threadId": request.thread_id,
+            "turnId": request.turn_id,
+            "itemId": request.item_id,
+            "questions": request.questions.iter().map(|question| {
+                serde_json::json!({
+                    "id": question.id,
+                    "header": question.header.clone().unwrap_or_default(),
+                    "question": question.question,
+                    "isOther": question.is_other_allowed,
+                    "isSecret": question.is_secret,
+                    "options": if question.options.is_empty() {
+                        serde_json::Value::Null
+                    } else {
+                        serde_json::Value::Array(
+                            question.options.iter().map(|option| {
+                                serde_json::json!({
+                                    "label": option.label,
+                                    "description": option.description.clone().unwrap_or_default(),
+                                })
+                            }).collect()
+                        )
+                    },
+                })
+            }).collect::<Vec<_>>(),
+        },
+    })
 }
 
 // -- IPC stream state change handler --
 
+#[derive(Debug)]
 enum StreamHandleError {
     VersionGap,
     NoCachedState,
@@ -2136,60 +2503,55 @@ fn handle_stream_state_change(
     server_id: &str,
     params: &ThreadStreamStateChangedParams,
 ) -> Result<(), StreamHandleError> {
-    match &params.change {
-        StreamChange::Snapshot { conversation_state } => {
-            let mut snapshot = thread_snapshot_from_conversation_json(
-                server_id,
-                conversation_state,
-            )
-            .map_err(|e| {
-                let preview: String = conversation_state.to_string().chars().take(500).collect();
-                StreamHandleError::DeserializeFailed(format!("{e}; json preview: {preview}"))
-            })?;
-
-            let key = ThreadKey {
-                server_id: server_id.to_string(),
-                thread_id: params.conversation_id.clone(),
-            };
-            if let Some(existing) = app_store.snapshot().threads.get(&key) {
-                copy_thread_runtime_fields(existing, &mut snapshot);
+    let mut cached_state = cache.remove(&params.conversation_id);
+    apply_stream_change_to_conversation_state(&mut cached_state, params).map_err(|error| {
+        match error {
+            ConversationStreamApplyError::NoCachedState => StreamHandleError::NoCachedState,
+            ConversationStreamApplyError::VersionGap { .. } => StreamHandleError::VersionGap,
+            ConversationStreamApplyError::PatchFailed(error) => {
+                StreamHandleError::PatchFailed(error.to_string())
             }
-
-            app_store.upsert_thread_snapshot(snapshot);
-            cache.insert(
-                params.conversation_id.clone(),
-                (params.version, conversation_state.clone()),
-            );
-            Ok(())
         }
-        StreamChange::Patches { patches } => {
-            let (cached_version, cached_json) = cache
-                .get_mut(&params.conversation_id)
-                .ok_or(StreamHandleError::NoCachedState)?;
+    })?;
 
-            if params.version != *cached_version + 1 {
-                return Err(StreamHandleError::VersionGap);
-            }
+    let (_, conversation_state) = cached_state
+        .as_ref()
+        .expect("cached state should exist after successful stream apply");
+    let ThreadProjection {
+        mut snapshot,
+        pending_approvals,
+        pending_user_inputs,
+    } = thread_projection_from_conversation_json(
+        server_id,
+        &params.conversation_id,
+        conversation_state,
+    )
+    .map_err(|e| {
+        let preview: String = conversation_state.to_string().chars().take(500).collect();
+        StreamHandleError::DeserializeFailed(format!("{e}; json preview: {preview}"))
+    })?;
 
-            crate::immer_patch::apply_patches(cached_json, patches)
-                .map_err(|e| StreamHandleError::PatchFailed(e.to_string()))?;
-
-            let mut snapshot = thread_snapshot_from_conversation_json(server_id, cached_json)
-                .map_err(StreamHandleError::DeserializeFailed)?;
-
-            let key = ThreadKey {
-                server_id: server_id.to_string(),
-                thread_id: params.conversation_id.clone(),
-            };
-            if let Some(existing) = app_store.snapshot().threads.get(&key) {
-                copy_thread_runtime_fields(existing, &mut snapshot);
-            }
-
-            app_store.upsert_thread_snapshot(snapshot);
-            *cached_version = params.version;
-            Ok(())
-        }
+    let key = ThreadKey {
+        server_id: server_id.to_string(),
+        thread_id: params.conversation_id.clone(),
+    };
+    if let Some(existing) = app_store.snapshot().threads.get(&key) {
+        copy_thread_runtime_fields(existing, &mut snapshot);
     }
+
+    app_store.upsert_thread_snapshot(snapshot);
+    sync_ipc_thread_requests(
+        app_store,
+        server_id,
+        &params.conversation_id,
+        pending_approvals,
+        pending_user_inputs,
+    );
+    cache.insert(
+        params.conversation_id.clone(),
+        cached_state.expect("cached state should exist after successful stream apply"),
+    );
+    Ok(())
 }
 
 async fn send_ipc_approval_response(
@@ -2367,7 +2729,10 @@ fn approval_response_json(
 #[cfg(test)]
 mod mobile_client_tests {
     use super::*;
+    use crate::conversation::ConversationItemContent;
     use crate::types::ThreadSummaryStatus;
+    use serde_json::json;
+    use std::path::PathBuf;
 
     fn make_thread_info(id: &str) -> ThreadInfo {
         ThreadInfo {
@@ -2450,5 +2815,217 @@ mod mobile_client_tests {
     fn remote_oauth_callback_port_reads_localhost_redirect() {
         let auth_url = "https://auth.openai.com/oauth/authorize?response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback&state=abc";
         assert_eq!(remote_oauth_callback_port(auth_url).unwrap(), 1455);
+    }
+
+    #[test]
+    fn handle_stream_state_change_streams_patches_and_updates_ipc_request_state() {
+        let app_store = AppStoreReducer::new();
+        let mut cache = HashMap::new();
+        let thread_id = "thread-1";
+        let server_id = "srv";
+        let key = ThreadKey {
+            server_id: server_id.to_string(),
+            thread_id: thread_id.to_string(),
+        };
+
+        let snapshot_params = ThreadStreamStateChangedParams {
+            conversation_id: thread_id.to_string(),
+            version: 1,
+            change: StreamChange::Snapshot {
+                conversation_state: json!({
+                    "latestModel": "gpt-5.4",
+                    "latestReasoningEffort": "medium",
+                    "turns": [
+                        {
+                            "turnId": "turn-1",
+                            "status": "inProgress",
+                            "params": {
+                                "input": [
+                                    { "type": "text", "text": "hello", "textElements": [] }
+                                ]
+                            },
+                            "items": [
+                                { "id": "assistant-1", "type": "agentMessage", "text": "hel" }
+                            ]
+                        }
+                    ],
+                    "requests": [
+                        {
+                            "id": "approval-1",
+                            "method": "item/commandExecution/requestApproval",
+                            "params": {
+                                "threadId": "thread-1",
+                                "turnId": "turn-1",
+                                "itemId": "exec-1",
+                                "command": "ls",
+                                "cwd": "/repo"
+                            }
+                        }
+                    ]
+                }),
+            },
+        };
+
+        handle_stream_state_change(&mut cache, &app_store, server_id, &snapshot_params).unwrap();
+
+        let snapshot = app_store.snapshot();
+        let thread = snapshot.threads.get(&key).unwrap();
+        assert_eq!(thread.model.as_deref(), Some("gpt-5.4"));
+        assert_eq!(thread.reasoning_effort.as_deref(), Some("medium"));
+        assert_eq!(thread.active_turn_id.as_deref(), Some("turn-1"));
+        assert_eq!(snapshot.pending_approvals.len(), 1);
+        assert_eq!(
+            thread.items.iter().find_map(|item| match &item.content {
+                ConversationItemContent::Assistant(data) => Some(data.text.as_str()),
+                _ => None,
+            }),
+            Some("hel")
+        );
+
+        let text_patch = ThreadStreamStateChangedParams {
+            conversation_id: thread_id.to_string(),
+            version: 2,
+            change: StreamChange::Patches {
+                patches: vec![
+                    codex_ipc::ImmerPatch {
+                        op: codex_ipc::ImmerOp::Replace,
+                        path: vec![
+                            codex_ipc::ImmerPathSegment::Key("turns".to_string()),
+                            codex_ipc::ImmerPathSegment::Index(0),
+                            codex_ipc::ImmerPathSegment::Key("items".to_string()),
+                            codex_ipc::ImmerPathSegment::Index(0),
+                            codex_ipc::ImmerPathSegment::Key("text".to_string()),
+                        ],
+                        value: Some(json!("hello")),
+                    },
+                    codex_ipc::ImmerPatch {
+                        op: codex_ipc::ImmerOp::Replace,
+                        path: vec![codex_ipc::ImmerPathSegment::Key("requests".to_string())],
+                        value: Some(json!([])),
+                    },
+                ],
+            },
+        };
+
+        handle_stream_state_change(&mut cache, &app_store, server_id, &text_patch).unwrap();
+
+        let snapshot = app_store.snapshot();
+        let thread = snapshot.threads.get(&key).unwrap();
+        assert_eq!(thread.active_turn_id.as_deref(), Some("turn-1"));
+        assert!(snapshot.pending_approvals.is_empty());
+        assert_eq!(
+            thread.items.iter().find_map(|item| match &item.content {
+                ConversationItemContent::Assistant(data) => Some(data.text.as_str()),
+                _ => None,
+            }),
+            Some("hello")
+        );
+
+        let completion_patch = ThreadStreamStateChangedParams {
+            conversation_id: thread_id.to_string(),
+            version: 3,
+            change: StreamChange::Patches {
+                patches: vec![codex_ipc::ImmerPatch {
+                    op: codex_ipc::ImmerOp::Replace,
+                    path: vec![
+                        codex_ipc::ImmerPathSegment::Key("turns".to_string()),
+                        codex_ipc::ImmerPathSegment::Index(0),
+                        codex_ipc::ImmerPathSegment::Key("status".to_string()),
+                    ],
+                    value: Some(json!("completed")),
+                }],
+            },
+        };
+
+        handle_stream_state_change(&mut cache, &app_store, server_id, &completion_patch).unwrap();
+
+        let snapshot = app_store.snapshot();
+        let thread = snapshot.threads.get(&key).unwrap();
+        assert_eq!(thread.active_turn_id, None);
+    }
+
+    #[test]
+    fn handle_stream_state_change_accepts_patch_on_thread_read_seeded_cache() {
+        let app_store = AppStoreReducer::new();
+        let thread_id = "thread-1";
+        let server_id = "srv";
+        let key = ThreadKey {
+            server_id: server_id.to_string(),
+            thread_id: thread_id.to_string(),
+        };
+        let thread = upstream::Thread {
+            id: thread_id.to_string(),
+            preview: "hello".to_string(),
+            ephemeral: false,
+            model_provider: "openai".to_string(),
+            created_at: 1,
+            updated_at: 2,
+            status: upstream::ThreadStatus::Active {
+                active_flags: Vec::new(),
+            },
+            path: Some(PathBuf::from("/tmp/thread.jsonl")),
+            cwd: PathBuf::from("/tmp"),
+            cli_version: "1.0.0".to_string(),
+            source: upstream::SessionSource::default(),
+            agent_nickname: None,
+            agent_role: None,
+            git_info: None,
+            name: Some("Thread".to_string()),
+            turns: vec![upstream::Turn {
+                id: "turn-1".to_string(),
+                status: upstream::TurnStatus::InProgress,
+                error: None,
+                items: vec![
+                    upstream::ThreadItem::UserMessage {
+                        id: "user-1".to_string(),
+                        content: vec![upstream::UserInput::Text {
+                            text: "hello".to_string(),
+                            text_elements: Vec::new(),
+                        }],
+                    },
+                    upstream::ThreadItem::AgentMessage {
+                        id: "assistant-1".to_string(),
+                        text: "hel".to_string(),
+                        phase: None,
+                        memory_citation: None,
+                    },
+                ],
+            }],
+        };
+        let mut cache = HashMap::from([(
+            thread_id.to_string(),
+            (1, seed_conversation_state_from_thread(&thread)),
+        )]);
+
+        let text_patch = ThreadStreamStateChangedParams {
+            conversation_id: thread_id.to_string(),
+            version: 2,
+            change: StreamChange::Patches {
+                patches: vec![codex_ipc::ImmerPatch {
+                    op: codex_ipc::ImmerOp::Replace,
+                    path: vec![
+                        codex_ipc::ImmerPathSegment::Key("turns".to_string()),
+                        codex_ipc::ImmerPathSegment::Index(0),
+                        codex_ipc::ImmerPathSegment::Key("items".to_string()),
+                        codex_ipc::ImmerPathSegment::Index(0),
+                        codex_ipc::ImmerPathSegment::Key("text".to_string()),
+                    ],
+                    value: Some(json!("hello")),
+                }],
+            },
+        };
+
+        handle_stream_state_change(&mut cache, &app_store, server_id, &text_patch).unwrap();
+
+        let snapshot = app_store.snapshot();
+        let thread = snapshot.threads.get(&key).unwrap();
+        assert_eq!(thread.active_turn_id.as_deref(), Some("turn-1"));
+        assert_eq!(
+            thread.items.iter().find_map(|item| match &item.content {
+                ConversationItemContent::Assistant(data) => Some(data.text.as_str()),
+                _ => None,
+            }),
+            Some("hello")
+        );
     }
 }

--- a/shared/rust-bridge/codex-mobile-client/src/ssh.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/ssh.rs
@@ -12,10 +12,10 @@ use futures::future::BoxFuture;
 use russh::ChannelMsg;
 use russh::ChannelStream;
 use russh::client::{self, Handle, Msg};
-use russh::keys::decode_secret_key;
 use russh::keys::HashAlg;
 use russh::keys::PrivateKeyWithHashAlg;
 use russh::keys::PublicKey;
+use russh::keys::decode_secret_key;
 use serde::Deserialize;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
@@ -668,6 +668,7 @@ printf '%s/codex-ipc/ipc-%s.sock' "$tmp" "$uid""#;
         override_path: Option<&str>,
     ) -> Result<Option<String>, SshError> {
         let socket_path = match override_path {
+            Some(path) if path.trim().is_empty() => return Ok(None),
             Some(path) => path.to_string(),
             None => self.resolve_remote_ipc_socket_path().await?,
         };
@@ -780,13 +781,7 @@ printf '%s/codex-ipc/ipc-%s.sock' "$tmp" "$uid""#;
                     RemoteShell::PowerShell => "NUL",
                 };
                 let websocket_ready = self
-                    .wait_for_forwarded_websocket_ready(
-                        probe_port,
-                        None,
-                        shell,
-                        null_path,
-                        None,
-                    )
+                    .wait_for_forwarded_websocket_ready(probe_port, None, shell, null_path, None)
                     .await;
                 probe_task.abort();
 
@@ -855,9 +850,7 @@ printf '%s/codex-ipc/ipc-%s.sock' "$tmp" "$uid""#;
                         r#"{cd_prefix}$logFile = {log}; $errFile = {log_err}; $proc = Start-Process -NoNewWindow -PassThru -RedirectStandardOutput $logFile -RedirectStandardError $errFile -FilePath {file_path} -ArgumentList {argument_list}; Write-Host $proc.Id"#,
                         cd_prefix = cd_prefix,
                         log = log_path,
-                        log_err = stderr_log_path
-                            .as_deref()
-                            .expect("windows stderr log path"),
+                        log_err = stderr_log_path.as_deref().expect("windows stderr log path"),
                         file_path = file_path,
                         argument_list = argument_list,
                     )
@@ -1589,7 +1582,11 @@ printf '%s' "$stable_bin""#,
         info!(
             "ssh install codex completed platform={} path={}",
             remote_platform_name(platform),
-            if installed_path.is_empty() { "$HOME/.litter/bin/codex" } else { installed_path }
+            if installed_path.is_empty() {
+                "$HOME/.litter/bin/codex"
+            } else {
+                installed_path
+            }
         );
         Ok(RemoteCodexBinary::Codex(if installed_path.is_empty() {
             "$HOME/.litter/bin/codex".to_string()
@@ -1868,7 +1865,11 @@ fn windows_start_process_spec(binary: &RemoteCodexBinary, listen_url: &str) -> (
     if is_windows_cmd_script(binary.path()) {
         let command = match binary {
             RemoteCodexBinary::Codex(path) => {
-                format!(r#""{}" app-server --listen {}"#, cmd_quote(path), listen_url)
+                format!(
+                    r#""{}" app-server --listen {}"#,
+                    cmd_quote(path),
+                    listen_url
+                )
             }
             RemoteCodexBinary::AppServer(path) => {
                 format!(r#""{}" --listen {}"#, cmd_quote(path), listen_url)
@@ -2148,11 +2149,11 @@ mod tests {
             &RemoteCodexBinary::AppServer(r#"C:\Program Files\Codex\codex-app-server.exe"#.into()),
             "ws://127.0.0.1:8390",
         );
-        assert_eq!(file_path, r#"'C:\Program Files\Codex\codex-app-server.exe'"#);
         assert_eq!(
-            argument_list,
-            "@('--listen', 'ws://127.0.0.1:8390')"
+            file_path,
+            r#"'C:\Program Files\Codex\codex-app-server.exe'"#
         );
+        assert_eq!(argument_list, "@('--listen', 'ws://127.0.0.1:8390')");
     }
 
     #[test]
@@ -2161,7 +2162,10 @@ mod tests {
             format_process_logs("stdout line", "stderr line"),
             "stdout:\nstdout line\n\nstderr:\nstderr line"
         );
-        assert_eq!(format_process_logs("", "stderr line"), "stderr:\nstderr line");
+        assert_eq!(
+            format_process_logs("", "stderr line"),
+            "stderr:\nstderr line"
+        );
     }
 
     #[test]

--- a/shared/rust-bridge/codex-mobile-client/src/store/boundary.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/store/boundary.rs
@@ -90,10 +90,8 @@ impl TryFrom<super::snapshot::ThreadSnapshot> for AppThreadSnapshot {
     type Error = String;
 
     fn try_from(thread: super::snapshot::ThreadSnapshot) -> Result<Self, Self::Error> {
-        let hydrated_conversation_items = merged_hydrated_items(
-            thread.items,
-            thread.local_overlay_items,
-        );
+        let hydrated_conversation_items =
+            merged_hydrated_items(thread.items, thread.local_overlay_items);
         Ok(Self {
             key: thread.key,
             info: thread.info,
@@ -119,7 +117,10 @@ fn merged_hydrated_items(
 ) -> Vec<HydratedConversationItem> {
     let mut merged = items;
     for overlay in local_overlay_items {
-        if merged.iter().all(|existing| !same_overlay_semantics(&overlay, existing)) {
+        if merged
+            .iter()
+            .all(|existing| !same_overlay_semantics(&overlay, existing))
+        {
             merged.push(overlay);
         }
     }

--- a/shared/rust-bridge/codex-mobile-client/src/types/models.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/types/models.rs
@@ -93,7 +93,10 @@ impl From<upstream::Thread> for ThreadInfo {
                 Some(thread.preview)
             },
             cwd: Some(thread.cwd.to_string_lossy().to_string()),
-            path: Some(thread.cwd.to_string_lossy().to_string()),
+            path: match thread.path {
+                Some(path) => Some(path.to_string_lossy().to_string()),
+                None => Some(thread.cwd.to_string_lossy().to_string()),
+            },
             model_provider: Some(thread.model_provider),
             agent_nickname,
             agent_role,

--- a/shared/rust-bridge/mobile-log-collector/src/main.rs
+++ b/shared/rust-bridge/mobile-log-collector/src/main.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 use axum::body::{Body, Bytes};
 use axum::extract::{ConnectInfo, Query, State};
 use axum::http::{HeaderMap, HeaderValue, StatusCode};
-use axum::response::{IntoResponse, Response};
+use axum::response::{Html, IntoResponse, Redirect, Response};
 use axum::routing::get;
 use axum::{Json, Router};
 use chrono::{TimeZone, Utc};
@@ -212,6 +212,9 @@ async fn serve(args: ServeArgs) -> Result<(), Box<dyn std::error::Error>> {
     });
 
     let app = Router::new()
+        .route("/", get(root_redirect))
+        .route("/tail", get(tail_ui))
+        .route("/static/renderjson.js", get(renderjson_asset))
         .route("/healthz", get(healthz))
         .route("/v1/logs", axum::routing::post(post_logs))
         .route("/v1/query", get(query_logs))
@@ -220,7 +223,12 @@ async fn serve(args: ServeArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     let addr: SocketAddr = args.bind.parse()?;
     let listener = TcpListener::bind(&addr).await?;
+    let local_addr = listener.local_addr()?;
     eprintln!("\x1b[32m[collector]\x1b[0m listening on {addr}");
+    eprintln!(
+        "\x1b[32m[collector]\x1b[0m web ui: {}",
+        local_tail_ui_url(local_addr)
+    );
     axum::serve(
         listener,
         app.into_make_service_with_connect_info::<SocketAddr>(),
@@ -231,6 +239,24 @@ async fn serve(args: ServeArgs) -> Result<(), Box<dyn std::error::Error>> {
 
 async fn healthz() -> Json<HealthResponse> {
     Json(HealthResponse { ok: true })
+}
+
+async fn root_redirect() -> Redirect {
+    Redirect::temporary("/tail")
+}
+
+async fn tail_ui() -> Html<&'static str> {
+    Html(include_str!("tail_ui.html"))
+}
+
+async fn renderjson_asset() -> impl IntoResponse {
+    (
+        [(
+            axum::http::header::CONTENT_TYPE,
+            HeaderValue::from_static("text/javascript; charset=utf-8"),
+        )],
+        include_str!("renderjson.js"),
+    )
 }
 
 async fn post_logs(
@@ -644,6 +670,16 @@ fn default_data_dir() -> PathBuf {
     std::env::temp_dir().join(format!("mobile-log-collector-{}", Uuid::new_v4()))
 }
 
+fn local_tail_ui_url(addr: SocketAddr) -> String {
+    let host = match addr.ip() {
+        IpAddr::V4(ip) if ip.is_unspecified() => "127.0.0.1".to_string(),
+        IpAddr::V6(ip) if ip.is_unspecified() => "[::1]".to_string(),
+        IpAddr::V4(ip) => ip.to_string(),
+        IpAddr::V6(ip) => format!("[{ip}]"),
+    };
+    format!("http://{host}:{}/tail", addr.port())
+}
+
 async fn run_query(args: ClientArgs) -> Result<(), Box<dyn std::error::Error>> {
     let client = reqwest::Client::new();
     let response = client
@@ -811,6 +847,15 @@ mod tests {
         assert!(is_private(IpAddr::V4(Ipv4Addr::LOCALHOST)));
         assert!(is_private(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 8))));
         assert!(!is_private(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));
+    }
+
+    #[test]
+    fn local_tail_ui_url_prefers_loopback_for_unspecified_bindings() {
+        let ipv4 = local_tail_ui_url(SocketAddr::from(([0, 0, 0, 0], 8585)));
+        let ipv6 = local_tail_ui_url(SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 0], 8585)));
+
+        assert_eq!(ipv4, "http://127.0.0.1:8585/tail");
+        assert_eq!(ipv6, "http://[::1]:8585/tail");
     }
 
     #[test]

--- a/shared/rust-bridge/mobile-log-collector/src/renderjson.js
+++ b/shared/rust-bridge/mobile-log-collector/src/renderjson.js
@@ -1,0 +1,189 @@
+// Copyright © 2013-2017 David Caldwell <david@porkrind.org>
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+var module, window, define, renderjson=(function() {
+    var themetext = function() {
+        var spans = [];
+        while (arguments.length)
+            spans.push(append(span(Array.prototype.shift.call(arguments)),
+                              text(Array.prototype.shift.call(arguments))));
+        return spans;
+    };
+    var append = function() {
+        var el = Array.prototype.shift.call(arguments);
+        for (var a=0; a<arguments.length; a++)
+            if (arguments[a].constructor == Array)
+                append.apply(this, [el].concat(arguments[a]));
+            else
+                el.appendChild(arguments[a]);
+        return el;
+    };
+    var prepend = function(el, child) {
+        el.insertBefore(child, el.firstChild);
+        return el;
+    };
+    var isempty = function(obj, pl) {
+        var keys = pl || Object.keys(obj);
+        for (var i in keys) if (Object.hasOwnProperty.call(obj, keys[i])) return false;
+        return true;
+    };
+    var text = function(txt) { return document.createTextNode(txt); };
+    var span = function(classname) {
+        var s = document.createElement("span");
+        if (classname) s.className = classname;
+        return s;
+    };
+    var A = function A(txt, classname, callback) {
+        var a = document.createElement("a");
+        if (classname) a.className = classname;
+        a.appendChild(text(txt));
+        a.href = "#";
+        a.onclick = function(e) {
+            callback();
+            if (e) e.stopPropagation();
+            return false;
+        };
+        return a;
+    };
+
+    function _renderjson(json, indent, dont_indent, show_level, options) {
+        var my_indent = dont_indent ? "" : indent;
+
+        var disclosure = function(open, placeholder, close, type, builder) {
+            var content;
+            var empty = span(type);
+            var show = function() {
+                if (!content) append(empty.parentNode,
+                                     content = prepend(builder(),
+                                                       A(options.hide, "disclosure",
+                                                         function() {
+                                                             content.style.display = "none";
+                                                             empty.style.display = "inline";
+                                                         })));
+                content.style.display = "inline";
+                empty.style.display = "none";
+            };
+            append(empty,
+                   A(options.show, "disclosure", show),
+                   themetext(type + " syntax", open),
+                   A(placeholder, null, show),
+                   themetext(type + " syntax", close));
+
+            var el = append(span(), text(my_indent.slice(0, -1)), empty);
+            if (show_level > 0 && type !== "string")
+                show();
+            return el;
+        };
+
+        if (json === null) return themetext(null, my_indent, "keyword", "null");
+        if (json === void 0) return themetext(null, my_indent, "keyword", "undefined");
+
+        if (typeof(json) === "string" && json.length > options.max_string_length)
+            return disclosure('"', json.substr(0, options.max_string_length) + " ...", '"', "string", function() {
+                return append(span("string"), themetext(null, my_indent, "string", JSON.stringify(json)));
+            });
+
+        if (typeof(json) !== "object" || [Number, String, Boolean, Date].indexOf(json.constructor) >= 0)
+            return themetext(null, my_indent, typeof(json), JSON.stringify(json));
+
+        if (json.constructor === Array) {
+            if (json.length === 0) return themetext(null, my_indent, "array syntax", "[]");
+
+            return disclosure("[", options.collapse_msg(json.length), "]", "array", function() {
+                var as = append(span("array"), themetext("array syntax", "[", null, "\n"));
+                for (var i=0; i<json.length; i++)
+                    append(as,
+                           _renderjson(options.replacer.call(json, i, json[i]), indent + "    ", false, show_level - 1, options),
+                           i !== json.length - 1 ? themetext("syntax", ",") : [],
+                           text("\n"));
+                append(as, themetext(null, indent, "array syntax", "]"));
+                return as;
+            });
+        }
+
+        if (isempty(json, options.property_list))
+            return themetext(null, my_indent, "object syntax", "{}");
+
+        return disclosure("{", options.collapse_msg(Object.keys(json).length), "}", "object", function() {
+            var os = append(span("object"), themetext("object syntax", "{", null, "\n"));
+            for (var k in json) var last = k;
+            var keys = options.property_list || Object.keys(json);
+            if (options.sort_objects)
+                keys = keys.sort();
+            for (var i in keys) {
+                var key = keys[i];
+                if (!(key in json)) continue;
+                append(os, themetext(null, indent + "    ", "key", '"' + key + '"', "object syntax", ": "),
+                       _renderjson(options.replacer.call(json, key, json[key]), indent + "    ", true, show_level - 1, options),
+                       key !== last ? themetext("syntax", ",") : [],
+                       text("\n"));
+            }
+            append(os, themetext(null, indent, "object syntax", "}"));
+            return os;
+        });
+    }
+
+    var renderjson = function renderjson(json) {
+        var options = new Object(renderjson.options);
+        options.replacer = typeof(options.replacer) === "function" ? options.replacer : function(k, v) { return v; };
+        var pre = append(document.createElement("pre"), _renderjson(json, "", false, options.show_to_level, options));
+        pre.className = "renderjson";
+        return pre;
+    };
+    renderjson.set_icons = function(show, hide) {
+        renderjson.options.show = show;
+        renderjson.options.hide = hide;
+        return renderjson;
+    };
+    renderjson.set_show_to_level = function(level) {
+        renderjson.options.show_to_level = typeof level === "string" && level.toLowerCase() === "all" ? Number.MAX_VALUE : level;
+        return renderjson;
+    };
+    renderjson.set_max_string_length = function(length) {
+        renderjson.options.max_string_length = typeof length === "string" && length.toLowerCase() === "none" ? Number.MAX_VALUE : length;
+        return renderjson;
+    };
+    renderjson.set_sort_objects = function(sort_bool) {
+        renderjson.options.sort_objects = sort_bool;
+        return renderjson;
+    };
+    renderjson.set_replacer = function(replacer) {
+        renderjson.options.replacer = replacer;
+        return renderjson;
+    };
+    renderjson.set_collapse_msg = function(collapse_msg) {
+        renderjson.options.collapse_msg = collapse_msg;
+        return renderjson;
+    };
+    renderjson.set_property_list = function(prop_list) {
+        renderjson.options.property_list = prop_list;
+        return renderjson;
+    };
+    renderjson.set_show_by_default = function(show) {
+        renderjson.options.show_to_level = show ? Number.MAX_VALUE : 0;
+        return renderjson;
+    };
+    renderjson.options = {};
+    renderjson.set_icons("⊕", "⊖");
+    renderjson.set_show_by_default(false);
+    renderjson.set_sort_objects(false);
+    renderjson.set_max_string_length("none");
+    renderjson.set_replacer(void 0);
+    renderjson.set_property_list(void 0);
+    renderjson.set_collapse_msg(function(len) { return len + " item" + (len === 1 ? "" : "s"); });
+    return renderjson;
+})();
+
+if (define) define({renderjson: renderjson});
+else (module || {}).exports = (window || {}).renderjson = renderjson;

--- a/shared/rust-bridge/mobile-log-collector/src/tail_ui.html
+++ b/shared/rust-bridge/mobile-log-collector/src/tail_ui.html
@@ -1,0 +1,634 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Mobile Log Collector Tail</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #ffffff;
+      --panel: #ffffff;
+      --panel-border: #e7e2d9;
+      --text: #171411;
+      --muted: #6c6257;
+      --accent: #1f5f4a;
+      --warn: #9a6a00;
+      --error: #b42318;
+      --trace: #8e857b;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font: 15px/1.55 "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
+    }
+
+    header {
+      display: grid;
+      gap: 14px;
+      padding: 28px 28px 18px;
+      border-bottom: 1px solid var(--panel-border);
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 28px;
+      font-weight: 500;
+      letter-spacing: -0.02em;
+      color: var(--text);
+    }
+
+    .meta,
+    .controls {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px 14px;
+      align-items: center;
+    }
+
+    .badge,
+    button,
+    .endpoint,
+    .filters {
+      border: 1px solid var(--panel-border);
+      background: var(--panel);
+      border-radius: 8px;
+      padding: 8px 10px;
+    }
+
+    .badge strong {
+      color: var(--accent);
+    }
+
+    button {
+      color: var(--text);
+      cursor: pointer;
+      font: 13px/1.3 "SFMono-Regular", "SF Mono", ui-monospace, Menlo, monospace;
+    }
+
+    button:hover {
+      border-color: #cfc7bc;
+      background: #faf8f4;
+    }
+
+    .endpoint,
+    .filters {
+      border-radius: 8px;
+      max-width: 100%;
+      overflow: auto;
+      white-space: normal;
+      color: var(--muted);
+      font: 12px/1.5 "SFMono-Regular", "SF Mono", ui-monospace, Menlo, monospace;
+    }
+
+    main {
+      display: grid;
+      gap: 0;
+      padding: 0 28px 72px;
+    }
+
+    .empty {
+      padding: 32px 0;
+      color: var(--muted);
+      text-align: left;
+    }
+
+    details.event {
+      border-bottom: 1px solid var(--panel-border);
+    }
+
+    details.event[open] {
+      background: #fcfbf8;
+    }
+
+    details.event > summary {
+      cursor: pointer;
+      list-style: none;
+    }
+
+    details.event > summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .event-summary {
+      display: grid;
+      grid-template-columns: auto auto auto auto minmax(0, 1fr);
+      gap: 10px 14px;
+      align-items: start;
+      padding: 16px 0;
+    }
+
+    .event-summary:hover {
+      background: transparent;
+    }
+
+    .timestamp,
+    .device,
+    .subsystem {
+      color: var(--muted);
+      font: 12px/1.4 "SFMono-Regular", "SF Mono", ui-monospace, Menlo, monospace;
+    }
+
+    .level {
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      font: 12px/1.4 "SFMono-Regular", "SF Mono", ui-monospace, Menlo, monospace;
+    }
+
+    .level-error { color: var(--error); }
+    .level-warn { color: var(--warn); }
+    .level-info { color: var(--accent); }
+    .level-debug { color: #67c7ff; }
+    .level-trace { color: var(--trace); }
+
+    .message {
+      min-width: 0;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      overflow-wrap: anywhere;
+    }
+
+    .event-json {
+      display: grid;
+      gap: 12px;
+      padding: 0 0 18px;
+    }
+
+    .json-inline-composite {
+      display: grid;
+      gap: 8px;
+      padding-top: 4px;
+    }
+
+    .json-inline-text {
+      color: var(--muted);
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      font: 13px/1.55 "SFMono-Regular", "SF Mono", ui-monospace, Menlo, monospace;
+    }
+
+    .embedded-json-label {
+      color: var(--accent);
+      font-size: 12px;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      font-family: "SFMono-Regular", "SF Mono", ui-monospace, Menlo, monospace;
+    }
+
+    .renderjson {
+      margin: 0;
+      padding-top: 4px;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      font: 13px/1.55 "SFMono-Regular", "SF Mono", ui-monospace, Menlo, monospace;
+      color: var(--text);
+    }
+
+    .renderjson a {
+      color: var(--accent);
+      text-decoration: none;
+    }
+
+    .renderjson .disclosure {
+      margin-right: 6px;
+      font-weight: 600;
+    }
+
+    .renderjson .syntax {
+      color: var(--muted);
+    }
+
+    .renderjson .string {
+      color: #f9a66c;
+    }
+
+    .renderjson .number {
+      color: #7ad7ff;
+    }
+
+    .renderjson .boolean {
+      color: #ffd166;
+    }
+
+    .renderjson .keyword {
+      color: var(--trace);
+    }
+
+    .renderjson .key {
+      color: #9dd7bc;
+    }
+
+    @media (max-width: 880px) {
+      .event-summary {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Mobile Log Collector Tail</h1>
+    <div class="meta">
+      <div class="badge">Status: <strong id="status">Booting</strong></div>
+      <div class="badge">Visible events: <strong id="count">0</strong></div>
+      <div class="badge">History preload: <strong id="history-limit">200</strong></div>
+    </div>
+    <div class="controls">
+      <button id="clear" type="button">Clear</button>
+      <button id="jump" type="button">Jump To Latest</button>
+    </div>
+    <div class="endpoint" id="endpoint"></div>
+    <div class="filters" id="filters"></div>
+  </header>
+
+  <main>
+    <div class="empty" id="empty">Waiting for log events...</div>
+    <div id="events"></div>
+  </main>
+
+  <script src="/static/renderjson.js"></script>
+  <script>
+    const MAX_EVENTS = 1000;
+    const DEFAULT_HISTORY_LIMIT = 200;
+    const url = new URL(window.location.href);
+    const liveParams = new URLSearchParams(url.search);
+    const historyParams = new URLSearchParams(url.search);
+    if (!historyParams.has("limit")) {
+      historyParams.set("limit", String(DEFAULT_HISTORY_LIMIT));
+    }
+
+    const endpoint = document.getElementById("endpoint");
+    const filters = document.getElementById("filters");
+    const statusEl = document.getElementById("status");
+    const countEl = document.getElementById("count");
+    const historyLimitEl = document.getElementById("history-limit");
+    const emptyEl = document.getElementById("empty");
+    const eventsEl = document.getElementById("events");
+    const clearButton = document.getElementById("clear");
+    const jumpButton = document.getElementById("jump");
+
+    endpoint.textContent = "Streaming " + buildApiUrl("/v1/tail", liveParams);
+    filters.textContent = url.search ? "Filters " + url.search : "Filters none";
+    historyLimitEl.textContent = historyParams.get("limit");
+
+    clearButton.addEventListener("click", () => {
+      eventsEl.replaceChildren();
+      updateCount();
+    });
+
+    jumpButton.addEventListener("click", () => {
+      window.scrollTo({ top: document.body.scrollHeight, behavior: "smooth" });
+    });
+
+    function buildApiUrl(path, params) {
+      const next = new URL(path, window.location.origin);
+      next.search = params.toString();
+      return next.toString();
+    }
+
+    function setStatus(text) {
+      statusEl.textContent = text;
+    }
+
+    function updateCount() {
+      const count = eventsEl.childElementCount;
+      countEl.textContent = String(count);
+      emptyEl.hidden = count > 0;
+    }
+
+    function isNearBottom() {
+      return window.innerHeight + window.scrollY >= document.body.scrollHeight - 180;
+    }
+
+    function scrollToLatest() {
+      window.scrollTo({ top: document.body.scrollHeight, behavior: "smooth" });
+    }
+
+    function tryParseJson(value) {
+      if (typeof value !== "string" || value.trim() === "" || value === "null") {
+        return value;
+      }
+      try {
+        return JSON.parse(value);
+      } catch {
+        return value;
+      }
+    }
+
+    function normalizeEvent(event) {
+      const copy = JSON.parse(JSON.stringify(event));
+      copy.fields_json = tryParseJson(copy.fields_json);
+      copy.payload_json = tryParseJson(copy.payload_json);
+      return copy;
+    }
+
+    function parseBalancedJson(text, startIndex) {
+      const opening = text[startIndex];
+      if (opening !== "{" && opening !== "[") {
+        return null;
+      }
+
+      const stack = [opening === "{" ? "}" : "]"];
+      let inString = false;
+      let escaping = false;
+
+      for (let index = startIndex + 1; index < text.length; index += 1) {
+        const char = text[index];
+        if (inString) {
+          if (escaping) {
+            escaping = false;
+            continue;
+          }
+          if (char === "\\") {
+            escaping = true;
+            continue;
+          }
+          if (char === "\"") {
+            inString = false;
+          }
+          continue;
+        }
+
+        if (char === "\"") {
+          inString = true;
+          continue;
+        }
+
+        if (char === "{") {
+          stack.push("}");
+          continue;
+        }
+        if (char === "[") {
+          stack.push("]");
+          continue;
+        }
+        if (char === "}" || char === "]") {
+          if (stack[stack.length - 1] !== char) {
+            return null;
+          }
+          stack.pop();
+          if (stack.length === 0) {
+            return text.slice(startIndex, index + 1);
+          }
+        }
+      }
+
+      return null;
+    }
+
+    function splitEmbeddedJson(text) {
+      if (typeof text !== "string" || text.trim() === "") {
+        return null;
+      }
+
+      const segments = [];
+      let cursor = 0;
+      let foundJson = false;
+
+      while (cursor < text.length) {
+        let candidateIndex = -1;
+        for (let index = cursor; index < text.length; index += 1) {
+          const char = text[index];
+          if (char === "{" || char === "[") {
+            candidateIndex = index;
+            break;
+          }
+        }
+
+        if (candidateIndex < 0) {
+          break;
+        }
+
+        const jsonSlice = parseBalancedJson(text, candidateIndex);
+        if (!jsonSlice) {
+          cursor = candidateIndex + 1;
+          continue;
+        }
+
+        let parsed;
+        try {
+          parsed = JSON.parse(jsonSlice);
+        } catch {
+          cursor = candidateIndex + 1;
+          continue;
+        }
+
+        if (candidateIndex > cursor) {
+          segments.push({ type: "text", value: text.slice(cursor, candidateIndex) });
+        }
+        segments.push({ type: "json", value: parsed });
+        cursor = candidateIndex + jsonSlice.length;
+        foundJson = true;
+      }
+
+      if (!foundJson) {
+        return null;
+      }
+      if (cursor < text.length) {
+        segments.push({ type: "text", value: text.slice(cursor) });
+      }
+
+      return segments.filter((segment) => segment.value !== "");
+    }
+
+    function summarizeText(text) {
+      if (typeof text !== "string") {
+        return "";
+      }
+      const segments = splitEmbeddedJson(text);
+      if (!segments) {
+        return text;
+      }
+      return segments
+        .map((segment) => (segment.type === "text" ? segment.value : "[json]"))
+        .join("")
+        .replace(/\s+/g, " ")
+        .trim();
+    }
+
+    function renderLibraryJson(value) {
+      return renderjson(value);
+    }
+
+    function renderEmbeddedJsonString(text) {
+      const segments = splitEmbeddedJson(text);
+      if (!segments) {
+        return null;
+      }
+
+      const container = document.createElement("div");
+      container.className = "json-inline-composite";
+
+      for (const segment of segments) {
+        if (segment.type === "text") {
+          const span = document.createElement("span");
+          span.className = "json-inline-text";
+          span.textContent = segment.value;
+          container.appendChild(span);
+          continue;
+        }
+
+        const label = document.createElement("div");
+        label.className = "embedded-json-label";
+        if (Array.isArray(segment.value)) {
+          label.textContent = "Embedded JSON Array(" + segment.value.length + ")";
+        } else {
+          label.textContent = "Embedded JSON Object(" + Object.keys(segment.value).length + ")";
+        }
+        container.appendChild(label);
+        container.appendChild(renderLibraryJson(segment.value));
+      }
+
+      return container;
+    }
+
+    function levelClass(level) {
+      const normalized = String(level || "").toLowerCase();
+      return "level level-" + (normalized || "info");
+    }
+
+    function formatTimestamp(timestampMs) {
+      const date = new Date(timestampMs);
+      if (Number.isNaN(date.getTime())) {
+        return String(timestampMs);
+      }
+      return date.toLocaleTimeString([], {
+        hour12: false,
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+        fractionalSecondDigits: 3,
+      });
+    }
+
+    function renderEvent(event) {
+      const nearBottom = isNearBottom();
+      const view = normalizeEvent(event);
+      const details = document.createElement("details");
+      details.className = "event";
+
+      const summary = document.createElement("summary");
+      summary.className = "event-summary";
+      summary.innerHTML =
+        "<span class=\"timestamp\"></span>" +
+        "<span class=\"device\"></span>" +
+        "<span class=\"" + levelClass(view.level) + "\"></span>" +
+        "<span class=\"subsystem\"></span>" +
+        "<span class=\"message\"></span>";
+      summary.children[0].textContent = formatTimestamp(view.timestamp_ms);
+      summary.children[1].textContent = view.device_name || view.device_id || "unknown-device";
+      summary.children[2].textContent = view.level || "INFO";
+      summary.children[3].textContent = view.subsystem || "unknown";
+      summary.children[4].textContent = summarizeText(view.message || "");
+      details.appendChild(summary);
+
+      const body = document.createElement("div");
+      body.className = "event-json";
+      const embeddedMessage = renderEmbeddedJsonString(view.message || "");
+      if (embeddedMessage) {
+        body.appendChild(embeddedMessage);
+      }
+      body.appendChild(renderLibraryJson(view));
+      details.appendChild(body);
+      eventsEl.appendChild(details);
+
+      while (eventsEl.childElementCount > MAX_EVENTS) {
+        eventsEl.firstElementChild.remove();
+      }
+
+      updateCount();
+      if (nearBottom) {
+        scrollToLatest();
+      }
+    }
+
+    async function readNdjsonStream(body, onEvent) {
+      const reader = body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) {
+          break;
+        }
+        buffer += decoder.decode(value, { stream: true });
+        let newlineIndex;
+        while ((newlineIndex = buffer.indexOf("\n")) >= 0) {
+          const line = buffer.slice(0, newlineIndex).trim();
+          buffer = buffer.slice(newlineIndex + 1);
+          if (!line) {
+            continue;
+          }
+          onEvent(JSON.parse(line));
+        }
+      }
+
+      buffer += decoder.decode();
+      const tail = buffer.trim();
+      if (tail) {
+        onEvent(JSON.parse(tail));
+      }
+    }
+
+    async function preloadHistory() {
+      const response = await fetch(buildApiUrl("/v1/query", historyParams));
+      if (!response.ok) {
+        throw new Error("history request failed with " + response.status);
+      }
+      const text = await response.text();
+      for (const line of text.split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed) {
+          continue;
+        }
+        renderEvent(JSON.parse(trimmed));
+      }
+    }
+
+    async function connectTailLoop() {
+      while (true) {
+        try {
+          setStatus("Connecting");
+          const response = await fetch(buildApiUrl("/v1/tail", liveParams));
+          if (!response.ok || !response.body) {
+            throw new Error("tail request failed with " + response.status);
+          }
+          setStatus("Live");
+          await readNdjsonStream(response.body, renderEvent);
+          setStatus("Reconnecting");
+        } catch (error) {
+          setStatus("Retrying: " + error.message);
+        }
+        await new Promise((resolve) => window.setTimeout(resolve, 1000));
+      }
+    }
+
+    async function boot() {
+      renderjson
+        .set_icons("▶", "▼")
+        .set_show_to_level(0)
+        .set_sort_objects(false)
+        .set_max_string_length("none");
+      try {
+        setStatus("Loading history");
+        await preloadHistory();
+      } catch (error) {
+        setStatus("History failed: " + error.message);
+      }
+      updateCount();
+      connectTailLoop();
+    }
+
+    boot();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `codex-ipc` conversation-state projection and patch application helpers so desktop IPC state can be normalized into normal mobile thread snapshots
- recover IPC patch-only streams in the shared mobile client by reseeding cache from `thread/read`, preserving active-turn, approval, and user-input state so streaming/thinking indicators continue updating on iOS and Android
- bundle current mobile followups across Android/iOS/shared Rust plus a browser tail UI for `mobile-log-collector` and updated `make log-collector` messaging

## Why
- IPC followers could miss live streaming state when desktop emitted patches before a snapshot, which caused mobile to fall back to one-shot thread refreshes instead of continuing the normal stream
- local mobile log inspection still required raw query output instead of a quick tail UI

## Impact
- IPC-backed mobile threads should now ingest desktop state like normal app-server thread data, including patch-driven updates
- local log collection now has a `/tail` web UI in addition to the existing API/CLI flow

## Validation
- `env RUSTC_WRAPPER= cargo test --manifest-path shared/rust-bridge/Cargo.toml -p codex-ipc conversation_state -- --nocapture`
- `env RUSTC_WRAPPER= cargo test --manifest-path shared/rust-bridge/Cargo.toml -p codex-mobile-client mobile_client_tests -- --nocapture`
- `env RUSTC_WRAPPER= cargo test --manifest-path shared/rust-bridge/Cargo.toml -p mobile-log-collector -- --nocapture`

## Notes
- the dirty `shared/third_party/codex` submodule state was intentionally left out of this PR
- I did not run a manual iOS/Android UI pass in this turn