### PR TITLE
fix(ios): submit composer on Return with external keyboard

### DIFF
--- a/apps/ios/Sources/Litter/Views/ConversationComposerEntryRowView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationComposerEntryRowView.swift
@@ -78,7 +78,9 @@ struct ConversationComposerEntryRowView: View {
                     ConversationComposerTextView(
                         text: $inputText,
                         isFocused: $isComposerFocused,
-                        onPasteImage: onPasteImage
+                        onPasteImage: onPasteImage,
+                        onSubmit: onSendText,
+                        submitsOnReturn: true
                     )
 
                     if inputText.isEmpty {

--- a/apps/ios/Sources/Litter/Views/ConversationComposerTextView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationComposerTextView.swift
@@ -5,6 +5,8 @@ struct ConversationComposerTextView: UIViewRepresentable {
     @Binding var text: String
     @Binding var isFocused: Bool
     let onPasteImage: (UIImage) -> Void
+    let onSubmit: (() -> Void)? = nil
+    var submitsOnReturn: Bool = false
     /// When true, the view returns no preferred size from `sizeThatFits`, letting
     /// SwiftUI fill the parent frame. Scrolling kicks in against the actual
     /// bounds instead of the 5-line clamp.
@@ -32,6 +34,8 @@ struct ConversationComposerTextView: UIViewRepresentable {
         textView.alwaysBounceVertical = false
         textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         textView.onPasteImage = onPasteImage
+        textView.onSubmit = onSubmit
+        textView.submitsOnReturn = submitsOnReturn
         textView.text = text
         context.coordinator.applyStyling(to: textView)
         context.coordinator.updateScrollState(for: textView)
@@ -41,6 +45,8 @@ struct ConversationComposerTextView: UIViewRepresentable {
     func updateUIView(_ uiView: PasteAwareComposerUITextView, context: Context) {
         context.coordinator.parent = self
         uiView.onPasteImage = onPasteImage
+        uiView.onSubmit = onSubmit
+        uiView.submitsOnReturn = submitsOnReturn
         context.coordinator.applyStyling(to: uiView)
 
         if uiView.text != text, uiView.markedTextRange == nil {
@@ -171,6 +177,8 @@ struct ConversationComposerTextView: UIViewRepresentable {
 
 final class PasteAwareComposerUITextView: UITextView {
     var onPasteImage: ((UIImage) -> Void)?
+    var onSubmit: (() -> Void)?
+    var submitsOnReturn: Bool = false
 
     override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
         if action == #selector(paste(_:)), UIPasteboard.general.hasImages {
@@ -185,5 +193,25 @@ final class PasteAwareComposerUITextView: UITextView {
             return
         }
         super.paste(sender)
+    }
+
+    override func pressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        guard submitsOnReturn,
+              let press = presses.first,
+              let key = press.key,
+              key.keyCode == .keyboardReturnOrEnter,
+              let onSubmit else {
+            super.pressesEnded(presses, with: event)
+            return
+        }
+
+        let effectiveFlags = press.modifierFlags.subtracting(.alphaShift)
+        // Submit on plain Return or Cmd+Return; let Shift+Return insert a newline
+        if effectiveFlags.isEmpty || effectiveFlags == .command {
+            onSubmit()
+            return
+        }
+
+        super.pressesEnded(presses, with: event)
     }
 }


### PR DESCRIPTION
## Problem
On iPad with an external keyboard, pressing **Return** in the inline message composer inserts a newline () instead of submitting the message. Users have to reach for the on-screen send button, which breaks the flow.

## Solution
Intercept hardware key events in \"PasteAwareComposerUITextView\" via \"pressesEnded(_:with:)\".

- **Return** → submits the message
- **Cmd+Return** → also submits (common muscle memory)
- **Shift+Return** → inserts a newline (preserves multi-line input ability)

## Scope
- Only the **inline entry-row composer** opts in (\"ConversationComposerEntryRowView\").
- The expanded composer and all other usages remain untouched.
- Fully backward-compatible: new parameters default to nil/false.

## Notes
- Uses iOS 13.4+ \"UIPress.key\" / \"modifierFlags\" APIs; app targets iOS 18.0.
- Zero Rust/shared-layer changes — pure iOS SwiftUI/UIKit.
