### PR TITLE
[codex] fix release workflow runner temp env

### DIFF
--- a/.github/workflows/android-play-release.yml
+++ b/.github/workflows/android-play-release.yml
@@ -93,7 +93,6 @@ jobs:
       SCCACHE_S3_USE_SSL: "true"
       SCCACHE_S3_KEY_PREFIX: ci/android
       SCCACHE_LOG: info
-      SCCACHE_ERROR_LOG: ${{ runner.temp }}/sccache-android.log
       AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
 
@@ -154,6 +153,7 @@ jobs:
 
       - name: Prime sccache
         run: |
+          export SCCACHE_ERROR_LOG="$RUNNER_TEMP/sccache-android.log"
           rm -f "$SCCACHE_ERROR_LOG"
           sccache --stop-server || true
           sccache --start-server
@@ -225,6 +225,7 @@ jobs:
           LITTER_VERSION_CODE_OVERRIDE: ${{ env.LITTER_VERSION_CODE_OVERRIDE }}
         run: |
           set -euo pipefail
+          export SCCACHE_ERROR_LOG="$RUNNER_TEMP/sccache-android.log"
           trap 'status=$?; echo "==> sccache stats"; sccache --show-stats || true; if [ -f "$SCCACHE_ERROR_LOG" ]; then echo "==> sccache error log"; tail -200 "$SCCACHE_ERROR_LOG" || true; fi; exit $status' EXIT
           make play-release
 

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -30,7 +30,6 @@ jobs:
       SCCACHE_S3_USE_SSL: "true"
       SCCACHE_S3_KEY_PREFIX: ci/ios
       SCCACHE_LOG: info
-      SCCACHE_ERROR_LOG: ${{ runner.temp }}/sccache-ios.log
       AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
 
@@ -87,6 +86,7 @@ jobs:
 
       - name: Prime sccache
         run: |
+          export SCCACHE_ERROR_LOG="$RUNNER_TEMP/sccache-ios.log"
           rm -f "$SCCACHE_ERROR_LOG"
           sccache --stop-server || true
           sccache --start-server
@@ -177,5 +177,6 @@ jobs:
           WAIT_FOR_PROCESSING: ${{ env.WAIT_FOR_PROCESSING }}
         run: |
           set -euo pipefail
+          export SCCACHE_ERROR_LOG="$RUNNER_TEMP/sccache-ios.log"
           trap 'status=$?; echo "==> sccache stats"; sccache --show-stats || true; if [ -f "$SCCACHE_ERROR_LOG" ]; then echo "==> sccache error log"; tail -200 "$SCCACHE_ERROR_LOG" || true; fi; exit $status' EXIT
           make testflight

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -199,7 +199,6 @@ jobs:
       SCCACHE_S3_USE_SSL: "true"
       SCCACHE_S3_KEY_PREFIX: ci/android
       SCCACHE_LOG: info
-      SCCACHE_ERROR_LOG: ${{ runner.temp }}/sccache-android.log
       AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
 
@@ -260,6 +259,7 @@ jobs:
 
       - name: Prime sccache
         run: |
+          export SCCACHE_ERROR_LOG="$RUNNER_TEMP/sccache-android.log"
           rm -f "$SCCACHE_ERROR_LOG"
           sccache --stop-server || true
           sccache --start-server
@@ -331,6 +331,7 @@ jobs:
           LITTER_VERSION_CODE_OVERRIDE: ${{ env.LITTER_VERSION_CODE_OVERRIDE }}
         run: |
           set -euo pipefail
+          export SCCACHE_ERROR_LOG="$RUNNER_TEMP/sccache-android.log"
           trap 'status=$?; echo "==> sccache stats"; sccache --show-stats || true; if [ -f "$SCCACHE_ERROR_LOG" ]; then echo "==> sccache error log"; tail -200 "$SCCACHE_ERROR_LOG" || true; fi; exit $status' EXIT
           make play-release
 
@@ -367,7 +368,6 @@ jobs:
       SCCACHE_S3_USE_SSL: "true"
       SCCACHE_S3_KEY_PREFIX: ci/ios
       SCCACHE_LOG: info
-      SCCACHE_ERROR_LOG: ${{ runner.temp }}/sccache-ios.log
       AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
 
@@ -424,6 +424,7 @@ jobs:
 
       - name: Prime sccache
         run: |
+          export SCCACHE_ERROR_LOG="$RUNNER_TEMP/sccache-ios.log"
           rm -f "$SCCACHE_ERROR_LOG"
           sccache --stop-server || true
           sccache --start-server
@@ -521,5 +522,6 @@ jobs:
           WAIT_FOR_PROCESSING: ${{ env.WAIT_FOR_PROCESSING }}
         run: |
           set -euo pipefail
+          export SCCACHE_ERROR_LOG="$RUNNER_TEMP/sccache-ios.log"
           trap 'status=$?; echo "==> sccache stats"; sccache --show-stats || true; if [ -f "$SCCACHE_ERROR_LOG" ]; then echo "==> sccache error log"; tail -200 "$SCCACHE_ERROR_LOG" || true; fi; exit $status' EXIT
           make testflight


### PR DESCRIPTION
## What changed

This PR moves the `SCCACHE_ERROR_LOG` path setup out of job-level `${{ runner.temp }}` expressions and back into runtime shell setup inside the steps that use it.

## Why

The previous workflow edit introduced job-level `runner.temp` references in the release workflows. GitHub rejected those workflows before scheduling any jobs, so the `main` release runs failed immediately with zero jobs.

## Impact

- `mobile-release.yml` can schedule again on `main` pushes
- `android-play-release.yml` and `ios-testflight.yml` no longer fail pre-scheduler for the same reason
- the sccache error log path is still available inside the steps that emit stats and tail logs

## Validation

- `ruby -e 'require "yaml"; %w[.github/workflows/android-play-release.yml .github/workflows/ios-testflight.yml .github/workflows/mobile-release.yml].each { |f| YAML.load_file(f) }'`
- `git diff --check HEAD~1..HEAD`

## Notes

This is the same isolated workflow fix commit that was pushed after PR #59 had already merged, so it needs its own follow-up merge to reach `main`.