### PR TITLE
fix(ios): tolerate null/non-string and #RRGGBBAA values in theme JSON

### DIFF
--- a/apps/ios/Sources/Litter/Models/ThemeDefinition.swift
+++ b/apps/ios/Sources/Litter/Models/ThemeDefinition.swift
@@ -11,7 +11,56 @@ struct ThemeDefinition: Codable {
         case light, dark
     }
 
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case type
+        case colors
+    }
+
+    init(name: String, type: ThemeType, colors: [String: String]) {
+        self.name = name
+        self.type = type
+        self.colors = colors
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+        type = try container.decode(ThemeType.self, forKey: .type)
+
+        // VS Code themes occasionally include null entries or non-string
+        // values (arrays, objects) under `colors`. Decode tolerantly and
+        // drop anything that isn't a string so the rest of the app can
+        // assume `[String: String]`.
+        let rawColors = try container.decode([String: ThemeColorValue].self, forKey: .colors)
+        colors = rawColors.compactMapValues { value in
+            value.string.map(Self.sanitizeHex)
+        }
+    }
+
+    // VS Code allows #RRGGBBAA. Downstream color helpers assume 6-digit
+    // RGB, so strip the trailing alpha pair at the decode boundary.
+    private static func sanitizeHex(_ raw: String) -> String {
+        guard raw.hasPrefix("#"), raw.count == 9 else { return raw }
+        return String(raw.prefix(7))
+    }
+
     // tokenColors are ignored — syntax highlighting is handled by Hairball
+}
+
+private struct ThemeColorValue: Decodable {
+    let string: String?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            string = nil
+        } else {
+            // Only string values are usable as theme colors; arrays,
+            // objects, numbers, etc. fall through as nil and get dropped.
+            string = try? container.decode(String.self)
+        }
+    }
 }
 
 // MARK: - Lightweight index entry for picker UI

--- a/apps/ios/Tests/LitterTests/ThemeDefinitionTests.swift
+++ b/apps/ios/Tests/LitterTests/ThemeDefinitionTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import Litter
+
+final class ThemeDefinitionTests: XCTestCase {
+    func testThemeDefinitionIgnoresNullAndNonStringColorEntries() throws {
+        let data = Data(
+            """
+            {
+              "name": "night-owl",
+              "type": "dark",
+              "colors": {
+                "editor.background": "#011627",
+                "editor.findRangeHighlightBackground": null,
+                "editor.foreground": "#d6deeb",
+                "symbolIcon.constantForeground": ["#79c0ff", "#d2a8ff"]
+              }
+            }
+            """.utf8
+        )
+
+        let theme = try JSONDecoder().decode(ThemeDefinition.self, from: data)
+
+        XCTAssertEqual(theme.colors["editor.background"], "#011627")
+        XCTAssertEqual(theme.colors["editor.foreground"], "#d6deeb")
+        XCTAssertNil(theme.colors["editor.findRangeHighlightBackground"])
+        XCTAssertNil(theme.colors["symbolIcon.constantForeground"])
+    }
+
+    func testThemeDefinitionStripsAlphaFromEightDigitHex() throws {
+        let data = Data(
+            """
+            {
+              "name": "alpha-theme",
+              "type": "dark",
+              "colors": {
+                "button.background": "#7e57c2cc",
+                "editor.background": "#011627"
+              }
+            }
+            """.utf8
+        )
+
+        let theme = try JSONDecoder().decode(ThemeDefinition.self, from: data)
+
+        // 8-digit #RRGGBBAA is sanitized to 6-digit #RRGGBB at decode time
+        // so downstream color helpers see a well-formed RGB string.
+        XCTAssertEqual(theme.colors["button.background"], "#7e57c2")
+        XCTAssertEqual(theme.colors["editor.background"], "#011627")
+    }
+}


### PR DESCRIPTION
VS Code themes can include null entries, non-string values, or 8-digit #RRGGBBAA hex under `colors`; decode them tolerantly and strip alpha at the boundary so downstream color helpers stay 6-digit.