### PR TITLE
ui: center Settings title in Android popover

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,4 @@
 	path = shared/third_party/codex
 	url = https://github.com/openai/codex
 	shallow = true
+	ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,4 +2,3 @@
 	path = shared/third_party/codex
 	url = https://github.com/openai/codex
 	shallow = true
-	ignore = dirty

--- a/apps/android/app/src/main/java/com/litter/android/ui/settings/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/settings/SettingsSheet.kt
@@ -171,11 +171,11 @@ private fun SettingsTopLevel(
     ) {
         // Title
         item {
-            Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                Spacer(Modifier.weight(1f))
+            Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
                 Text("Settings", color = LitterTheme.textPrimary, fontSize = 17.sp, fontWeight = FontWeight.SemiBold)
-                Spacer(Modifier.weight(1f))
-                TextButton(onClick = onDismiss) { Text("Done", color = LitterTheme.accent) }
+                TextButton(onClick = onDismiss, modifier = Modifier.align(Alignment.CenterEnd)) {
+                    Text("Done", color = LitterTheme.accent)
+                }
             }
             Spacer(Modifier.height(8.dp))
         }


### PR DESCRIPTION
## Summary
- Replace `Row` + equal `weight(1f)` spacers with a `Box` so the "Settings" title is truly centered against the full width
- "Done" button pinned to end via `Modifier.align(Alignment.CenterEnd)`

## Verification
Build and install: `make android-install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)