### PR TITLE
android: fix macOS SSH Codex launch diagnostics

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = shared/third_party/codex
 	url = https://github.com/openai/codex
 	shallow = true
+[submodule "shared/third_party/alleycat"]
+	path = shared/third_party/alleycat
+	url = https://github.com/dnakov/alleycat

--- a/apps/android/app/src/main/java/com/litter/android/ui/common/ModelSelectorPanel.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/common/ModelSelectorPanel.kt
@@ -409,10 +409,10 @@ private class ModelSearchIndex(models: List<ModelInfo>) {
 }
 
 internal fun ModelInfo.matchesModelSelection(
-    selection: String,
+    selection: String?,
     runtimeKind: AgentRuntimeKind? = null,
 ): Boolean {
-    val trimmed = selection.trim()
+    val trimmed = selection?.trim().orEmpty()
     if (trimmed.isEmpty()) return false
     if (runtimeKind != null && agentRuntimeKind != runtimeKind) return false
     return id == trimmed || model == trimmed

--- a/apps/android/app/src/main/java/com/litter/android/ui/discovery/DiscoveryScreen.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/discovery/DiscoveryScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -54,6 +55,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -87,6 +89,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import uniffi.codex_mobile_client.AgentAvailabilityStatus
 import uniffi.codex_mobile_client.AgentRuntimeKind
+import uniffi.codex_mobile_client.AppConnectionCommandSnapshot
+import uniffi.codex_mobile_client.AppConnectionProgressSnapshot
+import uniffi.codex_mobile_client.AppConnectionStepKind
+import uniffi.codex_mobile_client.AppConnectionStepState
 import uniffi.codex_mobile_client.AppSshSessionResult
 import uniffi.codex_mobile_client.AppServerHealth
 import uniffi.codex_mobile_client.AppServerSnapshot
@@ -100,6 +106,11 @@ private data class SshBridgeAgentContext(
     val host: String,
     val availability: List<RemoteAgentAvailability>,
     val credential: SavedSshCredential,
+)
+
+private data class ConnectionFailureDetails(
+    val message: String,
+    val progress: AppConnectionProgressSnapshot?,
 )
 
 /**
@@ -130,7 +141,7 @@ fun DiscoveryScreen(
     var connectionChoiceServer by remember { mutableStateOf<SavedServer?>(null) }
     var pendingAutoNavigateServerId by remember { mutableStateOf<String?>(null) }
     var wakingServerId by remember { mutableStateOf<String?>(null) }
-    var connectError by remember { mutableStateOf<String?>(null) }
+    var connectError by remember { mutableStateOf<ConnectionFailureDetails?>(null) }
     var renameTarget by remember { mutableStateOf<SavedServer?>(null) }
 
     var savedServers by remember { mutableStateOf(SavedServerStore.load(context)) }
@@ -154,7 +165,10 @@ fun DiscoveryScreen(
         } else if (serverSnapshot.health == AppServerHealth.DISCONNECTED) {
             serverSnapshot.connectionProgress?.terminalMessage?.let { message ->
                 pendingAutoNavigateServerId = null
-                connectError = message
+                connectError = ConnectionFailureDetails(
+                    message = message,
+                    progress = serverSnapshot.connectionProgress,
+                )
             }
         }
     }
@@ -335,7 +349,10 @@ fun DiscoveryScreen(
                 }
 
                 else -> {
-                    connectError = "Server did not respond after wake attempt. Enable Wake for network access on the Mac."
+                    connectError = ConnectionFailureDetails(
+                        message = "Server did not respond after wake attempt. Enable Wake for network access on the Mac.",
+                        progress = null,
+                    )
                 }
             }
         } catch (e: Exception) {
@@ -349,7 +366,10 @@ fun DiscoveryScreen(
                     "preferredConnectionMode" to entry.preferredConnectionMode,
                 ),
             )
-            connectError = e.message ?: "Unable to connect."
+            connectError = ConnectionFailureDetails(
+                message = e.message ?: "Unable to connect.",
+                progress = null,
+            )
         }
     }
 
@@ -532,7 +552,10 @@ fun DiscoveryScreen(
                                                 "os" to server.os,
                                             ),
                                         )
-                                        connectError = e.message ?: "Unable to connect."
+                                        connectError = ConnectionFailureDetails(
+                                            message = e.message ?: "Unable to connect.",
+                                            progress = null,
+                                        )
                                     }
                                 }
                             },
@@ -808,11 +831,13 @@ fun DiscoveryScreen(
         )
     }
 
-    connectError?.let { message ->
+    connectError?.let { failure ->
         AlertDialog(
             onDismissRequest = { connectError = null },
             title = { Text("Connection Failed") },
-            text = { Text(message) },
+            text = {
+                ConnectionFailureBody(failure)
+            },
             confirmButton = {
                 TextButton(onClick = { connectError = null }) {
                     Text("OK")
@@ -856,6 +881,102 @@ fun DiscoveryScreen(
                     },
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun ConnectionFailureBody(failure: ConnectionFailureDetails) {
+    Column(
+        modifier = Modifier
+            .heightIn(max = 420.dp)
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+        Text(
+            text = failure.message,
+            color = LitterTheme.textPrimary,
+            fontSize = 14.sp,
+            lineHeight = 20.sp,
+        )
+        failure.progress?.let { progress ->
+            if (progress.steps.isNotEmpty()) {
+                Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Text(
+                        text = "Steps",
+                        color = LitterTheme.textSecondary,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    progress.steps.forEach { step ->
+                        val detail = step.detail?.takeIf { it.isNotBlank() }
+                        Text(
+                            text = buildString {
+                                append(connectionStepLabel(step.kind))
+                                append(": ")
+                                append(connectionStateLabel(step.state))
+                                if (detail != null) {
+                                    append(" - ")
+                                    append(detail)
+                                }
+                            },
+                            color = connectionStateColor(step.state),
+                            fontSize = 12.sp,
+                            lineHeight = 17.sp,
+                        )
+                    }
+                }
+            }
+            if (progress.commands.isNotEmpty()) {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        text = "SSH commands",
+                        color = LitterTheme.textSecondary,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    progress.commands.forEach { command ->
+                        ConnectionCommandRow(command)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ConnectionCommandRow(command: AppConnectionCommandSnapshot) {
+    Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+        Text(
+            text = "${command.label}: ${connectionStateLabel(command.state)}",
+            color = connectionStateColor(command.state),
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Bold,
+        )
+        Text(
+            text = command.command,
+            color = LitterTheme.textSecondary,
+            fontSize = 11.sp,
+            lineHeight = 15.sp,
+            fontFamily = FontFamily.Monospace,
+        )
+        command.stdout?.takeIf { it.isNotBlank() }?.let { stdout ->
+            Text(
+                text = "stdout: ${stdout.trim().take(220)}",
+                color = LitterTheme.textSecondary,
+                fontSize = 11.sp,
+                lineHeight = 15.sp,
+                fontFamily = FontFamily.Monospace,
+            )
+        }
+        command.stderr?.takeIf { it.isNotBlank() }?.let { stderr ->
+            Text(
+                text = "stderr: ${stderr.trim().take(220)}",
+                color = Color(0xFFFF6B6B),
+                fontSize = 11.sp,
+                lineHeight = 15.sp,
+                fontFamily = FontFamily.Monospace,
+            )
         }
     }
 }
@@ -1780,6 +1901,35 @@ private fun orderedSshPorts(preferred: Int?): List<Int> = buildList {
     preferred?.let(::add)
     add(22)
 }.filter { it in 1..65535 }.distinct()
+
+private fun connectionStepLabel(kind: AppConnectionStepKind): String =
+    when (kind) {
+        AppConnectionStepKind.CONNECTING_TO_SSH -> "SSH"
+        AppConnectionStepKind.FINDING_CODEX -> "Find Codex"
+        AppConnectionStepKind.INSTALLING_CODEX -> "Install Codex"
+        AppConnectionStepKind.STARTING_APP_SERVER -> "Start server"
+        AppConnectionStepKind.OPENING_TUNNEL -> "Open tunnel"
+        AppConnectionStepKind.CONNECTED -> "Attach"
+    }
+
+private fun connectionStateLabel(state: AppConnectionStepState): String =
+    when (state) {
+        AppConnectionStepState.PENDING -> "pending"
+        AppConnectionStepState.IN_PROGRESS -> "running"
+        AppConnectionStepState.COMPLETED -> "ok"
+        AppConnectionStepState.FAILED -> "failed"
+        AppConnectionStepState.AWAITING_USER_INPUT -> "waiting"
+        AppConnectionStepState.CANCELLED -> "skipped"
+    }
+
+private fun connectionStateColor(state: AppConnectionStepState): Color =
+    when (state) {
+        AppConnectionStepState.COMPLETED -> LitterTheme.accent
+        AppConnectionStepState.FAILED -> Color(0xFFFF6B6B)
+        AppConnectionStepState.AWAITING_USER_INPUT -> Color(0xFFFFB020)
+        AppConnectionStepState.IN_PROGRESS -> LitterTheme.textPrimary
+        AppConnectionStepState.PENDING, AppConnectionStepState.CANCELLED -> LitterTheme.textSecondary
+    }
 
 private fun sendWakeMagicPacket(wakeMac: String, hostHint: String) {
     val mac = SavedServer.normalizeWakeMac(wakeMac) ?: return

--- a/shared/rust-bridge/Cargo.toml
+++ b/shared/rust-bridge/Cargo.toml
@@ -26,10 +26,10 @@ codex-cloud-requirements = { path = "../third_party/codex/codex-rs/cloud-require
 codex-config = { path = "../third_party/codex/codex-rs/config" }
 codex-utils-absolute-path = { path = "../third_party/codex/codex-rs/utils/absolute-path" }
 codex-git-utils = { path = "../third_party/codex/codex-rs/git-utils" }
-alleycat-bridge-core = { path = "../../../alleycat/crates/bridge-core" }
-alleycat-pi-bridge = { path = "../../../alleycat/crates/pi-bridge" }
-alleycat-claude-bridge = { path = "../../../alleycat/crates/claude-bridge" }
-alleycat-opencode-bridge = { path = "../../../alleycat/crates/opencode-bridge" }
+alleycat-bridge-core = { path = "../third_party/alleycat/crates/bridge-core" }
+alleycat-pi-bridge = { path = "../third_party/alleycat/crates/pi-bridge" }
+alleycat-claude-bridge = { path = "../third_party/alleycat/crates/claude-bridge" }
+alleycat-opencode-bridge = { path = "../third_party/alleycat/crates/opencode-bridge" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "net", "io-util"] }

--- a/shared/rust-bridge/codex-mobile-client/src/ffi/ssh.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/ffi/ssh.rs
@@ -481,16 +481,69 @@ pub(crate) async fn run_guided_ssh_connect(
         .app_store
         .update_server_connection_progress(&server_id, Some(progress.clone()));
 
+    let detect_shell_command = progress.push_command(
+        "Detect remote shell".to_string(),
+        "probe PowerShell, then fall back to POSIX shell".to_string(),
+    );
     let remote_shell = ssh_client.detect_remote_shell().await;
+    progress.finish_command(
+        detect_shell_command,
+        AppConnectionStepState::Completed,
+        Some(0),
+        Some(format!("{remote_shell:?}")),
+        None,
+    );
+    mobile_client
+        .app_store
+        .update_server_connection_progress(&server_id, Some(progress.clone()));
     info!(
         "guided ssh connect detected shell server_id={} shell={:?}",
         server_id, remote_shell
     );
-    let codex_binary = match ssh_client
+    let find_codex_command = progress.push_command(
+        "Find Codex".to_string(),
+        "source profile PATH and run command -v codex".to_string(),
+    );
+    mobile_client
+        .app_store
+        .update_server_connection_progress(&server_id, Some(progress.clone()));
+    let resolved_codex = match ssh_client
         .resolve_codex_binary_optional_with_shell(Some(remote_shell))
         .await
-        .map_err(map_ssh_error)?
     {
+        Ok(result) => {
+            progress.finish_command(
+                find_codex_command,
+                AppConnectionStepState::Completed,
+                Some(0),
+                Some(
+                    result
+                        .as_ref()
+                        .map(|binary| binary.path().to_string())
+                        .unwrap_or_else(|| "not found".to_string()),
+                ),
+                None,
+            );
+            mobile_client
+                .app_store
+                .update_server_connection_progress(&server_id, Some(progress.clone()));
+            result
+        }
+        Err(error) => {
+            progress.finish_command(
+                find_codex_command,
+                AppConnectionStepState::Failed,
+                None,
+                None,
+                Some(error.to_string()),
+            );
+            mobile_client
+                .app_store
+                .update_server_connection_progress(&server_id, Some(progress.clone()));
+            return Err(map_ssh_error(error));
+        }
+    };
+    let codex_binary = match resolved_codex {
         Some(binary) => {
             info!(
                 "guided ssh connect found codex server_id={} path={}",
@@ -610,18 +663,85 @@ pub(crate) async fn run_guided_ssh_connect(
                 .app_store
                 .update_server_connection_progress(&server_id, Some(progress.clone()));
 
+            let detect_platform_command = progress.push_command(
+                "Detect platform".to_string(),
+                "run uname/sysctl probe for Codex release asset".to_string(),
+            );
+            mobile_client
+                .app_store
+                .update_server_connection_progress(&server_id, Some(progress.clone()));
             let platform = ssh_client
                 .detect_remote_platform_with_shell(Some(remote_shell))
-                .await
-                .map_err(map_ssh_error)?;
+                .await;
+            let platform = match platform {
+                Ok(platform) => {
+                    progress.finish_command(
+                        detect_platform_command,
+                        AppConnectionStepState::Completed,
+                        Some(0),
+                        Some(format!("{platform:?}")),
+                        None,
+                    );
+                    mobile_client
+                        .app_store
+                        .update_server_connection_progress(&server_id, Some(progress.clone()));
+                    platform
+                }
+                Err(error) => {
+                    progress.finish_command(
+                        detect_platform_command,
+                        AppConnectionStepState::Failed,
+                        None,
+                        None,
+                        Some(error.to_string()),
+                    );
+                    mobile_client
+                        .app_store
+                        .update_server_connection_progress(&server_id, Some(progress.clone()));
+                    return Err(map_ssh_error(error));
+                }
+            };
             info!(
                 "guided ssh connect install platform server_id={} platform={:?}",
                 server_id, platform
             );
-            let (installed_binary, install_outcome) = ssh_client
-                .install_latest_stable_codex(platform)
-                .await
-                .map_err(map_ssh_error)?;
+            let install_command = progress.push_command(
+                "Install Codex".to_string(),
+                "download latest stable Codex into ~/.litter".to_string(),
+            );
+            mobile_client
+                .app_store
+                .update_server_connection_progress(&server_id, Some(progress.clone()));
+            let install_result = ssh_client.install_latest_stable_codex(platform).await;
+            let (installed_binary, install_outcome) = match install_result {
+                Ok(result) => result,
+                Err(error) => {
+                    progress.finish_command(
+                        install_command,
+                        AppConnectionStepState::Failed,
+                        None,
+                        None,
+                        Some(error.to_string()),
+                    );
+                    mobile_client
+                        .app_store
+                        .update_server_connection_progress(&server_id, Some(progress.clone()));
+                    return Err(map_ssh_error(error));
+                }
+            };
+            progress.finish_command(
+                install_command,
+                AppConnectionStepState::Completed,
+                Some(0),
+                Some(format!(
+                    "{} ({install_outcome:?})",
+                    installed_binary.path()
+                )),
+                None,
+            );
+            mobile_client
+                .app_store
+                .update_server_connection_progress(&server_id, Some(progress.clone()));
             info!(
                 "guided ssh connect install completed server_id={} path={} outcome={:?}",
                 server_id,
@@ -654,14 +774,54 @@ pub(crate) async fn run_guided_ssh_connect(
         server_id,
         credentials.host.as_str()
     );
+    let start_command = progress.push_command(
+        "Start Codex app server".to_string(),
+        format!(
+            "launch {} app-server over SSH tunnel",
+            codex_binary.path()
+        ),
+    );
+    mobile_client
+        .app_store
+        .update_server_connection_progress(&server_id, Some(progress.clone()));
     let bootstrap = ssh_client
         .bootstrap_codex_server_with_binary(
             &codex_binary,
             working_dir.as_deref(),
             config.host.contains(':'),
         )
-        .await
-        .map_err(map_ssh_error)?;
+        .await;
+    let bootstrap = match bootstrap {
+        Ok(bootstrap) => {
+            progress.finish_command(
+                start_command,
+                AppConnectionStepState::Completed,
+                Some(0),
+                Some(format!(
+                    "remote port {}, local tunnel 127.0.0.1:{}",
+                    bootstrap.server_port, bootstrap.tunnel_local_port
+                )),
+                None,
+            );
+            mobile_client
+                .app_store
+                .update_server_connection_progress(&server_id, Some(progress.clone()));
+            bootstrap
+        }
+        Err(error) => {
+            progress.finish_command(
+                start_command,
+                AppConnectionStepState::Failed,
+                None,
+                None,
+                Some(error.to_string()),
+            );
+            mobile_client
+                .app_store
+                .update_server_connection_progress(&server_id, Some(progress.clone()));
+            return Err(map_ssh_error(error));
+        }
+    };
     info!(
         "guided ssh connect bootstrap completed server_id={} remote_port={} local_tunnel_port={} pid={:?}",
         server_id, bootstrap.server_port, bootstrap.tunnel_local_port, bootstrap.pid

--- a/shared/rust-bridge/codex-mobile-client/src/logging/mod.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/logging/mod.rs
@@ -91,6 +91,15 @@ pub(crate) fn log_rust(
     let message = message.into();
     let fields_json = fields_json.filter(|value| !value.trim().is_empty());
 
+    #[cfg(target_os = "android")]
+    android_log_rust(
+        level,
+        &subsystem,
+        &category,
+        &message,
+        fields_json.as_deref(),
+    );
+
     match (level.into_tracing(), fields_json.as_deref()) {
         (Level::TRACE, Some(fields_json)) => {
             tracing::event!(
@@ -156,6 +165,52 @@ pub(crate) fn log_rust(
         }
         (Level::ERROR, None) => {
             tracing::event!(target: "mobile", Level::ERROR, subsystem = %subsystem, category = %category, "{message}");
+        }
+    }
+}
+
+#[cfg(target_os = "android")]
+fn android_log_rust(
+    level: LogLevelName,
+    subsystem: &str,
+    category: &str,
+    message: &str,
+    fields_json: Option<&str>,
+) {
+    use std::ffi::CString;
+    use std::os::raw::{c_char, c_int};
+
+    const ANDROID_LOG_DEBUG: c_int = 3;
+    const ANDROID_LOG_INFO: c_int = 4;
+    const ANDROID_LOG_WARN: c_int = 5;
+    const ANDROID_LOG_ERROR: c_int = 6;
+
+    unsafe extern "C" {
+        fn __android_log_write(prio: c_int, tag: *const c_char, text: *const c_char) -> c_int;
+    }
+
+    let priority = match level {
+        LogLevelName::Trace | LogLevelName::Debug => ANDROID_LOG_DEBUG,
+        LogLevelName::Info => ANDROID_LOG_INFO,
+        LogLevelName::Warn => ANDROID_LOG_WARN,
+        LogLevelName::Error => ANDROID_LOG_ERROR,
+    };
+    let tag = CString::new("LitterRust").ok();
+    let line = match fields_json {
+        Some(fields_json) => format!(
+            "{} {}/{} {} fields={}",
+            level.as_str(),
+            subsystem,
+            category,
+            message,
+            fields_json
+        ),
+        None => format!("{} {}/{} {}", level.as_str(), subsystem, category, message),
+    };
+    let text = CString::new(line).ok();
+    if let (Some(tag), Some(text)) = (tag, text) {
+        unsafe {
+            let _ = __android_log_write(priority, tag.as_ptr(), text.as_ptr());
         }
     }
 }

--- a/shared/rust-bridge/codex-mobile-client/src/ssh.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/ssh.rs
@@ -477,9 +477,29 @@ impl SshClient {
 
     /// Run a command on the remote host and collect its stdout/stderr.
     pub async fn exec(&self, command: &str) -> Result<ExecResult, SshError> {
-        tokio::time::timeout(EXEC_TIMEOUT, self.exec_inner(command))
+        append_android_debug_log(&format!(
+            "ssh_exec_start command={}",
+            redact_ssh_command_for_log(command)
+        ));
+        let result = tokio::time::timeout(EXEC_TIMEOUT, self.exec_inner(command))
             .await
-            .map_err(|_| SshError::Timeout)?
+            .map_err(|_| {
+                append_bridge_info_log(&format!(
+                    "ssh_exec_timeout command={}",
+                    redact_ssh_command_for_log(command)
+                ));
+                SshError::Timeout
+            })?;
+        match &result {
+            Ok(output) => append_android_debug_log(&format!(
+                "ssh_exec_done exit={} stdout={} stderr={}",
+                output.exit_code,
+                log_preview(&output.stdout),
+                log_preview(&output.stderr)
+            )),
+            Err(error) => append_bridge_info_log(&format!("ssh_exec_error error={error}")),
+        }
+        result
     }
 
     /// Open a streaming SSH exec channel.
@@ -1697,6 +1717,11 @@ Write-Host 'litter_restart_app_server stopped port={port}'"#
             remote_shell_name(shell),
             command.len()
         );
+        append_android_debug_log(&format!(
+            "ssh_exec_shell shell={} command={}",
+            remote_shell_name(shell),
+            redact_ssh_command_for_log(command)
+        ));
         match shell {
             // Force bootstrap scripts through a POSIX shell even when the
             // account's login shell is fish or another non-POSIX shell.
@@ -2289,8 +2314,9 @@ async fn proxy_connection(
 /// Shell snippet that sources common profile files to pick up PATH additions.
 /// Runs each file in a subshell so shell-specific syntax cannot crash the
 /// parent `/bin/sh` process, then imports the resulting PATH into the current
-/// shell via a temp file.
-pub(crate) const PROFILE_INIT: &str = r#"_litter_pf="/tmp/.litter_path_$$"; for f in "$HOME/.profile" "$HOME/.bash_profile" "$HOME/.bashrc" "$HOME/.zprofile" "$HOME/.zshrc"; do [ -f "$f" ] && (. "$f" 2>/dev/null; echo "$PATH") > "$_litter_pf" 2>/dev/null && PATH="$(cat "$_litter_pf")" ; done; rm -f "$_litter_pf" 2>/dev/null;"#;
+/// shell via a temp file. SSH non-login commands on macOS often start with a
+/// minimal PATH, so append common user/package-manager bin directories too.
+pub(crate) const PROFILE_INIT: &str = r#"_litter_pf="/tmp/.litter_path_$$"; if [ -n "$SHELL" ] && [ -x "$SHELL" ]; then "$SHELL" -lc 'printf %s "$PATH"' > "$_litter_pf" 2>/dev/null && [ -s "$_litter_pf" ] && PATH="$(cat "$_litter_pf")"; fi; for f in "$HOME/.zshenv" "$HOME/.profile" "$HOME/.bash_profile" "$HOME/.bashrc" "$HOME/.zprofile" "$HOME/.zshrc"; do [ -f "$f" ] && (. "$f" 2>/dev/null; echo "$PATH") > "$_litter_pf" 2>/dev/null && PATH="$(cat "$_litter_pf")" ; done; rm -f "$_litter_pf" 2>/dev/null; _litter_add_path() { case ":$PATH:" in *":$1:"*) ;; *) [ -d "$1" ] && PATH="$1:$PATH" ;; esac; }; _litter_add_path "$NVM_BIN"; _litter_nvm_dir="${NVM_DIR:-$HOME/.nvm}"; for d in "$_litter_nvm_dir"/versions/node/*/bin; do _litter_add_path "$d"; done; _litter_add_path "$ASDF_DATA_DIR/shims"; _litter_add_path "$HOME/.asdf/shims"; _litter_add_path "${BUN_INSTALL:-$HOME/.bun}/bin"; _litter_add_path "$HOME/.volta/bin"; _litter_add_path "$HOME/.local/bin"; _litter_add_path "${CARGO_HOME:-$HOME/.cargo}/bin"; _litter_add_path "/opt/homebrew/opt/node/bin"; _litter_add_path "/opt/homebrew/bin"; _litter_add_path "/usr/local/opt/node/bin"; _litter_add_path "/usr/local/bin"; export PATH;"#;
 
 /// Shell snippet that probes npm/pnpm for their global binary directories.
 /// Sets `_litter_npm_prefix`, `_litter_npm_global_bin`,
@@ -2422,6 +2448,30 @@ fn server_launch_command(
             ),
         },
     }
