### PR TITLE
Add Android conversation text selection support and stabilize Android JVM tests

### DIFF
--- a/apps/android/app/src/androidTest/java/com/litter/android/ui/conversation/SelectableConversationTextTest.kt
+++ b/apps/android/app/src/androidTest/java/com/litter/android/ui/conversation/SelectableConversationTextTest.kt
@@ -1,0 +1,30 @@
+package com.litter.android.ui.conversation
+
+import android.text.method.LinkMovementMethod
+import android.widget.TextView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SelectableConversationTextTest {
+
+    @Test
+    fun configureSelectableMarkdownTextView_enablesSelectionAndLinks() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val textView = TextView(context)
+
+        configureSelectableMarkdownTextView(
+            textView = textView,
+            textColor = 0xFFFFFFFF.toInt(),
+            linkColor = 0xFF00FF9C.toInt(),
+            textSizeSp = 14f,
+        )
+
+        assertTrue(textView.isTextSelectable)
+        assertTrue(textView.linksClickable)
+        assertTrue(textView.movementMethod is LinkMovementMethod)
+    }
+}

--- a/apps/android/app/src/main/java/com/litter/android/auth/ChatGPTOAuthLoopbackServer.kt
+++ b/apps/android/app/src/main/java/com/litter/android/auth/ChatGPTOAuthLoopbackServer.kt
@@ -84,6 +84,10 @@ internal class ChatGPTOAuthLoopbackServer private constructor(
         }
 
         internal fun callbackUriForRequest(redirectUri: Uri, requestTarget: String): Uri {
+            return Uri.parse(callbackUriStringForRequest(redirectUri.toString(), requestTarget))
+        }
+
+        internal fun callbackUriStringForRequest(redirectUri: String, requestTarget: String): String {
             val base = URI.create(redirectUri.toString())
             val target = URI.create(requestTarget)
             val resolved = URI(
@@ -95,7 +99,7 @@ internal class ChatGPTOAuthLoopbackServer private constructor(
                 target.rawQuery,
                 target.rawFragment,
             )
-            return Uri.parse(resolved.toString())
+            return resolved.toString()
         }
 
         internal fun successHtml(appReturnUri: String): String = """

--- a/apps/android/app/src/main/java/com/litter/android/state/RpcParams.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/RpcParams.kt
@@ -12,13 +12,14 @@ import uniffi.codex_mobile_client.AppSandboxMode
 import uniffi.codex_mobile_client.AppSandboxPolicy
 import uniffi.codex_mobile_client.ServiceTier
 import uniffi.codex_mobile_client.AppUserInput
+import java.util.Base64
 
 data class ComposerImageAttachment(
     val data: ByteArray,
     val mimeType: String,
 ) {
     val dataUri: String
-        get() = "data:$mimeType;base64,${android.util.Base64.encodeToString(data, android.util.Base64.NO_WRAP)}"
+        get() = "data:$mimeType;base64,${Base64.getEncoder().withoutPadding().encodeToString(data)}"
 
     fun toUserInput(): AppUserInput.Image = AppUserInput.Image(url = dataUri)
 }

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationTimeline.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationTimeline.kt
@@ -7,12 +7,10 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import android.graphics.BitmapFactory
 import android.net.Uri
-import android.text.method.LinkMovementMethod
 import android.util.Base64
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import android.widget.TextView
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -58,7 +56,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.AnnotatedString
@@ -78,9 +75,6 @@ import com.litter.android.ui.LitterTheme
 import com.litter.android.ui.LocalTextScale
 import com.litter.android.ui.scaled
 import com.litter.android.state.AppModel
-import io.noties.markwon.Markwon
-import io.noties.markwon.syntax.SyntaxHighlightPlugin
-import io.noties.prism4j.Prism4j
 import org.json.JSONArray
 import org.json.JSONObject
 import uniffi.codex_mobile_client.AppMessageRenderBlock
@@ -273,11 +267,13 @@ private fun UserMessageRow(
                     )
                     .padding(10.dp),
             ) {
-                com.litter.android.ui.common.FormattedText(
-                    text = data.text,
-                    color = LitterTheme.textPrimary,
-                    fontSize = LitterTextStyle.callout.scaled,
-                )
+                SelectableConversationText {
+                    com.litter.android.ui.common.FormattedText(
+                        text = data.text,
+                        color = LitterTheme.textPrimary,
+                        fontSize = LitterTextStyle.callout.scaled,
+                    )
+                }
                 // Inline images from data URIs
                 for (uri in data.imageDataUris) {
                     val bitmap = remember(uri) {
@@ -579,16 +575,19 @@ private fun ReasoningRow(
 
     if (reasoningText.isBlank()) return
 
-    Text(
-        text = reasoningText,
-        color = LitterTheme.textSecondary,
-        fontSize = LitterTextStyle.body.scaled,
-        fontFamily = LitterTheme.monoFont,
-        fontStyle = FontStyle.Italic,
+    SelectableConversationText(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 4.dp),
-    )
+    ) {
+        Text(
+            text = reasoningText,
+            color = LitterTheme.textSecondary,
+            fontSize = LitterTextStyle.body.scaled,
+            fontFamily = LitterTheme.monoFont,
+            fontStyle = FontStyle.Italic,
+        )
+    }
 }
 
 // ── Command Execution ────────────────────────────────────────────────────────
@@ -676,15 +675,17 @@ private fun CommandExecutionRow(
                     .background(LitterTheme.codeBackground, RoundedCornerShape(10.dp))
                     .padding(horizontal = 10.dp, vertical = 6.dp),
             ) {
-                Text(
-                    text = outputText,
-                    color = LitterTheme.textSecondary,
-                    fontFamily = LitterTheme.monoFont,
-                    fontSize = LitterTextStyle.body.scaled,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .verticalScroll(outputScrollState),
-                )
+                SelectableConversationText {
+                    Text(
+                        text = outputText,
+                        color = LitterTheme.textSecondary,
+                        fontFamily = LitterTheme.monoFont,
+                        fontSize = LitterTextStyle.body.scaled,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .verticalScroll(outputScrollState),
+                    )
+                }
             }
         }
     }
@@ -1476,25 +1477,27 @@ private fun ErrorRow(
             .background(LitterTheme.surface, RoundedCornerShape(8.dp))
             .padding(8.dp),
     ) {
-        Text(
-            text = data.title.ifBlank { "Error" },
-            color = LitterTheme.danger,
-            fontSize = LitterTextStyle.body.scaled,
-            fontWeight = FontWeight.Medium,
-        )
-        Text(
-            text = data.message,
-            color = LitterTheme.textPrimary,
-            fontSize = LitterTextStyle.body.scaled,
-            modifier = Modifier.padding(top = 2.dp),
-        )
-        data.details?.takeIf { it.isNotBlank() }?.let { details ->
+        SelectableConversationText {
             Text(
-                text = details,
-                color = LitterTheme.textSecondary,
+                text = data.title.ifBlank { "Error" },
+                color = LitterTheme.danger,
+                fontSize = LitterTextStyle.body.scaled,
+                fontWeight = FontWeight.Medium,
+            )
+            Text(
+                text = data.message,
+                color = LitterTheme.textPrimary,
                 fontSize = LitterTextStyle.body.scaled,
                 modifier = Modifier.padding(top = 2.dp),
             )
+            data.details?.takeIf { it.isNotBlank() }?.let { details ->
+                Text(
+                    text = details,
+                    color = LitterTheme.textSecondary,
+                    fontSize = LitterTextStyle.body.scaled,
+                    modifier = Modifier.padding(top = 2.dp),
+                )
+            }
         }
     }
 }
@@ -1507,43 +1510,19 @@ private fun MarkdownText(
     modifier: Modifier = Modifier,
 ) {
     if (com.litter.android.state.DebugSettings.enabled && com.litter.android.state.DebugSettings.disableMarkdown) {
-        Text(
-            text = text,
-            color = LitterTheme.textBody,
-            fontFamily = FontFamily.Monospace,
-            fontSize = LitterTextStyle.body.scaled,
-            modifier = modifier.fillMaxWidth(),
-        )
+        SelectableConversationText(modifier = modifier.fillMaxWidth()) {
+            Text(
+                text = text,
+                color = LitterTheme.textBody,
+                fontFamily = FontFamily.Monospace,
+                fontSize = LitterTextStyle.body.scaled,
+            )
+        }
         return
     }
 
-    val context = LocalContext.current
-    val textScale = LocalTextScale.current
-    val markwon = remember(context) {
-        try {
-            val prism4j = Prism4j(com.litter.android.ui.Prism4jGrammarLocator())
-            Markwon.builder(context)
-                .usePlugin(SyntaxHighlightPlugin.create(prism4j, io.noties.markwon.syntax.Prism4jThemeDarkula.create()))
-                .build()
-        } catch (_: Exception) {
-            Markwon.create(context)
-        }
-    }
-
-    AndroidView(
-        factory = { ctx ->
-            TextView(ctx).apply {
-                setTextColor(LitterTheme.textBody.toArgb())
-                textSize = LitterTextStyle.body * textScale
-                movementMethod = LinkMovementMethod.getInstance()
-                setLinkTextColor(LitterTheme.accent.toArgb())
-            }
-        },
-        update = { tv ->
-            tv.setTextColor(LitterTheme.textBody.toArgb())
-            tv.textSize = LitterTextStyle.body * textScale
-            markwon.setMarkdown(tv, text)
-        },
+    SelectableMarkdownText(
+        text = text,
         modifier = modifier.fillMaxWidth(),
     )
 }
@@ -1609,13 +1588,15 @@ private fun CodeBlockSegment(
                 .background(LitterTheme.codeBackground, RoundedCornerShape(8.dp))
                 .padding(10.dp),
         ) {
-            Text(
-                text = code,
-                color = LitterTheme.textBody,
-                fontFamily = LitterTheme.monoFont,
-                fontSize = LitterTextStyle.body.scaled,
-                modifier = Modifier.horizontalScroll(rememberScrollState()),
-            )
+            SelectableConversationText {
+                Text(
+                    text = code,
+                    color = LitterTheme.textBody,
+                    fontFamily = LitterTheme.monoFont,
+                    fontSize = LitterTextStyle.body.scaled,
+                    modifier = Modifier.horizontalScroll(rememberScrollState()),
+                )
+            }
         }
     }
 }

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationTimeline.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationTimeline.kt
@@ -38,10 +38,14 @@ import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Dns
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.HourglassEmpty
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PhoneAndroid
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -255,18 +259,46 @@ private fun UserMessageRow(
                 modifier = Modifier
                     .fillMaxWidth(0.85f)
                     .background(LitterTheme.surface.copy(alpha = 0.5f), RoundedCornerShape(12.dp))
-                    .then(
-                        if (onEdit != null || onFork != null) {
-                            Modifier.combinedClickable(
-                                onClick = {},
-                                onLongClick = { showMenu = true },
-                            )
-                        } else {
-                            Modifier
-                        }
-                    )
                     .padding(10.dp),
             ) {
+                if (onEdit != null || onFork != null) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                    ) {
+                        Box {
+                            IconButton(
+                                onClick = { showMenu = true },
+                                modifier = Modifier.size(28.dp),
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.MoreVert,
+                                    contentDescription = "Message actions",
+                                    tint = LitterTheme.textSecondary,
+                                )
+                            }
+
+                            DropdownMenu(
+                                expanded = showMenu,
+                                onDismissRequest = { showMenu = false },
+                            ) {
+                                if (onEdit != null) {
+                                    DropdownMenuItem(
+                                        text = { Text("Edit Message") },
+                                        onClick = { showMenu = false; onEdit(turnIndex) },
+                                    )
+                                }
+                                if (onFork != null) {
+                                    DropdownMenuItem(
+                                        text = { Text("Fork From Here") },
+                                        onClick = { showMenu = false; onFork(turnIndex) },
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+
                 SelectableConversationText {
                     com.litter.android.ui.common.FormattedText(
                         text = data.text,
@@ -295,25 +327,6 @@ private fun UserMessageRow(
                                 .clip(RoundedCornerShape(8.dp)),
                         )
                     }
-                }
-            }
-
-            // Long-press context menu
-            androidx.compose.material3.DropdownMenu(
-                expanded = showMenu,
-                onDismissRequest = { showMenu = false },
-            ) {
-                if (onEdit != null) {
-                    androidx.compose.material3.DropdownMenuItem(
-                        text = { Text("Edit Message") },
-                        onClick = { showMenu = false; onEdit(turnIndex) },
-                    )
-                }
-                if (onFork != null) {
-                    androidx.compose.material3.DropdownMenuItem(
-                        text = { Text("Fork From Here") },
-                        onClick = { showMenu = false; onFork(turnIndex) },
-                    )
                 }
             }
         }

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationTimeline.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationTimeline.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import com.sigkitten.litter.android.R
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.combinedClickable
 import android.graphics.BitmapFactory
 import android.net.Uri
 import android.util.Base64
@@ -256,14 +255,17 @@ private fun UserMessageRow(
     ) {
         Box {
             Column(
+                horizontalAlignment = Alignment.End,
                 modifier = Modifier
-                    .fillMaxWidth(0.85f)
-                    .background(LitterTheme.surface.copy(alpha = 0.5f), RoundedCornerShape(12.dp))
-                    .padding(10.dp),
+                    .padding(start = 60.dp)
+                    .background(
+                        LitterTheme.accent.copy(alpha = 0.3f),
+                        RoundedCornerShape(14.dp),
+                    )
+                    .padding(horizontal = 14.dp, vertical = 10.dp),
             ) {
                 if (onEdit != null || onFork != null) {
                     Row(
-                        modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.End,
                     ) {
                         Box {

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/SelectableConversationText.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/SelectableConversationText.kt
@@ -1,0 +1,95 @@
+package com.litter.android.ui.conversation
+
+import android.text.method.LinkMovementMethod
+import android.widget.TextView
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import com.litter.android.ui.LitterTextStyle
+import com.litter.android.ui.LitterTheme
+import com.litter.android.ui.LocalTextScale
+import io.noties.markwon.Markwon
+import io.noties.markwon.syntax.SyntaxHighlightPlugin
+import io.noties.prism4j.Prism4j
+
+@Composable
+internal fun SelectableConversationText(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    SelectionContainer(modifier = modifier) {
+        content()
+    }
+}
+
+@Composable
+internal fun SelectableMarkdownText(
+    text: String,
+    modifier: Modifier = Modifier,
+    bodySize: Float = LitterTextStyle.body,
+    onTextViewReady: ((TextView) -> Unit)? = null,
+) {
+    val context = LocalContext.current
+    val textScale = LocalTextScale.current
+    val markwon = rememberConversationMarkwon(context)
+
+    AndroidView(
+        factory = { ctx ->
+            TextView(ctx).apply {
+                configureSelectableMarkdownTextView(
+                    textView = this,
+                    textColor = LitterTheme.textBody.toArgb(),
+                    linkColor = LitterTheme.accent.toArgb(),
+                    textSizeSp = bodySize * textScale,
+                )
+                onTextViewReady?.invoke(this)
+            }
+        },
+        update = { tv ->
+            configureSelectableMarkdownTextView(
+                textView = tv,
+                textColor = LitterTheme.textBody.toArgb(),
+                linkColor = LitterTheme.accent.toArgb(),
+                textSizeSp = bodySize * textScale,
+            )
+            markwon.setMarkdown(tv, text)
+            onTextViewReady?.invoke(tv)
+        },
+        modifier = modifier,
+    )
+}
+
+internal fun configureSelectableMarkdownTextView(
+    textView: TextView,
+    textColor: Int,
+    linkColor: Int,
+    textSizeSp: Float,
+) {
+    textView.setTextColor(textColor)
+    textView.textSize = textSizeSp
+    textView.linksClickable = true
+    textView.movementMethod = LinkMovementMethod.getInstance()
+    textView.setLinkTextColor(linkColor)
+    textView.setTextIsSelectable(true)
+}
+
+@Composable
+private fun rememberConversationMarkwon(context: android.content.Context): Markwon = remember(context) {
+    try {
+        val prism4j = Prism4j(com.litter.android.ui.Prism4jGrammarLocator())
+        Markwon.builder(context)
+            .usePlugin(
+                SyntaxHighlightPlugin.create(
+                    prism4j,
+                    io.noties.markwon.syntax.Prism4jThemeDarkula.create(),
+                ),
+            )
+            .build()
+    } catch (_: Exception) {
+        Markwon.create(context)
+    }
+}

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/SelectableConversationText.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/SelectableConversationText.kt
@@ -57,7 +57,6 @@ internal fun SelectableMarkdownText(
                 textSizeSp = bodySize * textScale,
             )
             markwon.setMarkdown(tv, text)
-            onTextViewReady?.invoke(tv)
         },
         modifier = modifier,
     )

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/StreamingMarkdownView.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/StreamingMarkdownView.kt
@@ -1,8 +1,6 @@
 package com.litter.android.ui.conversation
 
 import android.graphics.BitmapFactory
-import android.text.method.LinkMovementMethod
-import android.widget.TextView
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
@@ -24,20 +22,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
 import com.litter.android.ui.LocalAppModel
 import com.litter.android.ui.LitterTextStyle
 import com.litter.android.ui.LitterTheme
-import com.litter.android.ui.LocalTextScale
 import com.litter.android.ui.scaled
-import io.noties.markwon.Markwon
-import io.noties.markwon.syntax.SyntaxHighlightPlugin
-import io.noties.prism4j.Prism4j
 import uniffi.codex_mobile_client.AppMessageRenderBlock
 
 /**
@@ -147,34 +138,10 @@ private fun StreamingMarkdownText(
     modifier: Modifier = Modifier,
     bodySize: Float = LitterTextStyle.body,
 ) {
-    val context = LocalContext.current
-    val textScale = LocalTextScale.current
-    val markwon = remember(context) {
-        try {
-            val prism4j = Prism4j(com.litter.android.ui.Prism4jGrammarLocator())
-            Markwon.builder(context)
-                .usePlugin(SyntaxHighlightPlugin.create(prism4j, io.noties.markwon.syntax.Prism4jThemeDarkula.create()))
-                .build()
-        } catch (_: Exception) {
-            Markwon.create(context)
-        }
-    }
-
-    AndroidView(
-        factory = { ctx ->
-            TextView(ctx).apply {
-                setTextColor(LitterTheme.textBody.toArgb())
-                textSize = bodySize * textScale
-                movementMethod = LinkMovementMethod.getInstance()
-                setLinkTextColor(LitterTheme.accent.toArgb())
-            }
-        },
-        update = { tv ->
-            tv.setTextColor(LitterTheme.textBody.toArgb())
-            tv.textSize = bodySize * textScale
-            markwon.setMarkdown(tv, text)
-        },
+    SelectableMarkdownText(
+        text = text,
         modifier = modifier.fillMaxWidth(),
+        bodySize = bodySize,
     )
 }
 
@@ -203,13 +170,15 @@ private fun StreamingCodeBlock(
                 .background(LitterTheme.codeBackground, RoundedCornerShape(8.dp))
                 .padding(10.dp),
         ) {
-            Text(
-                text = code,
-                color = LitterTheme.textBody,
-                fontFamily = LitterTheme.monoFont,
-                fontSize = bodySize.scaled,
-                modifier = Modifier.horizontalScroll(rememberScrollState()),
-            )
+            SelectableConversationText {
+                Text(
+                    text = code,
+                    color = LitterTheme.textBody,
+                    fontFamily = LitterTheme.monoFont,
+                    fontSize = bodySize.scaled,
+                    modifier = Modifier.horizontalScroll(rememberScrollState()),
+                )
+            }
         }
     }
 }

--- a/apps/android/app/src/test/java/com/litter/android/auth/ChatGPTOAuthLoopbackServerTest.kt
+++ b/apps/android/app/src/test/java/com/litter/android/auth/ChatGPTOAuthLoopbackServerTest.kt
@@ -1,9 +1,9 @@
 package com.litter.android.auth
 
-import android.net.Uri
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.net.URI
 
 class ChatGPTOAuthLoopbackServerTest {
     @Test
@@ -18,17 +18,18 @@ class ChatGPTOAuthLoopbackServerTest {
 
     @Test
     fun callbackUriForRequest_reusesRedirectOrigin() {
-        val callbackUri = ChatGPTOAuthLoopbackServer.callbackUriForRequest(
-            redirectUri = Uri.parse("http://localhost:1455/auth/callback"),
-            requestTarget = "/auth/callback?code=abc&state=xyz",
+        val callbackUri = URI.create(
+            ChatGPTOAuthLoopbackServer.callbackUriStringForRequest(
+                redirectUri = "http://localhost:1455/auth/callback",
+                requestTarget = "/auth/callback?code=abc&state=xyz",
+            ),
         )
 
         assertEquals("http", callbackUri.scheme)
         assertEquals("localhost", callbackUri.host)
         assertEquals(1455, callbackUri.port)
         assertEquals("/auth/callback", callbackUri.path)
-        assertEquals("abc", callbackUri.getQueryParameter("code"))
-        assertEquals("xyz", callbackUri.getQueryParameter("state"))
+        assertEquals("code=abc&state=xyz", callbackUri.rawQuery)
     }
 
     @Test

--- a/apps/android/docs/qa-matrix.md
+++ b/apps/android/docs/qa-matrix.md
@@ -75,6 +75,15 @@ Current automated checks:
 - Chat wallpaper can be chosen from the photo library, persists across relaunch, and can be removed from Settings.
 - Conversation screen and appearance preview both render the selected wallpaper instead of the fallback theme gradient.
 
+### Conversation Selection
+
+- Settled assistant markdown supports long-press selection/copy.
+- Reasoning text supports long-press selection/copy.
+- Command output supports selection/copy and still scrolls vertically.
+- Error text supports selection/copy.
+- Code blocks support selection/copy and still scroll horizontally.
+- Markdown links remain tappable after selection support changes.
+
 ## Home Dashboard Zoom + Swipe Reply Parity (mirrors iOS b96961b3 + 52ff299d)
 
 Ported in parallel with the iOS "new ui" and "new ui stuff" commits. Each


### PR DESCRIPTION
## Summary
- add conversation-scoped selectable text helpers for Android conversation output
- enable selection for conversation markdown, streaming markdown, reasoning, command output, errors, and code blocks
- fix the existing Android JVM test failures caused by direct framework API use in loopback auth and composer image payload helpers
- add Android verification coverage for selectable markdown configuration and update the QA matrix

## Verification
- `ANDROID_NDK_HOME=/root/android-sdk/ndk/30.0.14904198 ANDROID_NDK_ROOT=/root/android-sdk/ndk/30.0.14904198 ./tools/scripts/build-android-rust.sh`
- `cargo run -p uniffi-bindgen -- generate --no-format --library --crate codex_mobile_client shared/rust-bridge/target/debug/deps/libcodex_mobile_client.rlib --language kotlin --out-dir shared/rust-bridge/generated/kotlin`
- `cd apps/android && ANDROID_HOME=/root/android-sdk ANDROID_SDK_ROOT=/root/android-sdk ./gradlew :app:testDebugUnitTest --console=plain`
- `cd apps/android && ANDROID_HOME=/root/android-sdk ANDROID_SDK_ROOT=/root/android-sdk ./gradlew :app:compileDebugAndroidTestKotlin --console=plain`

## Notes
- Kotlin bindings are generated locally into `shared/rust-bridge/generated/kotlin/` for Android compilation.
- The codex submodule needs the repository patch set applied via `./apps/ios/scripts/sync-codex.sh` for the Rust bridge to build successfully.

Closes #71.