### PR TITLE
ci: harden release sccache

### DIFF
--- a/.github/workflows/android-apk-release.yml
+++ b/.github/workflows/android-apk-release.yml
@@ -135,6 +135,8 @@ jobs:
       SCCACHE_REGION: auto
       SCCACHE_S3_USE_SSL: "true"
       SCCACHE_S3_KEY_PREFIX: ci/android
+      SCCACHE_LOG: info
+      SCCACHE_ERROR_LOG: ${{ runner.temp }}/sccache-android.log
       AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
 
@@ -170,6 +172,12 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
+      - name: Prime sccache
+        run: |
+          sccache --stop-server || true
+          sccache --start-server
+          sccache --show-stats || true
+
       - name: Download shared prep artifact
         uses: actions/download-artifact@v4
         with:
@@ -190,7 +198,9 @@ jobs:
           touch .build-stamps/sync .build-stamps/bindings-kotlin
 
       - name: Install cargo-ndk
-        run: cargo install cargo-ndk
+        env:
+          RUSTC_WRAPPER: sccache
+        run: cargo install cargo-ndk --locked
 
       - name: Build Rust JNI libs
         env:

--- a/.github/workflows/android-play-release.yml
+++ b/.github/workflows/android-play-release.yml
@@ -91,6 +91,8 @@ jobs:
       SCCACHE_REGION: auto
       SCCACHE_S3_USE_SSL: "true"
       SCCACHE_S3_KEY_PREFIX: ci/android
+      SCCACHE_LOG: info
+      SCCACHE_ERROR_LOG: ${{ runner.temp }}/sccache-android.log
       AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
 
@@ -149,6 +151,12 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
+      - name: Prime sccache
+        run: |
+          sccache --stop-server || true
+          sccache --start-server
+          sccache --show-stats || true
+
       - name: Download shared prep artifact
         uses: actions/download-artifact@v4
         with:
@@ -169,7 +177,9 @@ jobs:
           touch .build-stamps/sync .build-stamps/bindings-kotlin
 
       - name: Install cargo-ndk
-        run: cargo install cargo-ndk
+        env:
+          RUSTC_WRAPPER: sccache
+        run: cargo install cargo-ndk --locked
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -205,7 +215,10 @@ jobs:
           LITTER_PLAY_SERVICE_ACCOUNT_JSON: ${{ runner.temp }}/play-service-account.json
           LITTER_PLAY_TRACK: internal
           LITTER_VERSION_CODE_OVERRIDE: ${{ env.LITTER_VERSION_CODE_OVERRIDE }}
-        run: make play-release
+        run: |
+          set -euo pipefail
+          trap 'status=$?; echo "==> sccache stats"; sccache --show-stats || true; if [ -f "$SCCACHE_ERROR_LOG" ]; then echo "==> sccache error log"; tail -200 "$SCCACHE_ERROR_LOG" || true; fi; exit $status' EXIT
+          make play-release
 
       - name: Generate checksums
         run: |

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -29,6 +29,8 @@ jobs:
       SCCACHE_REGION: auto
       SCCACHE_S3_USE_SSL: "true"
       SCCACHE_S3_KEY_PREFIX: ci/ios
+      SCCACHE_LOG: info
+      SCCACHE_ERROR_LOG: ${{ runner.temp }}/sccache-ios.log
       AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
 
@@ -82,6 +84,12 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Prime sccache
+        run: |
+          sccache --stop-server || true
+          sccache --start-server
+          sccache --show-stats || true
 
       - name: Decode App Store Connect API key
         env:
@@ -165,4 +173,7 @@ jobs:
           MARKETING_VERSION: ${{ env.MARKETING_VERSION }}
           BETA_GROUP_NAMES: ${{ env.BETA_GROUP_NAMES }}
           WAIT_FOR_PROCESSING: ${{ env.WAIT_FOR_PROCESSING }}
