### PR TITLE
polish server pills and ssh credentials entry

### DIFF
--- a/apps/android/app/src/main/java/com/litter/android/ui/discovery/DiscoveryScreen.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/discovery/DiscoveryScreen.kt
@@ -24,6 +24,8 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.QrCodeScanner
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.outlined.DesktopWindows
 import androidx.compose.material.icons.outlined.DeveloperBoard
 import androidx.compose.material.icons.outlined.Dns
@@ -57,6 +59,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.litter.android.state.SavedServer
@@ -1143,6 +1146,7 @@ private fun SSHLoginDialog(
     var username by remember(server.id) { mutableStateOf(initialCredential?.username ?: "") }
     var authMethod by remember(server.id) { mutableStateOf(initialCredential?.method ?: SshAuthMethod.PASSWORD) }
     var password by remember(server.id) { mutableStateOf(initialCredential?.password ?: "") }
+    var isPasswordVisible by remember(server.id) { mutableStateOf(false) }
     var privateKey by remember(server.id) { mutableStateOf(initialCredential?.privateKey ?: "") }
     var passphrase by remember(server.id) { mutableStateOf(initialCredential?.passphrase ?: "") }
     var rememberCredentials by remember(server.id) { mutableStateOf(initialCredential != null) }
@@ -1184,7 +1188,10 @@ private fun SSHLoginDialog(
                         Text(if (authMethod == SshAuthMethod.PASSWORD) "Password *" else "Password")
                     }
                     TextButton(
-                        onClick = { authMethod = SshAuthMethod.KEY },
+                        onClick = {
+                            authMethod = SshAuthMethod.KEY
+                            isPasswordVisible = false
+                        },
                         enabled = !isConnecting,
                     ) {
                         Text(if (authMethod == SshAuthMethod.KEY) "SSH Key *" else "SSH Key")
@@ -1196,7 +1203,30 @@ private fun SSHLoginDialog(
                         onValueChange = { password = it },
                         label = { Text("Password") },
                         singleLine = true,
-                        visualTransformation = PasswordVisualTransformation(),
+                        visualTransformation = if (isPasswordVisible) {
+                            VisualTransformation.None
+                        } else {
+                            PasswordVisualTransformation()
+                        },
+                        trailingIcon = {
+                            IconButton(
+                                onClick = { isPasswordVisible = !isPasswordVisible },
+                                enabled = !isConnecting,
+                            ) {
+                                Icon(
+                                    imageVector = if (isPasswordVisible) {
+                                        Icons.Filled.VisibilityOff
+                                    } else {
+                                        Icons.Filled.Visibility
+                                    },
+                                    contentDescription = if (isPasswordVisible) {
+                                        "Hide password"
+                                    } else {
+                                        "Show password"
+                                    },
+                                )
+                            }
+                        },
                     )
                     Row(
                         verticalAlignment = Alignment.CenterVertically,

--- a/apps/android/app/src/main/java/com/litter/android/ui/home/ServerPillRow.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/home/ServerPillRow.kt
@@ -10,9 +10,10 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -47,6 +48,9 @@ import com.litter.android.ui.scaled
 import uniffi.codex_mobile_client.AgentRuntimeInfo
 import uniffi.codex_mobile_client.AgentRuntimeKind
 import uniffi.codex_mobile_client.AppServerSnapshot
+
+private const val MaxRuntimeBadgesWithoutOverflow = 4
+private const val RuntimeBadgesWhenOverflowing = 3
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -168,24 +172,52 @@ private fun AgentRuntimeBadgeStack(runtimes: List<AgentRuntimeInfo>) {
         .sortedBy { it.kind.runtimeSortIndex }
         .distinctBy { it.kind }
     if (visible.isEmpty()) return
-    val badgeSize = 18
-    val badgeOffset = 11
+    val isOverflowing = visible.size > MaxRuntimeBadgesWithoutOverflow
+    val displayed = if (isOverflowing) visible.take(RuntimeBadgesWhenOverflowing) else visible
+    val overflowCount = if (isOverflowing) visible.size - displayed.size else 0
 
-    Box(
-        modifier = Modifier
-            .size(
-                width = (badgeSize + ((visible.size - 1).coerceAtLeast(0) * badgeOffset)).dp,
-                height = badgeSize.dp,
-            ),
+    Row(
+        horizontalArrangement = Arrangement.spacedBy((-7).dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        visible.forEachIndexed { index, runtime ->
+        displayed.forEachIndexed { index, runtime ->
             AgentRuntimeBadge(
                 runtime = runtime,
-                modifier = Modifier
-                    .offset(x = (index * badgeOffset).dp)
-                    .zIndex(index.toFloat()),
+                modifier = Modifier.zIndex(index.toFloat()),
             )
         }
+        if (overflowCount > 0) {
+            AgentRuntimeOverflowBadge(
+                count = overflowCount,
+                modifier = Modifier.zIndex(displayed.size.toFloat()),
+            )
+        }
+    }
+}
+
+@Composable
+private fun AgentRuntimeOverflowBadge(
+    count: Int,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .height(18.dp)
+            .widthIn(min = 18.dp)
+            .clip(RoundedCornerShape(5.dp))
+            .background(Color.Black.copy(alpha = 0.82f))
+            .border(0.55.dp, LitterTheme.textPrimary.copy(alpha = 0.28f), RoundedCornerShape(5.dp))
+            .padding(horizontal = 4.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "+$count",
+            color = LitterTheme.textPrimary,
+            fontSize = LitterTextStyle.caption2.scaled,
+            fontWeight = FontWeight.Bold,
+            fontFamily = LitterTheme.monoFont,
+            maxLines = 1,
+        )
     }
 }
 

--- a/apps/ios/Sources/Litter/Views/SSHLoginSheet.swift
+++ b/apps/ios/Sources/Litter/Views/SSHLoginSheet.swift
@@ -8,6 +8,7 @@ struct SSHLoginSheet: View {
     @Environment(\.dismiss) private var dismiss
     @State private var username: String
     @State private var password = ""
+    @State private var isPasswordVisible = false
     @State private var useKey = false
     @State private var privateKey = ""
     @State private var passphrase = ""
@@ -102,9 +103,7 @@ struct SSHLoginSheet: View {
                                 .litterFont(.footnote)
                                 .foregroundColor(LitterTheme.textPrimary)
                         } else {
-                            SecureField("password", text: $password)
-                                .litterFont(.footnote)
-                                .foregroundColor(LitterTheme.textPrimary)
+                            passwordInput
 
                             VStack(alignment: .leading, spacing: 4) {
                                 Toggle(isOn: $unlockMacosKeychain) {
@@ -190,8 +189,36 @@ struct SSHLoginSheet: View {
         }
         .onChange(of: useKey) { _, isUsingKey in
             if isUsingKey {
+                isPasswordVisible = false
                 unlockMacosKeychain = false
             }
+        }
+    }
+
+    private var passwordInput: some View {
+        HStack(spacing: 8) {
+            Group {
+                if isPasswordVisible {
+                    TextField("password", text: $password)
+                        .textContentType(.password)
+                } else {
+                    SecureField("password", text: $password)
+                        .textContentType(.password)
+                }
+            }
+            .litterFont(.footnote)
+            .foregroundColor(LitterTheme.textPrimary)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled(true)
+
+            Button {
+                isPasswordVisible.toggle()
+            } label: {
+                Image(systemName: isPasswordVisible ? "eye.slash" : "eye")
+                    .foregroundColor(LitterTheme.textSecondary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(isPasswordVisible ? "Hide password" : "Show password")
         }
     }
 
@@ -306,6 +333,7 @@ struct SSHLoginSheet: View {
 
     private func clearSensitiveInput() {
         password = ""
+        isPasswordVisible = false
         privateKey = ""
         passphrase = ""
     }

--- a/apps/ios/Sources/Litter/Views/ServerPill.swift
+++ b/apps/ios/Sources/Litter/Views/ServerPill.swift
@@ -67,6 +67,9 @@ private struct AgentRuntimeBadgeStack: View {
     let runtimes: [AgentRuntimeInfo]
     private let badgeSize: CGFloat = 18
     private let badgeOffset: CGFloat = 11
+    private let maxBadgesWithoutOverflow = 4
+    private let badgesWhenOverflowing = 3
+    private var overlapSpacing: CGFloat { badgeOffset - badgeSize }
 
     private var visibleRuntimes: [AgentRuntimeInfo] {
         var seenKinds: [AgentRuntimeKind] = []
@@ -84,20 +87,50 @@ private struct AgentRuntimeBadgeStack: View {
 
     var body: some View {
         let visible = visibleRuntimes
-        if !visible.isEmpty {
-            ZStack(alignment: .leading) {
-                ForEach(Array(visible.enumerated()), id: \.offset) { index, runtime in
+        let isOverflowing = visible.count > maxBadgesWithoutOverflow
+        let displayed = isOverflowing ? Array(visible.prefix(badgesWhenOverflowing)) : visible
+        let overflowCount = isOverflowing ? visible.count - displayed.count : 0
+
+        if !displayed.isEmpty {
+            HStack(spacing: overlapSpacing) {
+                ForEach(Array(displayed.enumerated()), id: \.element.kind) { index, runtime in
                     AgentRuntimeBadge(runtime: runtime)
-                        .offset(x: CGFloat(index) * badgeOffset)
                         .zIndex(Double(index))
                 }
+                if overflowCount > 0 {
+                    AgentRuntimeOverflowBadge(count: overflowCount)
+                        .zIndex(Double(displayed.count))
+                }
             }
-            .frame(
-                width: badgeSize + CGFloat(max(visible.count - 1, 0)) * badgeOffset,
-                height: badgeSize
-            )
+            .fixedSize()
+            .layoutPriority(1)
             .accessibilityLabel(visible.map(\.displayName).joined(separator: ", "))
         }
+    }
+}
+
+private struct AgentRuntimeOverflowBadge: View {
+    let count: Int
+
+    var body: some View {
+        Text("+\(count)")
+            .litterMonoFont(size: 9, weight: .bold)
+            .foregroundStyle(LitterTheme.textPrimary)
+            .lineLimit(1)
+            .minimumScaleFactor(0.75)
+            .padding(.horizontal, 4)
+            .frame(minWidth: 18)
+            .frame(height: 18)
+            .background(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(Color.black.opacity(0.82))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .stroke(LitterTheme.textPrimary.opacity(0.28), lineWidth: 0.55)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+            .shadow(color: .black.opacity(0.32), radius: 2, y: 1)
     }
 }
 


### PR DESCRIPTION
  - Add show/hide password toggles to SSH login on iOS and Android.
  - Cap server runtime badge stacks on iOS and Android.
  - Add `+N` overflow badges when a server has many runtimes.
  - Reset password visibility when switching auth modes or clearing sensitive input.

<img width="497" height="1008" alt="e6a499c4066220f1dd14b750b0338a21159eae9a9e5666229f4b45e4e24b2975" src="https://github.com/user-attachments/assets/113d6a9e-1d2c-4868-9cef-2b9ced6cc1be" />

<img width="520" height="1033" alt="af57de8422dfde9fbe5b31745cfe098bb1fa047bda6216d79ac9c2881415e336" src="https://github.com/user-attachments/assets/4707f527-0210-4d45-a1ca-4d4c9b0ebe91" />