+}
+
+fn redact_ssh_command_for_log(command: &str) -> String {
+    if command.contains("security unlock-keychain -p") {
+        return "<redacted macOS keychain unlock command>".to_string();
+    }
+    log_preview(command)
+}
+
+fn log_preview(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return "<empty>".to_string();
+    }
+    const LIMIT: usize = 1200;
+    let mut preview = String::new();
+    for (index, ch) in trimmed.chars().enumerate() {
+        if index == LIMIT {
+            preview.push_str("...");
+            return preview.replace('\n', "\\n");
+        }
+        preview.push(ch);
+    }
+    preview.replace('\n', "\\n")
 }
 
 fn format_process_logs(stdout: &str, stderr: &str) -> String {
@@ -2837,9 +2887,47 @@ mod tests {
         assert!(PROFILE_INIT.contains(".profile"));
         assert!(PROFILE_INIT.contains(".bash_profile"));
         assert!(PROFILE_INIT.contains(".bashrc"));
+        assert!(PROFILE_INIT.contains(".zshenv"));
         assert!(PROFILE_INIT.contains(".zprofile"));
         assert!(PROFILE_INIT.contains(".zshrc"));
+        assert!(PROFILE_INIT.contains("\"$SHELL\" -lc"));
         assert!(!PROFILE_INIT.contains("-ic 'printf %s \"$PATH\"'"));
+    }
+
+    #[test]
+    fn test_profile_init_adds_common_node_paths() {
+        assert!(PROFILE_INIT.contains("_litter_add_path"));
+        assert!(PROFILE_INIT.contains("$NVM_BIN"));
+        assert!(PROFILE_INIT.contains("${NVM_DIR:-$HOME/.nvm}"));
+        assert!(PROFILE_INIT.contains("/versions/node/*/bin"));
+        assert!(PROFILE_INIT.contains("$ASDF_DATA_DIR/shims"));
+        assert!(PROFILE_INIT.contains("$HOME/.asdf/shims"));
+        assert!(PROFILE_INIT.contains("${BUN_INSTALL:-$HOME/.bun}/bin"));
+        assert!(PROFILE_INIT.contains("$HOME/.volta/bin"));
+        assert!(PROFILE_INIT.contains("$HOME/.local/bin"));
+        assert!(PROFILE_INIT.contains("${CARGO_HOME:-$HOME/.cargo}/bin"));
+        assert!(PROFILE_INIT.contains("/opt/homebrew/opt/node/bin"));
+        assert!(PROFILE_INIT.contains("/opt/homebrew/bin"));
+        assert!(PROFILE_INIT.contains("/usr/local/opt/node/bin"));
+        assert!(PROFILE_INIT.contains("/usr/local/bin"));
+        assert!(PROFILE_INIT.contains("export PATH"));
+    }
+
+    #[test]
+    fn test_posix_launch_runs_after_profile_init() {
+        let command = format!(
+            "{profile_init} nohup {launch} </dev/null >/tmp/codex.log 2>&1 & echo $!",
+            profile_init = PROFILE_INIT,
+            launch = server_launch_command(
+                &RemoteCodexBinary::Codex("/opt/homebrew/bin/codex".into()),
+                "ws://127.0.0.1:8390",
+                RemoteShell::Posix,
+            )
+        );
+
+        assert!(command.starts_with(PROFILE_INIT));
+        assert!(command.contains("/opt/homebrew/bin"));
+        assert!(command.contains("nohup '/opt/homebrew/bin/codex' app-server"));
     }
 
     #[test]

--- a/shared/rust-bridge/codex-mobile-client/src/store/mod.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/store/mod.rs
@@ -14,8 +14,9 @@ pub use boundary::{
 pub use reducer::AppStoreReducer;
 pub(crate) use snapshot::QueuedFollowUpDraft;
 pub use snapshot::{
-    AppConnectionProgressSnapshot, AppConnectionStepKind, AppConnectionStepSnapshot,
-    AppConnectionStepState, AppQueuedFollowUpKind, AppQueuedFollowUpPreview, AppSnapshot,
-    AppVoiceSessionSnapshot, ServerHealthSnapshot, ServerSnapshot, ThreadSnapshot,
+    AppConnectionCommandSnapshot, AppConnectionProgressSnapshot, AppConnectionStepKind,
+    AppConnectionStepSnapshot, AppConnectionStepState, AppQueuedFollowUpKind,
+    AppQueuedFollowUpPreview, AppSnapshot, AppVoiceSessionSnapshot, ServerHealthSnapshot,
+    ServerSnapshot, ThreadSnapshot,
 };
 pub use updates::{AppStoreUpdateRecord, ThreadStreamingDeltaKind};

--- a/shared/rust-bridge/codex-mobile-client/src/store/snapshot.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/store/snapshot.rs
@@ -39,8 +39,19 @@ pub struct AppConnectionStepSnapshot {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, uniffi::Record)]
+pub struct AppConnectionCommandSnapshot {
+    pub label: String,
+    pub command: String,
+    pub state: AppConnectionStepState,
+    pub exit_code: Option<u32>,
+    pub stdout: Option<String>,
+    pub stderr: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Record)]
 pub struct AppConnectionProgressSnapshot {
     pub steps: Vec<AppConnectionStepSnapshot>,
+    pub commands: Vec<AppConnectionCommandSnapshot>,
     pub pending_install: bool,
     pub terminal_message: Option<String>,
 }
