### PR TITLE
fix: allow dismissing Input Required modal on iOS and Android

### DIFF
--- a/apps/android/app/src/main/java/com/litter/android/ui/LitterApp.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/LitterApp.kt
@@ -448,12 +448,18 @@ fun LitterApp(
 
             // Global approval overlay
             val approvals = snapshot?.pendingApprovals.orEmpty()
-            val userInputs = snapshot?.pendingUserInputs.orEmpty()
+            var dismissedUserInputIds by remember { mutableStateOf(setOf<String>()) }
+            val userInputs = snapshot?.pendingUserInputs.orEmpty().filter {
+                !dismissedUserInputIds.contains(it.id)
+            }
             if (approvals.isNotEmpty() || userInputs.isNotEmpty()) {
                 ApprovalOverlay(
                     approvals = approvals,
                     userInputs = userInputs,
                     appStore = appModel.store,
+                    onDismissUserInput = { id ->
+                        dismissedUserInputIds = dismissedUserInputIds + id
+                    },
                 )
             }
         }

--- a/apps/android/app/src/main/java/com/litter/android/ui/LitterApp.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/LitterApp.kt
@@ -59,6 +59,26 @@ val LocalAppModel = staticCompositionLocalOf<AppModel> {
 }
 
 /**
+ * UI-only ledger of pending-user-input request IDs the user has manually dismissed.
+ * Lives at the app shell so the inline composer prompt and the global approval
+ * overlay agree on what's been hidden.
+ */
+class DismissedUserInputState {
+    var ids by mutableStateOf(setOf<String>())
+        private set
+
+    fun dismiss(id: String) {
+        ids = ids + id
+    }
+
+    fun isDismissed(id: String): Boolean = ids.contains(id)
+}
+
+val LocalDismissedUserInputs = staticCompositionLocalOf<DismissedUserInputState> {
+    error("DismissedUserInputState not provided")
+}
+
+/**
  * Root composable for the app. Manages navigation stack and global overlays.
  */
 @OptIn(ExperimentalMaterial3Api::class)
@@ -81,9 +101,11 @@ fun LitterApp(
 
     // Read currentStep so Compose tracks it as a dependency and recomposes on change.
     val textScale = ConversationTextSize.fromStep(TextSizePrefs.currentStep).scale
+    val dismissedUserInputs = remember { DismissedUserInputState() }
     CompositionLocalProvider(
         LocalAppModel provides appModel,
         LocalTextScale provides textScale,
+        LocalDismissedUserInputs provides dismissedUserInputs,
     ) {
         val snapshot by appModel.snapshot.collectAsState()
         val scope = androidx.compose.runtime.rememberCoroutineScope()
@@ -448,18 +470,15 @@ fun LitterApp(
 
             // Global approval overlay
             val approvals = snapshot?.pendingApprovals.orEmpty()
-            var dismissedUserInputIds by remember { mutableStateOf(setOf<String>()) }
             val userInputs = snapshot?.pendingUserInputs.orEmpty().filter {
-                !dismissedUserInputIds.contains(it.id)
+                !dismissedUserInputs.isDismissed(it.id)
             }
             if (approvals.isNotEmpty() || userInputs.isNotEmpty()) {
                 ApprovalOverlay(
                     approvals = approvals,
                     userInputs = userInputs,
                     appStore = appModel.store,
-                    onDismissUserInput = { id ->
-                        dismissedUserInputIds = dismissedUserInputIds + id
-                    },
+                    onDismissUserInput = { id -> dismissedUserInputs.dismiss(id) },
                 )
             }
         }

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ApprovalOverlay.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ApprovalOverlay.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -55,6 +56,7 @@ fun ApprovalOverlay(
     approvals: List<PendingApproval>,
     userInputs: List<PendingUserInputRequest>,
     appStore: AppStore,
+    onDismissUserInput: ((String) -> Unit)? = null,
 ) {
     val scope = rememberCoroutineScope()
 
@@ -92,6 +94,7 @@ fun ApprovalOverlay(
                             appStore.respondToUserInput(input.id, answers)
                         }
                     },
+                    onDismiss = { onDismissUserInput?.invoke(input.id) },
                 )
             }
         }
