### PR TITLE
[codex] fix mobile release cache reuse

### DIFF
--- a/.github/workflows/android-play-release.yml
+++ b/.github/workflows/android-play-release.yml
@@ -16,7 +16,7 @@ jobs:
       SCCACHE_ENDPOINT: ${{ secrets.SCCACHE_R2_ENDPOINT }}
       SCCACHE_REGION: auto
       SCCACHE_S3_USE_SSL: "true"
-      SCCACHE_S3_KEY_PREFIX: ci/android-release-prep
+      SCCACHE_S3_KEY_PREFIX: ci/android-release
       SCCACHE_LOG: info
       AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
@@ -91,7 +91,7 @@ jobs:
       SCCACHE_ENDPOINT: ${{ secrets.SCCACHE_R2_ENDPOINT }}
       SCCACHE_REGION: auto
       SCCACHE_S3_USE_SSL: "true"
-      SCCACHE_S3_KEY_PREFIX: ci/android
+      SCCACHE_S3_KEY_PREFIX: ci/android-release
       SCCACHE_LOG: info
       AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
@@ -146,7 +146,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android
+          targets: aarch64-linux-android,x86_64-linux-android
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -208,26 +208,61 @@ jobs:
           VERSION_CODE="$((200000000 + GITHUB_RUN_NUMBER))"
           echo "LITTER_VERSION_CODE_OVERRIDE=$VERSION_CODE" >> "$GITHUB_ENV"
 
-      - name: Publish to Google Play
+      - name: Build Android release APK
         env:
           JAVA_HOME: ${{ env.JAVA_HOME }}
           ANDROID_SDK_ROOT: ${{ env.ANDROID_HOME }}
           ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/30.0.14904198
           CARGO_BUILD_JOBS: "2"
           GRADLE_MAX_WORKERS: "2"
+          ANDROID_RELEASE_ABIS: arm64-v8a
           RUSTC_WRAPPER: sccache
+          LITTER_VERSION_CODE_OVERRIDE: ${{ env.LITTER_VERSION_CODE_OVERRIDE }}
+        run: |
+          set -euo pipefail
+          export SCCACHE_ERROR_LOG="$RUNNER_TEMP/sccache-android.log"
+          trap 'status=$?; echo "==> sccache stats"; sccache --show-stats || true; if [ -f "$SCCACHE_ERROR_LOG" ]; then echo "==> sccache error log"; tail -200 "$SCCACHE_ERROR_LOG" || true; fi; exit $status' EXIT
+          sccache --zero-stats || true
+          make android-release
+          echo "==> sccache stats after Android release APK build"
+          sccache --show-stats || true
+
+      - name: Build Android release bundle
+        env:
+          JAVA_HOME: ${{ env.JAVA_HOME }}
+          ANDROID_SDK_ROOT: ${{ env.ANDROID_HOME }}
+          ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/30.0.14904198
+          CARGO_BUILD_JOBS: "2"
+          GRADLE_MAX_WORKERS: "2"
+          ANDROID_RELEASE_ABIS: arm64-v8a
+          RUSTC_WRAPPER: sccache
+          LITTER_VERSION_CODE_OVERRIDE: ${{ env.LITTER_VERSION_CODE_OVERRIDE }}
+          UPLOAD: "0"
+        run: |
+          set -euo pipefail
+          export SCCACHE_ERROR_LOG="$RUNNER_TEMP/sccache-android.log"
+          trap 'status=$?; echo "==> sccache stats"; sccache --show-stats || true; if [ -f "$SCCACHE_ERROR_LOG" ]; then echo "==> sccache error log"; tail -200 "$SCCACHE_ERROR_LOG" || true; fi; exit $status' EXIT
+          sccache --zero-stats || true
+          ./apps/android/scripts/play-upload.sh
+          echo "==> sccache stats after Android release bundle build"
+          sccache --show-stats || true
+
+      - name: Publish Android bundle to Google Play
+        env:
+          JAVA_HOME: ${{ env.JAVA_HOME }}
+          ANDROID_SDK_ROOT: ${{ env.ANDROID_HOME }}
+          ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/30.0.14904198
+          GRADLE_MAX_WORKERS: "2"
           LITTER_UPLOAD_STORE_FILE: ${{ env.LITTER_UPLOAD_STORE_FILE }}
           LITTER_UPLOAD_STORE_PASSWORD: ${{ secrets.LITTER_UPLOAD_STORE_PASSWORD }}
           LITTER_UPLOAD_KEY_ALIAS: ${{ secrets.LITTER_UPLOAD_KEY_ALIAS }}
           LITTER_UPLOAD_KEY_PASSWORD: ${{ secrets.LITTER_UPLOAD_KEY_PASSWORD }}
           LITTER_PLAY_SERVICE_ACCOUNT_JSON: ${{ env.LITTER_PLAY_SERVICE_ACCOUNT_JSON }}
           LITTER_PLAY_TRACK: internal