-        run: make testflight
+        run: |
+          set -euo pipefail
+          trap 'status=$?; echo "==> sccache stats"; sccache --show-stats || true; if [ -f "$SCCACHE_ERROR_LOG" ]; then echo "==> sccache error log"; tail -200 "$SCCACHE_ERROR_LOG" || true; fi; exit $status' EXIT
+          make testflight

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -180,7 +180,9 @@ jobs:
           touch .build-stamps/sync .build-stamps/bindings-kotlin
 
       - name: Install cargo-ndk
-        run: cargo install cargo-ndk
+        env:
+          RUSTC_WRAPPER: sccache
+        run: cargo install cargo-ndk --locked
 
       - name: Build Rust JNI libs
         env:

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -197,6 +197,8 @@ jobs:
       SCCACHE_REGION: auto
       SCCACHE_S3_USE_SSL: "true"
       SCCACHE_S3_KEY_PREFIX: ci/android
+      SCCACHE_LOG: info
+      SCCACHE_ERROR_LOG: ${{ runner.temp }}/sccache-android.log
       AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
 
@@ -255,6 +257,12 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
+      - name: Prime sccache
+        run: |
+          sccache --stop-server || true
+          sccache --start-server
+          sccache --show-stats || true
+
       - name: Download shared prep artifact
         uses: actions/download-artifact@v4
         with:
@@ -275,7 +283,9 @@ jobs:
           touch .build-stamps/sync .build-stamps/bindings-kotlin
 
       - name: Install cargo-ndk
-        run: cargo install cargo-ndk
+        env:
+          RUSTC_WRAPPER: sccache
+        run: cargo install cargo-ndk --locked
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -311,7 +321,10 @@ jobs:
           LITTER_PLAY_SERVICE_ACCOUNT_JSON: ${{ runner.temp }}/play-service-account.json
           LITTER_PLAY_TRACK: internal
           LITTER_VERSION_CODE_OVERRIDE: ${{ env.LITTER_VERSION_CODE_OVERRIDE }}
-        run: make play-release
+        run: |
+          set -euo pipefail
+          trap 'status=$?; echo "==> sccache stats"; sccache --show-stats || true; if [ -f "$SCCACHE_ERROR_LOG" ]; then echo "==> sccache error log"; tail -200 "$SCCACHE_ERROR_LOG" || true; fi; exit $status' EXIT
+          make play-release
 
       - name: Generate checksums
         run: |
@@ -345,6 +358,8 @@ jobs:
       SCCACHE_REGION: auto
       SCCACHE_S3_USE_SSL: "true"
       SCCACHE_S3_KEY_PREFIX: ci/ios
+      SCCACHE_LOG: info
+      SCCACHE_ERROR_LOG: ${{ runner.temp }}/sccache-ios.log
       AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
 
@@ -398,6 +413,12 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Prime sccache
+        run: |
+          sccache --stop-server || true
+          sccache --start-server
+          sccache --show-stats || true
 
       - name: Download shared prep artifact
         uses: actions/download-artifact@v4
@@ -486,4 +507,7 @@ jobs:
           MARKETING_VERSION: ${{ env.MARKETING_VERSION }}
           BETA_GROUP_NAMES: ${{ env.BETA_GROUP_NAMES }}
           WAIT_FOR_PROCESSING: ${{ env.WAIT_FOR_PROCESSING }}
-        run: make testflight
+        run: |
+          set -euo pipefail
+          trap 'status=$?; echo "==> sccache stats"; sccache --show-stats || true; if [ -f "$SCCACHE_ERROR_LOG" ]; then echo "==> sccache error log"; tail -200 "$SCCACHE_ERROR_LOG" || true; fi; exit $status' EXIT
+          make testflight


### PR DESCRIPTION
## Summary
- run `cargo install cargo-ndk` through `sccache` in CI
- prime `sccache` before release jobs and dump stats/error logs on failure
- keep release and CI workflow behavior aligned across Android and iOS

## Verification
- ruby -e 'require "yaml"; %w[.github/workflows/mobile-release.yml .github/workflows/mobile-ci.yml .github/workflows/android-play-release.yml .github/workflows/android-apk-release.yml .github/workflows/ios-testflight.yml].each { |f| YAML.load_file(f) }; puts "yaml ok"'
- git diff --check