### PR TITLE
mobile: initialize rustls provider before bridge startup

### DIFF
--- a/shared/rust-bridge/Cargo.lock
+++ b/shared/rust-bridge/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "8fac2ce611db8b8cee9b2aa886ca03c924e9da5e5295d0dbd0526e5d0b0710f7"
 dependencies = [
  "allocative_derive",
  "bumpalo",
- "ctor",
+ "ctor 0.1.26",
  "hashbrown 0.14.5",
  "num-bigint",
 ]
@@ -2040,6 +2040,7 @@ dependencies = [
  "codex-keyring-store",
  "codex-protocol",
  "codex-terminal-detection",
+ "codex-utils-rustls-provider",
  "once_cell",
  "os_info",
  "rand 0.9.2",
@@ -2078,6 +2079,7 @@ dependencies = [
  "codex-ipc",
  "codex-protocol",
  "codex-utils-absolute-path",
+ "codex-utils-rustls-provider",
  "futures",
  "lru 0.12.5",
  "openssl-sys",

--- a/shared/rust-bridge/Cargo.toml
+++ b/shared/rust-bridge/Cargo.toml
@@ -24,6 +24,7 @@ codex-cloud-requirements = { path = "../third_party/codex/codex-rs/cloud-require
 codex-config = { path = "../third_party/codex/codex-rs/config" }
 codex-utils-absolute-path = { path = "../third_party/codex/codex-rs/utils/absolute-path" }
 codex-git-utils = { path = "../third_party/codex/codex-rs/git-utils" }
+codex-utils-rustls-provider = { path = "../third_party/codex/codex-rs/utils/rustls-provider" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "net", "io-util"] }

--- a/shared/rust-bridge/codex-mobile-client/Cargo.toml
+++ b/shared/rust-bridge/codex-mobile-client/Cargo.toml
@@ -22,6 +22,7 @@ codex-utils-absolute-path = { workspace = true }
 codex-git-utils = { workspace = true }
 codex-feedback = { workspace = true }
 codex-arg0 = { workspace = true }
+codex-utils-rustls-provider = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }

--- a/shared/rust-bridge/codex-mobile-client/src/ffi/shared.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/ffi/shared.rs
@@ -1,4 +1,5 @@
 use crate::MobileClient;
+use codex_utils_rustls_provider::ensure_rustls_crypto_provider;
 use std::sync::Arc;
 use std::sync::OnceLock;
 static SHARED_RUNTIME: OnceLock<Arc<tokio::runtime::Runtime>> = OnceLock::new();
@@ -7,6 +8,7 @@ static PLATFORM_INIT: OnceLock<()> = OnceLock::new();
 
 fn ensure_platform_init() {
     PLATFORM_INIT.get_or_init(|| {
+        ensure_rustls_crypto_provider();
         #[cfg(target_os = "ios")]
         crate::ios_exec::install();
     });

--- a/shared/rust-bridge/codex-mobile-client/src/mobile_client_impl.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/mobile_client_impl.rs
@@ -11,6 +11,7 @@ use tokio::sync::{Mutex, broadcast, mpsc};
 use tracing::{debug, info, trace, warn};
 use url::Url;
 
+use codex_utils_rustls_provider::ensure_rustls_crypto_provider;
 use crate::discovery::{DiscoveredServer, DiscoveryConfig, DiscoveryService, MdnsSeed};
 use crate::session::connection::InProcessConfig;
 use crate::session::connection::{
@@ -173,6 +174,7 @@ impl MobileClient {
     /// Create a new `MobileClient`.
     pub fn new() -> Self {
         crate::logging::install_ipc_wire_trace_logger();
+        ensure_rustls_crypto_provider();
         let event_processor = Arc::new(EventProcessor::new());
         let app_store = Arc::new(AppStoreReducer::new());
         let sessions = Arc::new(RwLock::new(HashMap::new()));


### PR DESCRIPTION
## Summary
- Install the process-wide rustls crypto provider from the shared mobile init path so iOS/Android bridge construction cannot hit the Rustls 0.23 provider panic.
- Keep `MobileClient::new()` as a second line of defense.
- Add the shared workspace dependency needed by the mobile Rust crate.

## Verification
- Rebuilt the iPhone target after the Rust init fix.
- Confirmed the app launches successfully on a real iPhone.

## Scope
- This PR intentionally includes only the mobile Rustls startup fix.
- It does not include unrelated local edits or the separate websocket token/logging follow-up.