-          LITTER_VERSION_CODE_OVERRIDE: ${{ env.LITTER_VERSION_CODE_OVERRIDE }}
+          GRADLE_EXCLUDED_TASKS: ":app:bundleRelease"
         run: |
           set -euo pipefail
-          export SCCACHE_ERROR_LOG="$RUNNER_TEMP/sccache-android.log"
-          trap 'status=$?; echo "==> sccache stats"; sccache --show-stats || true; if [ -f "$SCCACHE_ERROR_LOG" ]; then echo "==> sccache error log"; tail -200 "$SCCACHE_ERROR_LOG" || true; fi; exit $status' EXIT
-          make play-release
+          ./apps/android/scripts/play-upload.sh
 
       - name: Generate checksums
         run: |

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   upload-testflight:
     runs-on: macos-15
-    timeout-minutes: 90
+    timeout-minutes: 150
     environment: release
     env:
       HOMEBREW_NO_AUTO_UPDATE: "1"
@@ -28,7 +28,7 @@ jobs:
       SCCACHE_ENDPOINT: ${{ secrets.SCCACHE_R2_ENDPOINT }}
       SCCACHE_REGION: auto
       SCCACHE_S3_USE_SSL: "true"
-      SCCACHE_S3_KEY_PREFIX: ci/ios
+      SCCACHE_S3_KEY_PREFIX: ci/ios-release
       SCCACHE_LOG: info
       AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
@@ -179,4 +179,5 @@ jobs:
           set -euo pipefail
           export SCCACHE_ERROR_LOG="$RUNNER_TEMP/sccache-ios.log"
           trap 'status=$?; echo "==> sccache stats"; sccache --show-stats || true; if [ -f "$SCCACHE_ERROR_LOG" ]; then echo "==> sccache error log"; tail -200 "$SCCACHE_ERROR_LOG" || true; fi; exit $status' EXIT
+          sccache --zero-stats || true
           make testflight

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -85,7 +85,7 @@ jobs:
       SCCACHE_ENDPOINT: ${{ secrets.SCCACHE_R2_ENDPOINT }}
       SCCACHE_REGION: auto
       SCCACHE_S3_USE_SSL: "true"
-      SCCACHE_S3_KEY_PREFIX: ci/mobile-release-prep
+      SCCACHE_S3_KEY_PREFIX: ci/mobile-release
       SCCACHE_LOG: info
       AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
@@ -197,7 +197,7 @@ jobs:
       SCCACHE_ENDPOINT: ${{ secrets.SCCACHE_R2_ENDPOINT }}
       SCCACHE_REGION: auto
       SCCACHE_S3_USE_SSL: "true"
-      SCCACHE_S3_KEY_PREFIX: ci/android
+      SCCACHE_S3_KEY_PREFIX: ci/mobile-release
       SCCACHE_LOG: info
       AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
@@ -252,7 +252,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android
+          targets: aarch64-linux-android,x86_64-linux-android
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -314,26 +314,61 @@ jobs:
           VERSION_CODE="$((200000000 + GITHUB_RUN_NUMBER))"
           echo "LITTER_VERSION_CODE_OVERRIDE=$VERSION_CODE" >> "$GITHUB_ENV"
 
-      - name: Publish to Google Play
+      - name: Build Android release APK
         env:
           JAVA_HOME: ${{ env.JAVA_HOME }}
           ANDROID_SDK_ROOT: ${{ env.ANDROID_HOME }}
           ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/30.0.14904198
           CARGO_BUILD_JOBS: "2"
           GRADLE_MAX_WORKERS: "2"
+          ANDROID_RELEASE_ABIS: arm64-v8a
           RUSTC_WRAPPER: sccache