@@ -200,6 +203,7 @@ private fun ApprovalCard(
 private fun UserInputCard(
     request: PendingUserInputRequest,
     onSubmit: (List<PendingUserInputAnswer>) -> Unit,
+    onDismiss: (() -> Unit)? = null,
 ) {
     val answers = remember { mutableMapOf<String, String>() }
 
@@ -208,20 +212,39 @@ private fun UserInputCard(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        // Requester badge
-        val requester = buildString {
-            request.requesterAgentNickname?.let { append(it) }
-            request.requesterAgentRole?.let {
-                if (isNotEmpty()) append(" ")
-                append("[$it]")
+        // Header with close button
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Requester badge
+            val requester = buildString {
+                request.requesterAgentNickname?.let { append(it) }
+                request.requesterAgentRole?.let {
+                    if (isNotEmpty()) append(" ")
+                    append("[$it]")
+                }
             }
-        }
-        if (requester.isNotBlank()) {
-            Text(
-                text = requester,
-                color = LitterTheme.accent,
-                fontSize = LitterTextStyle.caption2.scaled,
-            )
+            if (requester.isNotBlank()) {
+                Text(
+                    text = requester,
+                    color = LitterTheme.accent,
+                    fontSize = LitterTextStyle.caption2.scaled,
+                )
+            } else {
+                Spacer(modifier = Modifier.weight(1f))
+            }
+            if (onDismiss != null) {
+                Text(
+                    text = "✕",
+                    color = LitterTheme.textMuted,
+                    fontSize = LitterTextStyle.body.scaled,
+                    modifier = Modifier
+                        .clickable { onDismiss() }
+                        .padding(4.dp),
+                )
+            }
         }
 
         for (question in request.questions) {

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ApprovalOverlay.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ApprovalOverlay.kt
@@ -31,6 +31,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -242,7 +244,8 @@ private fun UserInputCard(
                     fontSize = LitterTextStyle.body.scaled,
                     modifier = Modifier
                         .clickable { onDismiss() }
-                        .padding(4.dp),
+                        .padding(4.dp)
+                        .semantics { contentDescription = "Dismiss input request" },
                 )
             }
         }

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ComposerBar.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ComposerBar.kt
@@ -82,6 +82,8 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.sp
 import com.litter.android.state.AppModel
 import com.litter.android.state.ComposerImageAttachment
@@ -627,7 +629,8 @@ fun ComposerBar(
                             fontSize = LitterTextStyle.body.scaled,
                             modifier = Modifier
                                 .clickable { onDismissPendingUserInput() }
-                                .padding(4.dp),
+                                .padding(4.dp)
+                                .semantics { contentDescription = "Dismiss input request" },
                         )
                     }
                 }

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ComposerBar.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ComposerBar.kt
@@ -159,6 +159,7 @@ fun ComposerBar(
     onShowSkillsSheet: (() -> Unit)? = null,
     onSlashError: ((String) -> Unit)? = null,
     pendingUserInput: PendingUserInputRequest? = null,
+    onDismissPendingUserInput: (() -> Unit)? = null,
 ) {
     val appModel = LocalAppModel.current
     val context = LocalContext.current
@@ -370,6 +371,9 @@ fun ComposerBar(
     // dialog. Keep this in sync if you change slash-command dispatch or
     // payload shape.
     val sendCurrent: () -> Unit = {
+        if (pendingUserInput != null) {
+            onDismissPendingUserInput?.invoke()
+        }
         val handledAsSlash = parseSlashCommandInvocation(text)?.let { invocation ->
             if (dispatchSlashCommand(invocation.command.name, invocation.args)) {
                 textFieldValue = TextFieldValue("")
@@ -604,6 +608,29 @@ fun ComposerBar(
                     .padding(12.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
+                // Header with close button
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = "Input Required",
+                        color = LitterTheme.textPrimary,
+                        fontSize = LitterTextStyle.caption.scaled,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    if (onDismissPendingUserInput != null) {
+                        Text(
+                            text = "✕",
+                            color = LitterTheme.textMuted,
+                            fontSize = LitterTextStyle.body.scaled,
+                            modifier = Modifier
+                                .clickable { onDismissPendingUserInput() }
+                                .padding(4.dp),
+                        )
+                    }
+                }
                 for (question in pendingUserInput.questions) {
                     Text(question.question, color = LitterTheme.textPrimary, fontSize = LitterTextStyle.footnote.scaled)
                     if (question.options.isNotEmpty()) {

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationScreen.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationScreen.kt
@@ -275,11 +275,13 @@ fun ConversationScreen(
         collaborationModesLoading = false
     }
 
-    // Pending user input for this thread
-    var dismissedUserInputIds by remember { mutableStateOf(setOf<String>()) }
-    val pendingInput = remember(snapshot, threadKey, dismissedUserInputIds) {
+    // Pending user input for this thread. The dismissal ledger is shared with
+    // the global ApprovalOverlay via [LocalDismissedUserInputs] so dismissing
+    // from either surface hides the request everywhere.
+    val dismissedUserInputs = com.litter.android.ui.LocalDismissedUserInputs.current
+    val pendingInput = remember(snapshot, threadKey, dismissedUserInputs.ids) {
         snapshot?.pendingUserInputs?.firstOrNull {
-            it.threadId == threadKey.threadId && !dismissedUserInputIds.contains(it.id)
+            it.threadId == threadKey.threadId && !dismissedUserInputs.isDismissed(it.id)
         }
     }
 
@@ -836,7 +838,7 @@ fun ConversationScreen(
                         onSlashError = { slashErrorMessage = it },
                         pendingUserInput = pendingInput,
                         onDismissPendingUserInput = {
-                            pendingInput?.let { dismissedUserInputIds = dismissedUserInputIds + it.id }
+                            pendingInput?.let { dismissedUserInputs.dismiss(it.id) }
                         },
                     )
 

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationScreen.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationScreen.kt
@@ -276,8 +276,11 @@ fun ConversationScreen(
     }
 
     // Pending user input for this thread
-    val pendingInput = remember(snapshot, threadKey) {
-        snapshot?.pendingUserInputs?.firstOrNull { it.threadId == threadKey.threadId }
+    var dismissedUserInputIds by remember { mutableStateOf(setOf<String>()) }
+    val pendingInput = remember(snapshot, threadKey, dismissedUserInputIds) {
+        snapshot?.pendingUserInputs?.firstOrNull {
+            it.threadId == threadKey.threadId && !dismissedUserInputIds.contains(it.id)
+        }
     }
 
     val activeTaskSummary = remember(items) {
@@ -832,6 +835,9 @@ fun ConversationScreen(
                         onShowSkillsSheet = { showSkillsSheet = true },
                         onSlashError = { slashErrorMessage = it },
                         pendingUserInput = pendingInput,
+                        onDismissPendingUserInput = {
+                            pendingInput?.let { dismissedUserInputIds = dismissedUserInputIds + it.id }
+                        },
                     )
 
                     Spacer(Modifier.navigationBarsPadding())

--- a/apps/ios/Sources/Litter/Views/ConversationComposerContentView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationComposerContentView.swift
@@ -22,6 +22,7 @@ struct ConversationComposerContentView: View {
     @Binding var showAttachMenu: Bool
     let onClearAttachment: () -> Void
     let onRespondToPendingUserInput: ([String: [String]]) -> Void
+    let onDismissPendingUserInput: () -> Void
     let onImplementPlan: () -> Void
     let onDismissPlanImplementation: () -> Void
     let onSteerQueuedFollowUp: (AppQueuedFollowUpPreview) -> Void
@@ -57,6 +58,7 @@ struct ConversationComposerContentView: View {
         showAttachMenu: Binding<Bool>,
         onClearAttachment: @escaping () -> Void,
         onRespondToPendingUserInput: @escaping ([String: [String]]) -> Void,
+        onDismissPendingUserInput: @escaping () -> Void = {},
         onImplementPlan: @escaping () -> Void = {},
         onDismissPlanImplementation: @escaping () -> Void = {},
         onSteerQueuedFollowUp: @escaping (AppQueuedFollowUpPreview) -> Void,
@@ -91,6 +93,7 @@ struct ConversationComposerContentView: View {
         _showAttachMenu = showAttachMenu
         self.onClearAttachment = onClearAttachment
         self.onRespondToPendingUserInput = onRespondToPendingUserInput
+        self.onDismissPendingUserInput = onDismissPendingUserInput
         self.onImplementPlan = onImplementPlan
         self.onDismissPlanImplementation = onDismissPlanImplementation
         self.onSteerQueuedFollowUp = onSteerQueuedFollowUp
@@ -154,9 +157,13 @@ struct ConversationComposerContentView: View {
                 }
 
                 if let pendingUserInputRequest {
-                    PendingUserInputPromptView(request: pendingUserInputRequest, onSubmit: onRespondToPendingUserInput)
-                        .padding(.horizontal, 12)
-                        .padding(.top, 8)
+                    PendingUserInputPromptView(
+                        request: pendingUserInputRequest,
+                        onSubmit: onRespondToPendingUserInput,
+                        onDismiss: onDismissPendingUserInput
+                    )
+                    .padding(.horizontal, 12)
+                    .padding(.top, 8)
                 }
 
                 if hasPendingPlanImplementation {

--- a/apps/ios/Sources/Litter/Views/ConversationView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationView.swift
@@ -1425,9 +1425,11 @@ private struct ConversationInputBar: View {
     @State private var hasLoggedKeyboardShown = false
     @State private var isComposerFocused = false
     @State private var composerSelectionRange = NSRange(location: 0, length: 0)
+    @State private var dismissedPendingUserInputIds: Set<String> = []
 
     private var pendingUserInputRequest: PendingUserInputRequest? {
-        snapshot.pendingUserInputRequest
+        guard let request = snapshot.pendingUserInputRequest else { return nil }
+        return dismissedPendingUserInputIds.contains(request.id) ? nil : request
     }
 
     private var pendingModelOverride: String? {
@@ -1568,6 +1570,7 @@ private struct ConversationInputBar: View {
                 showAttachMenu: $showAttachMenu,
                 onClearAttachment: clearAttachment,
                 onRespondToPendingUserInput: respondToPendingUserInput,
+                onDismissPendingUserInput: dismissPendingUserInput,
                 onImplementPlan: { Task { await implementPlan() } },
                 onDismissPlanImplementation: dismissPlanImplementationPrompt,
                 onSteerQueuedFollowUp: steerQueuedFollowUp,
@@ -1673,6 +1676,9 @@ private struct ConversationInputBar: View {
         let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
         let image = attachedImage
         guard !text.isEmpty || image != nil else { return }
+        if let request = snapshot.pendingUserInputRequest {
+            dismissedPendingUserInputIds.insert(request.id)
+        }
         if image == nil,
            let invocation = parseSlashCommandInvocation(text) {
             inputText = ""
@@ -1690,6 +1696,11 @@ private struct ConversationInputBar: View {
         let pluginMentions = collectPluginMentionsForSubmission(text)
         pluginMentionSelections = []
         onSend(text, image, skillMentions, pluginMentions)
+    }
+
+    private func dismissPendingUserInput() {
+        guard let request = snapshot.pendingUserInputRequest else { return }
+        dismissedPendingUserInputIds.insert(request.id)
     }
 
     private func collectPluginMentionsForSubmission(_ text: String) -> [PluginMentionSelection] {
@@ -2983,6 +2994,7 @@ private func index(in text: String, offset: Int) -> String.Index? {
 struct PendingUserInputPromptView: View {
     let request: PendingUserInputRequest
     let onSubmit: ([String: [String]]) -> Void
+    let onDismiss: () -> Void
 
     @State private var selectedAnswers: [String: String] = [:]
     @State private var otherAnswers: [String: String] = [:]
@@ -3022,6 +3034,13 @@ struct PendingUserInputPromptView: View {
                     .litterFont(.caption, weight: .semibold)
                     .foregroundColor(LitterTheme.textPrimary)
                 Spacer()
+                Button(action: onDismiss) {
+                    Image(systemName: "xmark.circle.fill")
+                        .litterFont(.body)
+                        .foregroundColor(LitterTheme.textMuted)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Dismiss input request")
             }
 
             if let requesterLabel {


### PR DESCRIPTION
When the Input Required modal is open and the user sends a message without answering, the modal now closes automatically. A close (✕) button is also added so the user can dismiss the prompt manually.

### Changes
- **iOS:** add `dismissedPendingUserInputIds` set in `ConversationView`; dismiss on send or via new ✕ button in `PendingUserInputPromptView`.
- **Android:** add `dismissedUserInputIds` state in `ConversationScreen`, `ComposerBar`, `LitterApp` and `ApprovalOverlay`; dismiss on send or via new ✕ button in inline prompt and global overlay.