### PR TITLE
bridge: refresh Pi session hydration

### DIFF
--- a/shared/rust-bridge/Cargo.lock
+++ b/shared/rust-bridge/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
 [[package]]
 name = "alleycat-bridge-core"
 version = "0.1.0"
-source = "git+https://github.com/dnakov/alleycat.git?rev=cd0beeeb668e01ef1f09e5d6dfa5cd10e4985048#cd0beeeb668e01ef1f09e5d6dfa5cd10e4985048"
+source = "git+https://github.com/mkelzeer/alleycat.git?rev=09f47cc420b9cfef857de99eba20e55e84caea17#09f47cc420b9cfef857de99eba20e55e84caea17"
 dependencies = [
  "alleycat-codex-proto",
  "anyhow",
@@ -332,7 +332,7 @@ dependencies = [
 [[package]]
 name = "alleycat-claude-bridge"
 version = "0.1.0"
-source = "git+https://github.com/dnakov/alleycat.git?rev=cd0beeeb668e01ef1f09e5d6dfa5cd10e4985048#cd0beeeb668e01ef1f09e5d6dfa5cd10e4985048"
+source = "git+https://github.com/mkelzeer/alleycat.git?rev=09f47cc420b9cfef857de99eba20e55e84caea17#09f47cc420b9cfef857de99eba20e55e84caea17"
 dependencies = [
  "alleycat-bridge-core",
  "alleycat-codex-proto",
@@ -356,7 +356,7 @@ dependencies = [
 [[package]]
 name = "alleycat-codex-proto"
 version = "0.1.0"
-source = "git+https://github.com/dnakov/alleycat.git?rev=cd0beeeb668e01ef1f09e5d6dfa5cd10e4985048#cd0beeeb668e01ef1f09e5d6dfa5cd10e4985048"
+source = "git+https://github.com/mkelzeer/alleycat.git?rev=09f47cc420b9cfef857de99eba20e55e84caea17#09f47cc420b9cfef857de99eba20e55e84caea17"
 dependencies = [
  "chrono",
  "serde",
@@ -367,7 +367,7 @@ dependencies = [
 [[package]]
 name = "alleycat-opencode-bridge"
 version = "0.1.0"
-source = "git+https://github.com/dnakov/alleycat.git?rev=cd0beeeb668e01ef1f09e5d6dfa5cd10e4985048#cd0beeeb668e01ef1f09e5d6dfa5cd10e4985048"
+source = "git+https://github.com/mkelzeer/alleycat.git?rev=09f47cc420b9cfef857de99eba20e55e84caea17#09f47cc420b9cfef857de99eba20e55e84caea17"
 dependencies = [
  "alleycat-bridge-core",
  "anyhow",
@@ -391,7 +391,7 @@ dependencies = [
 [[package]]
 name = "alleycat-pi-bridge"
 version = "0.1.0"
-source = "git+https://github.com/dnakov/alleycat.git?rev=cd0beeeb668e01ef1f09e5d6dfa5cd10e4985048#cd0beeeb668e01ef1f09e5d6dfa5cd10e4985048"
+source = "git+https://github.com/mkelzeer/alleycat.git?rev=09f47cc420b9cfef857de99eba20e55e84caea17#09f47cc420b9cfef857de99eba20e55e84caea17"
 dependencies = [
  "alleycat-bridge-core",
  "alleycat-codex-proto",

--- a/shared/rust-bridge/Cargo.toml
+++ b/shared/rust-bridge/Cargo.toml
@@ -26,10 +26,12 @@ codex-cloud-requirements = { path = "../third_party/codex/codex-rs/cloud-require
 codex-config = { path = "../third_party/codex/codex-rs/config" }
 codex-utils-absolute-path = { path = "../third_party/codex/codex-rs/utils/absolute-path" }
 codex-git-utils = { path = "../third_party/codex/codex-rs/git-utils" }
-alleycat-bridge-core = { git = "https://github.com/dnakov/alleycat.git", rev = "cd0beeeb668e01ef1f09e5d6dfa5cd10e4985048" }
-alleycat-pi-bridge = { git = "https://github.com/dnakov/alleycat.git", rev = "cd0beeeb668e01ef1f09e5d6dfa5cd10e4985048" }
-alleycat-claude-bridge = { git = "https://github.com/dnakov/alleycat.git", rev = "cd0beeeb668e01ef1f09e5d6dfa5cd10e4985048" }
-alleycat-opencode-bridge = { git = "https://github.com/dnakov/alleycat.git", rev = "cd0beeeb668e01ef1f09e5d6dfa5cd10e4985048" }
+# Fork carries pi session hydration refresh: existing ~/.pi/agent/sessions JSONL rows
+# are upserted by path so mobile can catch up to desktop-continued sessions.
+alleycat-bridge-core = { git = "https://github.com/mkelzeer/alleycat.git", rev = "09f47cc420b9cfef857de99eba20e55e84caea17" }
+alleycat-pi-bridge = { git = "https://github.com/mkelzeer/alleycat.git", rev = "09f47cc420b9cfef857de99eba20e55e84caea17" }
+alleycat-claude-bridge = { git = "https://github.com/mkelzeer/alleycat.git", rev = "09f47cc420b9cfef857de99eba20e55e84caea17" }
+alleycat-opencode-bridge = { git = "https://github.com/mkelzeer/alleycat.git", rev = "09f47cc420b9cfef857de99eba20e55e84caea17" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "net", "io-util"] }


### PR DESCRIPTION
## Summary\n- Point the shared Rust bridge at the Alleycat fork/revision that refreshes hydrated Pi session rows from existing ~/.pi/agent/sessions JSONL files\n- Keeps mobile thread ids stable while allowing iOS to catch up to desktop-continued Pi sessions on reconnect/list/read\n\nDepends on: https://github.com/dnakov/alleycat/pull/7\n\n## Verification\n- cargo test -p alleycat-pi-bridge hydrate (in /tmp/alleycat)\n- cargo update/check in Litter was not run because the cloned repo has an uninitialized shared/third_party/codex submodule