+          LITTER_VERSION_CODE_OVERRIDE: ${{ env.LITTER_VERSION_CODE_OVERRIDE }}
+        run: |
+          set -euo pipefail
+          export SCCACHE_ERROR_LOG="$RUNNER_TEMP/sccache-android.log"
+          trap 'status=$?; echo "==> sccache stats"; sccache --show-stats || true; if [ -f "$SCCACHE_ERROR_LOG" ]; then echo "==> sccache error log"; tail -200 "$SCCACHE_ERROR_LOG" || true; fi; exit $status' EXIT
+          sccache --zero-stats || true
+          make android-release
+          echo "==> sccache stats after Android release APK build"
+          sccache --show-stats || true
+
+      - name: Build Android release bundle
+        env:
+          JAVA_HOME: ${{ env.JAVA_HOME }}
+          ANDROID_SDK_ROOT: ${{ env.ANDROID_HOME }}
+          ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/30.0.14904198
+          CARGO_BUILD_JOBS: "2"
+          GRADLE_MAX_WORKERS: "2"
+          ANDROID_RELEASE_ABIS: arm64-v8a
+          RUSTC_WRAPPER: sccache
+          LITTER_VERSION_CODE_OVERRIDE: ${{ env.LITTER_VERSION_CODE_OVERRIDE }}
+          UPLOAD: "0"
+        run: |
+          set -euo pipefail
+          export SCCACHE_ERROR_LOG="$RUNNER_TEMP/sccache-android.log"
+          trap 'status=$?; echo "==> sccache stats"; sccache --show-stats || true; if [ -f "$SCCACHE_ERROR_LOG" ]; then echo "==> sccache error log"; tail -200 "$SCCACHE_ERROR_LOG" || true; fi; exit $status' EXIT
+          sccache --zero-stats || true
+          ./apps/android/scripts/play-upload.sh
+          echo "==> sccache stats after Android release bundle build"
+          sccache --show-stats || true
+
+      - name: Publish Android bundle to Google Play
+        env:
+          JAVA_HOME: ${{ env.JAVA_HOME }}
+          ANDROID_SDK_ROOT: ${{ env.ANDROID_HOME }}
+          ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/30.0.14904198
+          GRADLE_MAX_WORKERS: "2"
           LITTER_UPLOAD_STORE_FILE: ${{ env.LITTER_UPLOAD_STORE_FILE }}
           LITTER_UPLOAD_STORE_PASSWORD: ${{ secrets.LITTER_UPLOAD_STORE_PASSWORD }}
           LITTER_UPLOAD_KEY_ALIAS: ${{ secrets.LITTER_UPLOAD_KEY_ALIAS }}
           LITTER_UPLOAD_KEY_PASSWORD: ${{ secrets.LITTER_UPLOAD_KEY_PASSWORD }}
           LITTER_PLAY_SERVICE_ACCOUNT_JSON: ${{ env.LITTER_PLAY_SERVICE_ACCOUNT_JSON }}
           LITTER_PLAY_TRACK: internal
-          LITTER_VERSION_CODE_OVERRIDE: ${{ env.LITTER_VERSION_CODE_OVERRIDE }}
+          GRADLE_EXCLUDED_TASKS: ":app:bundleRelease"
         run: |
           set -euo pipefail
-          export SCCACHE_ERROR_LOG="$RUNNER_TEMP/sccache-android.log"
-          trap 'status=$?; echo "==> sccache stats"; sccache --show-stats || true; if [ -f "$SCCACHE_ERROR_LOG" ]; then echo "==> sccache error log"; tail -200 "$SCCACHE_ERROR_LOG" || true; fi; exit $status' EXIT
-          make play-release
+          ./apps/android/scripts/play-upload.sh
 
       - name: Generate checksums
         run: |
@@ -358,7 +393,7 @@ jobs:
     needs: [detect-release-changes, shared-prep]
     if: needs.detect-release-changes.outputs.release_ios == 'true'
     runs-on: macos-15
-    timeout-minutes: 90
+    timeout-minutes: 150
     environment: release
     env:
       HOMEBREW_NO_AUTO_UPDATE: "1"
@@ -366,7 +401,7 @@ jobs:
       SCCACHE_ENDPOINT: ${{ secrets.SCCACHE_R2_ENDPOINT }}
       SCCACHE_REGION: auto
       SCCACHE_S3_USE_SSL: "true"
-      SCCACHE_S3_KEY_PREFIX: ci/ios
+      SCCACHE_S3_KEY_PREFIX: ci/mobile-release
       SCCACHE_LOG: info
       AWS_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
@@ -524,4 +559,5 @@ jobs:
           set -euo pipefail
           export SCCACHE_ERROR_LOG="$RUNNER_TEMP/sccache-ios.log"
           trap 'status=$?; echo "==> sccache stats"; sccache --show-stats || true; if [ -f "$SCCACHE_ERROR_LOG" ]; then echo "==> sccache error log"; tail -200 "$SCCACHE_ERROR_LOG" || true; fi; exit $status' EXIT
+          sccache --zero-stats || true
           make testflight

--- a/Makefile
+++ b/Makefile
@@ -368,7 +368,9 @@ test-android:
 	@echo "==> Running Android tests..."
 	@cd $(ANDROID_DIR) && ./gradlew :app:testDebugUnitTest
 
