### PR TITLE
[codex] tighten iOS collapsed transcript previews

### DIFF
--- a/apps/ios/Litter.xcodeproj/xcshareddata/xcschemes/Litter.xcscheme
+++ b/apps/ios/Litter.xcodeproj/xcshareddata/xcschemes/Litter.xcscheme
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1600"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES"
-      runPostActionsOnFailure = "NO">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -27,8 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -40,8 +38,7 @@
       </MacroExpansion>
       <Testables>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "NO">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "7BB0106D190F10717D781234"
@@ -51,8 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -74,9 +69,7 @@
             ReferencedContainer = "container:Litter.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
-         <StoreKitConfigurationFileReference
+      <StoreKitConfigurationFileReference
          identifier = "../../Sources/Litter/Resources/TipJarProducts.storekit">
       </StoreKitConfigurationFileReference>
    </LaunchAction>
@@ -96,8 +89,6 @@
             ReferencedContainer = "container:Litter.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/apps/ios/Sources/Litter/Views/ConversationTimelineView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationTimelineView.swift
@@ -525,7 +525,7 @@ private struct ConversationExplorationGroupRow: View {
 
     var body: some View {
         let entries = explorationEntries
-        let visibleEntries = expanded ? entries : Array(entries.prefix(3))
+        let visibleEntries = expanded ? entries : Array(entries.prefix(2))
 
         VStack(alignment: .leading, spacing: 8) {
             Button(action: toggleExpanded) {
@@ -533,9 +533,11 @@ private struct ConversationExplorationGroupRow: View {
                     Image(systemName: "magnifyingglass")
                         .litterFont(size: 12, weight: .semibold)
                         .foregroundColor(isActive ? LitterTheme.warning : LitterTheme.textSecondary)
-                    Text(summaryText)
+                    Text(verbatim: summaryText)
                         .litterFont(.caption)
                         .foregroundColor(LitterTheme.textSystem)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
                         .frame(maxWidth: .infinity, alignment: .leading)
                     Image(systemName: expanded ? "chevron.up" : "chevron.down")
                         .litterFont(size: 11, weight: .medium)
@@ -551,9 +553,11 @@ private struct ConversationExplorationGroupRow: View {
                             .fill(entry.isInProgress ? LitterTheme.warning : LitterTheme.textMuted)
                             .frame(width: explorationBulletSize, height: explorationBulletSize)
                             .padding(.top, explorationBulletTopPadding)
-                        Text(entry.label)
+                        Text(verbatim: displayedLabel(for: entry))
                             .litterFont(.caption)
                             .foregroundColor(LitterTheme.textSecondary)
+                            .lineLimit(expanded ? nil : 1)
+                            .truncationMode(.tail)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
                 }
@@ -589,6 +593,19 @@ private struct ConversationExplorationGroupRow: View {
         withAnimation(.easeInOut(duration: 0.2)) {
             expanded.toggle()
         }
+    }
+
+    private func displayedLabel(for entry: ExplorationDisplayEntry) -> String {
+        guard !expanded else { return entry.label }
+        let collapsed = entry.label
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if collapsed.count <= 140 {
+            return collapsed
+        }
+        let cutoff = collapsed.index(collapsed.startIndex, offsetBy: 140)
+        return "\(collapsed[..<cutoff])..."
     }
 
     private var explorationEntries: [ExplorationDisplayEntry] {

--- a/apps/ios/Sources/Litter/Views/ConversationView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationView.swift
@@ -995,20 +995,22 @@ private struct ConversationTurnRow: View {
 
     private var previewTextBlock: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(turn.preview.primaryText)
+            Text(verbatim: turn.preview.primaryText)
                 .litterFont(.body, weight: .semibold)
                 .foregroundColor(LitterTheme.textPrimary)
                 .lineLimit(1)
+                .truncationMode(.tail)
                 .minimumScaleFactor(0.82)
                 .allowsTightening(true)
                 .multilineTextAlignment(.leading)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
             ZStack(alignment: .bottomLeading) {
-                Text(responsePreviewText)
+                Text(verbatim: responsePreviewText)
                     .litterFont(.body)
                     .foregroundColor(LitterTheme.textSecondary.opacity(0.82))
                     .lineLimit(2)
+                    .truncationMode(.tail)
                     .multilineTextAlignment(.leading)
                     .frame(
                         maxWidth: .infinity,
@@ -1153,7 +1155,7 @@ private struct CollapsedTurnMetaItem: View {
             Image(systemName: systemImage)
                 .litterFont(size: 9, weight: .medium)
                 .foregroundColor(LitterTheme.textMuted)
-            Text(text)
+            Text(verbatim: text)
                 .litterMonoFont(size: 10)
                 .foregroundColor(LitterTheme.textSecondary)
                 .lineLimit(1)


### PR DESCRIPTION
## What changed

This follow-up trims and truncates the collapsed iOS transcript/exploration preview rows so they stop carrying large multiline text into the collapsed layout.

It also includes the current shared scheme file update from the local tree.

## Why

The remaining local iOS diff after the main mobile runtime merge was focused on collapsed transcript presentation. The preview rows now use verbatim text, tighter limits, and explicit truncation so collapsed rows stay compact and cheaper to lay out.

## Impact

- exploration group summaries collapse to shorter single-line text
- collapsed turn preview text truncates explicitly instead of expanding layout pressure
- the scheme file matches the current local Xcode-generated state

## Validation

- `xmllint --noout apps/ios/Litter.xcodeproj/xcshareddata/xcschemes/Litter.xcscheme`
- `git diff --check -- apps/ios/Litter.xcodeproj/xcshareddata/xcschemes/Litter.xcscheme apps/ios/Sources/Litter/Views/ConversationTimelineView.swift apps/ios/Sources/Litter/Views/ConversationView.swift`

## Notes

The local checkout still has patched-submodule dirt under `shared/third_party/codex`, but that is not part of this parent repo PR.