@@ -80,6 +91,7 @@ impl AppConnectionProgressSnapshot {
                     detail: None,
                 },
             ],
+            commands: Vec::new(),
             pending_install: false,
             terminal_message: None,
         }
@@ -94,6 +106,34 @@ impl AppConnectionProgressSnapshot {
         if let Some(step) = self.steps.iter_mut().find(|step| step.kind == kind) {
             step.state = state;
             step.detail = detail;
+        }
+    }
+
+    pub fn push_command(&mut self, label: String, command: String) -> usize {
+        self.commands.push(AppConnectionCommandSnapshot {
+            label,
+            command,
+            state: AppConnectionStepState::InProgress,
+            exit_code: None,
+            stdout: None,
+            stderr: None,
+        });
+        self.commands.len().saturating_sub(1)
+    }
+
+    pub fn finish_command(
+        &mut self,
+        index: usize,
+        state: AppConnectionStepState,
+        exit_code: Option<u32>,
+        stdout: Option<String>,
+        stderr: Option<String>,
+    ) {
+        if let Some(command) = self.commands.get_mut(index) {
+            command.state = state;
+            command.exit_code = exit_code;
+            command.stdout = stdout;
+            command.stderr = stderr;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add nvm-aware PATH bootstrapping for non-login SSH commands so npm-style Codex wrappers can find node on macOS
- expose SSH bootstrap command diagnostics in the shared connection progress snapshot and Android failure dialog
- route Rust bridge logs to Android logcat under LitterRust
- add the Alleycat submodule and point workspace dependencies at the in-repo path

## Verification
- cargo test -p codex-mobile-client profile_init -- --nocapture
- make android-emulator-fast
- adb -s R5CX315X6FT install -r apps/android/app/build/outputs/apk/debug/app-debug.apk

Closes #89 