-testflight: ios
+ios-release-prep: rust-ios-package ios-frameworks xcgen
+
+testflight: ios-release-prep
 	@echo "==> Uploading to TestFlight..."
 	@MARKETING_VERSION=1.0.1 $(IOS_SCRIPTS)/testflight-upload.sh
 

--- a/apps/android/scripts/play-upload.sh
+++ b/apps/android/scripts/play-upload.sh
@@ -10,10 +10,20 @@ VARIANT="${VARIANT:-Release}"
 UPLOAD="${UPLOAD:-1}"
 TRACK="${LITTER_PLAY_TRACK:-internal}"
 GRADLE_MAX_WORKERS="${GRADLE_MAX_WORKERS:-}"
+EXTRA_GRADLE_TASKS="${EXTRA_GRADLE_TASKS:-}"
+GRADLE_EXCLUDED_TASKS="${GRADLE_EXCLUDED_TASKS:-}"
 
 declare -a GRADLE_ARGS=(--no-daemon)
 if [[ -n "$GRADLE_MAX_WORKERS" ]]; then
     GRADLE_ARGS+=("--max-workers=$GRADLE_MAX_WORKERS")
+fi
+if [[ -n "$GRADLE_EXCLUDED_TASKS" ]]; then
+    EXCLUDED_TASKS_NORMALIZED="${GRADLE_EXCLUDED_TASKS//,/ }"
+    read -r -a EXCLUDED_TASKS <<<"$EXCLUDED_TASKS_NORMALIZED"
+    for task in "${EXCLUDED_TASKS[@]}"; do
+        [[ -n "$task" ]] || continue
+        GRADLE_ARGS+=("-x" "$task")
+    done
 fi
 
 # Source credentials from env file if present and vars are not already set
@@ -50,7 +60,14 @@ if [[ "$UPLOAD" == "1" ]]; then
 
     TASK=":app:publish${VARIANT}Bundle"
     echo "==> Publishing $VARIANT bundle to Google Play track '$TRACK'"
-    "$GRADLEW" -p "$ANDROID_DIR" "${GRADLE_ARGS[@]}" "$TASK" \
+    GRADLE_TASKS=()
+    if [[ -n "$EXTRA_GRADLE_TASKS" ]]; then
+        EXTRA_TASKS_NORMALIZED="${EXTRA_GRADLE_TASKS//,/ }"
+        read -r -a EXTRA_TASKS <<<"$EXTRA_TASKS_NORMALIZED"
+        GRADLE_TASKS+=("${EXTRA_TASKS[@]}")
+    fi
+    GRADLE_TASKS+=("$TASK")
+    "$GRADLEW" -p "$ANDROID_DIR" "${GRADLE_ARGS[@]}" "${GRADLE_TASKS[@]}" \
         -PLITTER_PLAY_SERVICE_ACCOUNT_JSON="$LITTER_PLAY_SERVICE_ACCOUNT_JSON" \
         -PLITTER_PLAY_TRACK="$TRACK" \
         -PLITTER_UPLOAD_STORE_FILE="$LITTER_UPLOAD_STORE_FILE" \
@@ -60,7 +77,14 @@ if [[ "$UPLOAD" == "1" ]]; then
 else
     TASK=":app:bundle${VARIANT}"
     echo "==> Building local AAB for $VARIANT (no upload)"
-    "$GRADLEW" -p "$ANDROID_DIR" "${GRADLE_ARGS[@]}" "$TASK"
+    GRADLE_TASKS=()
+    if [[ -n "$EXTRA_GRADLE_TASKS" ]]; then
+        EXTRA_TASKS_NORMALIZED="${EXTRA_GRADLE_TASKS//,/ }"
+        read -r -a EXTRA_TASKS <<<"$EXTRA_TASKS_NORMALIZED"
+        GRADLE_TASKS+=("${EXTRA_TASKS[@]}")
+    fi
+    GRADLE_TASKS+=("$TASK")
+    "$GRADLEW" -p "$ANDROID_DIR" "${GRADLE_ARGS[@]}" "${GRADLE_TASKS[@]}"
 fi
 
 echo "==> Done"


### PR DESCRIPTION
## Summary
- unify sccache prefixes inside the mobile release lanes so shared prep and release jobs can reuse cache entries
- split Android Play release into APK build, bundle build, and publish steps for better logs and cache stats
- stop TestFlight uploads from doing the redundant simulator prebuild and raise the iOS release timeout

## Verification
- ruby -e 'require "yaml"; %w[.github/workflows/mobile-release.yml .github/workflows/android-play-release.yml .github/workflows/ios-testflight.yml].each { |f| YAML.load_file(f); puts "ok #{f}" }'\n- bash -n apps/android/scripts/play-upload.sh\n- bash -n apps/ios/scripts/testflight-upload.sh\n- git diff --check