### PR TITLE
[codex] Add OpenAI base URL setting

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -58,7 +58,20 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Configure sccache
+        run: |
+          if [ -n "${SCCACHE_ENDPOINT:-}" ] && [ -n "${AWS_ACCESS_KEY_ID:-}" ] && [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+            echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          else
+            echo "SCCACHE_BUCKET=" >> "$GITHUB_ENV"
+            echo "SCCACHE_ENDPOINT=" >> "$GITHUB_ENV"
+            echo "SCCACHE_S3_KEY_PREFIX=" >> "$GITHUB_ENV"
+            echo "AWS_ACCESS_KEY_ID=" >> "$GITHUB_ENV"
+            echo "AWS_SECRET_ACCESS_KEY=" >> "$GITHUB_ENV"
+          fi
+
       - name: Setup sccache
+        if: env.SCCACHE_ENDPOINT != '' && env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != ''
         uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Sync codex submodule
@@ -75,7 +88,6 @@ jobs:
       - name: Generate shared mobile bindings
         if: steps.mobile-bindings-cache.outputs.cache-hit != 'true'
         env:
-          RUSTC_WRAPPER: sccache
           CARGO_INCREMENTAL: "0"
         run: |
           cd shared/rust-bridge
@@ -148,7 +160,20 @@ jobs:
         with:
           targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android
 
+      - name: Configure sccache
+        run: |
+          if [ -n "${SCCACHE_ENDPOINT:-}" ] && [ -n "${AWS_ACCESS_KEY_ID:-}" ] && [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+            echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          else
+            echo "SCCACHE_BUCKET=" >> "$GITHUB_ENV"
+            echo "SCCACHE_ENDPOINT=" >> "$GITHUB_ENV"
+            echo "SCCACHE_S3_KEY_PREFIX=" >> "$GITHUB_ENV"
+            echo "AWS_ACCESS_KEY_ID=" >> "$GITHUB_ENV"
+            echo "AWS_SECRET_ACCESS_KEY=" >> "$GITHUB_ENV"
+          fi
+
       - name: Setup sccache
+        if: env.SCCACHE_ENDPOINT != '' && env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != ''
         uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Download shared prep artifact
@@ -171,14 +196,11 @@ jobs:
           touch .build-stamps/sync .build-stamps/bindings-kotlin
 
       - name: Install cargo-ndk
-        env:
-          RUSTC_WRAPPER: sccache
         run: cargo install cargo-ndk --locked
 
       - name: Build Rust JNI libs
         env:
           ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/30.0.14904198
-          RUSTC_WRAPPER: sccache
         run: make rust-android
 
       - name: Setup Gradle
@@ -221,7 +243,20 @@ jobs:
         with:
           targets: aarch64-apple-ios-sim,i686-unknown-linux-musl
 
+      - name: Configure sccache
+        run: |
+          if [ -n "${SCCACHE_ENDPOINT:-}" ] && [ -n "${AWS_ACCESS_KEY_ID:-}" ] && [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+            echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          else
+            echo "SCCACHE_BUCKET=" >> "$GITHUB_ENV"
+            echo "SCCACHE_ENDPOINT=" >> "$GITHUB_ENV"
+            echo "SCCACHE_S3_KEY_PREFIX=" >> "$GITHUB_ENV"
+            echo "AWS_ACCESS_KEY_ID=" >> "$GITHUB_ENV"
+            echo "AWS_SECRET_ACCESS_KEY=" >> "$GITHUB_ENV"
+          fi
+
       - name: Setup sccache
+        if: env.SCCACHE_ENDPOINT != '' && env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != ''
         uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Download shared prep artifact
@@ -244,8 +279,6 @@ jobs:
           touch .build-stamps/sync .build-stamps/bindings-swift
 
       - name: Build Rust for iOS simulator
-        env:
-          RUSTC_WRAPPER: sccache
         run: env -u CARGO_INCREMENTAL ./apps/ios/scripts/build-rust.sh --preserve-current --fast-sim --skip-bindings
 
       - name: Download Alpine rootfs

--- a/apps/android/app/src/main/java/com/litter/android/state/OpenAIApiKeyStore.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/OpenAIApiKeyStore.kt
@@ -7,9 +7,15 @@ class OpenAIApiKeyStore(context: Context) {
     private val prefs = openEncryptedPrefsOrReset(context, PREFS_NAME)
 
     fun hasStoredKey(): Boolean = !load().isNullOrBlank()
+    fun hasStoredBaseUrl(): Boolean = !loadBaseUrl().isNullOrBlank()
 
     fun load(): String? {
         val raw = prefs.getString(KEY_API_KEY, null)?.trim()
+        return raw?.takeIf { it.isNotEmpty() }
+    }
+
+    fun loadBaseUrl(): String? {
+        val raw = prefs.getString(KEY_BASE_URL, null)?.trim()
         return raw?.takeIf { it.isNotEmpty() }
     }
 
@@ -19,21 +25,42 @@ class OpenAIApiKeyStore(context: Context) {
         applyToEnvironment()
     }
 
+    fun saveBaseUrl(baseUrl: String) {
+        val trimmed = baseUrl.trim()
+        prefs.edit().putString(KEY_BASE_URL, trimmed).commit()
+        applyToEnvironment()
+    }
+
     fun clear() {
         prefs.edit().remove(KEY_API_KEY).commit()
         try {
-            Os.unsetenv(ENV_KEY)
+            Os.unsetenv(API_KEY_ENV_KEY)
+        } catch (_: Exception) {
+        }
+    }
+
+    fun clearBaseUrl() {
+        prefs.edit().remove(KEY_BASE_URL).commit()
+        try {
+            Os.unsetenv(BASE_URL_ENV_KEY)
         } catch (_: Exception) {
         }
     }
 
     fun applyToEnvironment() {
         val key = load()
+        val baseUrl = loadBaseUrl()
         try {
             if (key.isNullOrEmpty()) {
-                Os.unsetenv(ENV_KEY)
+                Os.unsetenv(API_KEY_ENV_KEY)
             } else {
-                Os.setenv(ENV_KEY, key, true)
+                Os.setenv(API_KEY_ENV_KEY, key, true)
+            }
+
+            if (baseUrl.isNullOrEmpty()) {
+                Os.unsetenv(BASE_URL_ENV_KEY)
+            } else {
+                Os.setenv(BASE_URL_ENV_KEY, baseUrl, true)
             }
         } catch (_: Exception) {
         }
@@ -42,6 +69,8 @@ class OpenAIApiKeyStore(context: Context) {
     companion object {
         private const val PREFS_NAME = "litter_openai_api_key"
         private const val KEY_API_KEY = "openai_api_key"
-        private const val ENV_KEY = "OPENAI_API_KEY"
+        private const val KEY_BASE_URL = "openai_base_url"
+        private const val API_KEY_ENV_KEY = "OPENAI_API_KEY"
+        private const val BASE_URL_ENV_KEY = "OPENAI_BASE_URL"
     }
 }

--- a/apps/android/app/src/main/java/com/litter/android/ui/settings/AccountSheet.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/settings/AccountSheet.kt
@@ -63,9 +63,11 @@ fun AccountSheet(
     val account = server?.account
     val apiKeyStore = remember(context) { OpenAIApiKeyStore(context.applicationContext) }
     var apiKey by remember { mutableStateOf("") }
+    var openAIBaseUrl by remember { mutableStateOf("") }
     var error by remember { mutableStateOf<String?>(null) }
     var isAuthWorking by remember { mutableStateOf(false) }
     var hasStoredApiKey by remember { mutableStateOf(apiKeyStore.hasStoredKey()) }
+    var hasStoredBaseUrl by remember { mutableStateOf(apiKeyStore.hasStoredBaseUrl()) }
     val authLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult(),
     ) { result ->
@@ -108,6 +110,7 @@ fun AccountSheet(
 
     androidx.compose.runtime.LaunchedEffect(serverId, account) {
         hasStoredApiKey = apiKeyStore.hasStoredKey()
+        hasStoredBaseUrl = apiKeyStore.hasStoredBaseUrl()
     }
 
     androidx.compose.runtime.LaunchedEffect(serverId) {
@@ -174,6 +177,14 @@ fun AccountSheet(
         if (server?.isLocal == true && hasStoredApiKey) {
             Text(
                 "Local OpenAI API key is saved.",
+                color = LitterTheme.accent,
+                fontSize = 12.sp,
+            )
+        }
+
+        if (server?.isLocal == true && hasStoredBaseUrl) {
+            Text(
+                "OpenAI-compatible base URL is saved.",
                 color = LitterTheme.accent,
                 fontSize = 12.sp,
             )
@@ -279,6 +290,84 @@ fun AccountSheet(
                     Text(if (hasStoredApiKey) "Update API Key" else "Save API Key")
                 }
             }
+
+            Text(
+                if (hasStoredBaseUrl) {
+                    "Custom OpenAI-compatible endpoint saved for the local Codex server."
+                } else {
+                    "Optional OpenAI-compatible endpoint for local models."
+                },
+                color = LitterTheme.textSecondary,
+                fontSize = 12.sp,
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = openAIBaseUrl,
+                    onValueChange = { openAIBaseUrl = it },
+                    label = { Text("Base URL") },
+                    placeholder = { Text("http://host:port/v1") },
+                    singleLine = true,
+                    modifier = Modifier.weight(1f),
+                )
+                Button(
+                    onClick = {
+                        val normalized = normalizeOpenAIBaseUrl(openAIBaseUrl)
+                        if (normalized == null) {
+                            error = "Enter a valid http or https base URL."
+                        } else {
+                            scope.launch {
+                                isAuthWorking = true
+                                try {
+                                    apiKeyStore.saveBaseUrl(normalized)
+                                    appModel.restartLocalServer()
+                                    hasStoredBaseUrl = apiKeyStore.hasStoredBaseUrl()
+                                    if (hasStoredBaseUrl) {
+                                        openAIBaseUrl = ""
+                                        error = null
+                                    } else {
+                                        error = "Base URL did not persist locally."
+                                    }
+                                } catch (e: Exception) {
+                                    error = e.message
+                                } finally {
+                                    isAuthWorking = false
+                                }
+                            }
+                        }
+                    },
+                    enabled = openAIBaseUrl.isNotBlank() && !isAuthWorking,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = LitterTheme.accent,
+                        contentColor = Color.Black,
+                    ),
+                ) {
+                    Text(if (hasStoredBaseUrl) "Update" else "Save")
+                }
+            }
+            if (hasStoredBaseUrl) {
+                OutlinedButton(
+                    onClick = {
+                        scope.launch {
+                            isAuthWorking = true
+                            try {
+                                apiKeyStore.clearBaseUrl()
+                                appModel.restartLocalServer()
+                                hasStoredBaseUrl = apiKeyStore.hasStoredBaseUrl()
+                                openAIBaseUrl = ""
+                                error = null
+                            } catch (e: Exception) {
+                                error = e.message
+                            } finally {
+                                isAuthWorking = false
+                            }
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = !isAuthWorking,
+                ) {
+                    Text("Clear Base URL")
+                }
+            }
         } else if (server?.isLocal == false) {
             Text(
                 "Remote servers request their own OAuth login when needed. Account login and API key entry stay local-only.",
@@ -291,4 +380,14 @@ fun AccountSheet(
             Text(it, color = LitterTheme.danger, fontSize = 12.sp)
         }
     }
+}
+
+private fun normalizeOpenAIBaseUrl(rawValue: String): String? {
+    val trimmed = rawValue.trim().trimEnd('/')
+    if (trimmed.isEmpty()) return null
+    val uri = runCatching { java.net.URI(trimmed) }.getOrNull() ?: return null
+    val scheme = uri.scheme?.lowercase()
+    if (scheme != "http" && scheme != "https") return null
+    if (uri.host.isNullOrBlank()) return null
+    return trimmed
 }

--- a/apps/android/app/src/main/java/com/litter/android/ui/settings/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/settings/SettingsSheet.kt
@@ -1318,9 +1318,11 @@ private fun AccountSection(server: uniffi.codex_mobile_client.AppServerSnapshot)
     val scope = rememberCoroutineScope()
     val apiKeyStore = remember(context) { OpenAIApiKeyStore(context.applicationContext) }
     var apiKey by remember { mutableStateOf("") }
+    var openAIBaseUrl by remember { mutableStateOf("") }
     var isAuthWorking by remember { mutableStateOf(false) }
     var authError by remember { mutableStateOf<String?>(null) }
     var hasStoredApiKey by remember { mutableStateOf(apiKeyStore.hasStoredKey()) }
+    var hasStoredBaseUrl by remember { mutableStateOf(apiKeyStore.hasStoredBaseUrl()) }
     val authLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult(),
     ) { result ->
@@ -1380,6 +1382,7 @@ private fun AccountSection(server: uniffi.codex_mobile_client.AppServerSnapshot)
 
     androidx.compose.runtime.LaunchedEffect(server.serverId, server.account) {
         hasStoredApiKey = apiKeyStore.hasStoredKey()
+        hasStoredBaseUrl = apiKeyStore.hasStoredBaseUrl()
     }
 
     Column(
@@ -1411,6 +1414,14 @@ private fun AccountSection(server: uniffi.codex_mobile_client.AppServerSnapshot)
         if (server.isLocal && hasStoredApiKey) {
             Text(
                 "Local OpenAI API key is saved.",
+                color = LitterTheme.accent,
+                fontSize = 11.sp,
+            )
+        }
+
+        if (server.isLocal && hasStoredBaseUrl) {
+            Text(
+                "OpenAI-compatible base URL is saved.",
                 color = LitterTheme.accent,
                 fontSize = 11.sp,
             )
@@ -1500,6 +1511,84 @@ private fun AccountSection(server: uniffi.codex_mobile_client.AppServerSnapshot)
                     )
                 }
             }
+
+            Text(
+                if (hasStoredBaseUrl) {
+                    "Custom OpenAI-compatible endpoint saved for the local Codex server."
+                } else {
+                    "Optional OpenAI-compatible endpoint for local models."
+                },
+                color = LitterTheme.textSecondary,
+                fontSize = 11.sp,
+            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                BasicTextField(
+                    value = openAIBaseUrl,
+                    onValueChange = { openAIBaseUrl = it },
+                    textStyle = TextStyle(color = LitterTheme.textPrimary, fontSize = 13.sp),
+                    cursorBrush = SolidColor(LitterTheme.accent),
+                    modifier = Modifier.weight(1f).background(LitterTheme.codeBackground, RoundedCornerShape(6.dp)).padding(8.dp),
+                    decorationBox = { inner -> if (openAIBaseUrl.isEmpty()) Text("http://host:port/v1", color = LitterTheme.textMuted, fontSize = 13.sp); inner() },
+                )
+                Spacer(Modifier.width(8.dp))
+                TextButton(
+                    onClick = {
+                        val normalized = normalizeOpenAIBaseUrl(openAIBaseUrl)
+                        if (normalized == null) {
+                            authError = "Enter a valid http or https base URL."
+                        } else {
+                            scope.launch {
+                                isAuthWorking = true
+                                try {
+                                    apiKeyStore.saveBaseUrl(normalized)
+                                    appModel.restartLocalServer()
+                                    hasStoredBaseUrl = apiKeyStore.hasStoredBaseUrl()
+                                    if (hasStoredBaseUrl) {
+                                        openAIBaseUrl = ""
+                                        authError = null
+                                    } else {
+                                        authError = "Base URL did not persist locally."
+                                    }
+                                } catch (e: Exception) {
+                                    authError = e.message
+                                } finally {
+                                    isAuthWorking = false
+                                }
+                            }
+                        }
+                    },
+                    enabled = openAIBaseUrl.trim().isNotEmpty() && !isAuthWorking,
+                ) {
+                    Text(
+                        if (hasStoredBaseUrl) "Update" else "Save",
+                        color = LitterTheme.accent,
+                        fontSize = 12.sp,
+                    )
+                }
+            }
+            if (hasStoredBaseUrl) {
+                TextButton(
+                    onClick = {
+                        scope.launch {
+                            isAuthWorking = true
+                            try {
+                                apiKeyStore.clearBaseUrl()
+                                appModel.restartLocalServer()
+                                hasStoredBaseUrl = apiKeyStore.hasStoredBaseUrl()
+                                openAIBaseUrl = ""
+                                authError = null
+                            } catch (e: Exception) {
+                                authError = e.message
+                            } finally {
+                                isAuthWorking = false
+                            }
+                        }
+                    },
+                    enabled = !isAuthWorking,
+                ) {
+                    Text("Clear Base URL", color = LitterTheme.danger, fontSize = 12.sp)
+                }
+            }
         } else {
             Text(
                 "Remote servers request their own OAuth login when needed. Settings login and API key entry stay local-only.",
@@ -1510,6 +1599,16 @@ private fun AccountSection(server: uniffi.codex_mobile_client.AppServerSnapshot)
 
         authError?.let { Text(it, color = LitterTheme.danger, fontSize = 11.sp) }
     }
+}
+
+private fun normalizeOpenAIBaseUrl(rawValue: String): String? {
+    val trimmed = rawValue.trim().trimEnd('/')
+    if (trimmed.isEmpty()) return null
+    val uri = runCatching { java.net.URI(trimmed) }.getOrNull() ?: return null
+    val scheme = uri.scheme?.lowercase()
+    if (scheme != "http" && scheme != "https") return null
+    if (uri.host.isNullOrBlank()) return null
+    return trimmed
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/apps/ios/Sources/Litter/Models/OpenAIApiKeyStore.swift
+++ b/apps/ios/Sources/Litter/Models/OpenAIApiKeyStore.swift
@@ -5,8 +5,10 @@ final class OpenAIApiKeyStore {
     static let shared = OpenAIApiKeyStore()
 
     private let service = "com.sigkitten.litter.openai-api-key"
-    private let account = "default"
-    private let envKey = "OPENAI_API_KEY"
+    private let apiKeyAccount = "default"
+    private let baseURLAccount = "openai-base-url"
+    private let apiKeyEnvKey = "OPENAI_API_KEY"
+    private let baseURLEnvKey = "OPENAI_BASE_URL"
 
     private init() {}
 
@@ -14,8 +16,20 @@ final class OpenAIApiKeyStore {
         (try? load())?.isEmpty == false
     }
 
+    var hasStoredBaseURL: Bool {
+        (try? loadBaseURL())?.isEmpty == false
+    }
+
     func load() throws -> String? {
-        let query = baseQuery().merging([
+        try load(account: apiKeyAccount)
+    }
+
+    func loadBaseURL() throws -> String? {
+        try load(account: baseURLAccount)
+    }
+
+    private func load(account: String) throws -> String? {
+        let query = baseQuery(account: account).merging([
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne,
         ]) { _, new in new }
@@ -42,9 +56,19 @@ final class OpenAIApiKeyStore {
     }
 
     func save(_ key: String) throws {
-        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        try save(value: key, account: apiKeyAccount)
+        applyToEnvironment()
+    }
+
+    func saveBaseURL(_ baseURL: String) throws {
+        try save(value: baseURL, account: baseURLAccount)
+        applyToEnvironment()
+    }
+
+    private func save(value: String, account: String) throws {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         let data = Data(trimmed.utf8)
-        let attributes: [String: Any] = baseQuery().merging([
+        let attributes: [String: Any] = baseQuery(account: account).merging([
             kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
             kSecValueData as String: data,
         ]) { _, new in new }
@@ -55,7 +79,7 @@ final class OpenAIApiKeyStore {
                 kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
                 kSecValueData as String: data,
             ]
-            let updateStatus = SecItemUpdate(baseQuery() as CFDictionary, updates as CFDictionary)
+            let updateStatus = SecItemUpdate(baseQuery(account: account) as CFDictionary, updates as CFDictionary)
             guard updateStatus == errSecSuccess else {
                 throw NSError(
                     domain: NSOSStatusErrorDomain,
@@ -63,7 +87,6 @@ final class OpenAIApiKeyStore {
                     userInfo: [NSLocalizedDescriptionKey: "Keychain error (\(updateStatus))"]
                 )
             }
-            applyToEnvironment()
             return
         }
 
@@ -74,11 +97,20 @@ final class OpenAIApiKeyStore {
                 userInfo: [NSLocalizedDescriptionKey: "Keychain error (\(status))"]
             )
         }
-        applyToEnvironment()
     }
 
     func clear() throws {
-        let status = SecItemDelete(baseQuery() as CFDictionary)
+        try clear(account: apiKeyAccount)
+        unsetenv(apiKeyEnvKey)
+    }
+
+    func clearBaseURL() throws {
+        try clear(account: baseURLAccount)
+        unsetenv(baseURLEnvKey)
+    }
+
+    private func clear(account: String) throws {
+        let status = SecItemDelete(baseQuery(account: account) as CFDictionary)
         guard status == errSecSuccess || status == errSecItemNotFound else {
             throw NSError(
                 domain: NSOSStatusErrorDomain,
@@ -86,18 +118,23 @@ final class OpenAIApiKeyStore {
                 userInfo: [NSLocalizedDescriptionKey: "Keychain error (\(status))"]
             )
         }
-        unsetenv(envKey)
     }
 
     func applyToEnvironment() {
         if let key = (try? load()) ?? nil, !key.isEmpty {
-            setenv(envKey, key, 1)
+            setenv(apiKeyEnvKey, key, 1)
         } else {
-            unsetenv(envKey)
+            unsetenv(apiKeyEnvKey)
+        }
+
+        if let baseURL = (try? loadBaseURL()) ?? nil, !baseURL.isEmpty {
+            setenv(baseURLEnvKey, baseURL, 1)
+        } else {
+            unsetenv(baseURLEnvKey)
         }
     }
 
-    private func baseQuery() -> [String: Any] {
+    private func baseQuery(account: String) -> [String: Any] {
         [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,

--- a/apps/ios/Sources/Litter/Views/SettingsView.swift
+++ b/apps/ios/Sources/Litter/Views/SettingsView.swift
@@ -294,9 +294,11 @@ private struct SettingsConnectionAccountSection: View {
     @Environment(AppModel.self) private var appModel
     let server: AppServerSnapshot
     @State private var apiKey = ""
+    @State private var openAIBaseURL = ""
     @State private var isAuthWorking = false
     @State private var authError: String?
     @State private var hasStoredApiKey = OpenAIApiKeyStore.shared.hasStoredKey
+    @State private var hasStoredBaseURL = OpenAIApiKeyStore.shared.hasStoredBaseURL
     @State private var hasStoredChatGPTTokens = false
 
     var body: some View {
@@ -328,6 +330,13 @@ private struct SettingsConnectionAccountSection: View {
 
             if server.isLocal, hasStoredApiKey {
                 Text("Local OpenAI API key is saved.")
+                    .litterFont(.caption)
+                    .foregroundColor(LitterTheme.accent)
+                    .listRowBackground(LitterTheme.surface.opacity(0.6))
+            }
+
+            if server.isLocal, hasStoredBaseURL {
+                Text("OpenAI-compatible base URL is saved.")
                     .litterFont(.caption)
                     .foregroundColor(LitterTheme.accent)
                     .listRowBackground(LitterTheme.surface.opacity(0.6))
@@ -387,6 +396,52 @@ private struct SettingsConnectionAccountSection: View {
                     .litterFont(.caption)
                     .foregroundColor(LitterTheme.accent)
                     .disabled(apiKey.trimmingCharacters(in: .whitespaces).isEmpty || isAuthWorking)
+                }
+                .listRowBackground(LitterTheme.surface.opacity(0.6))
+
+                VStack(alignment: .leading, spacing: 8) {
+                    if hasStoredBaseURL {
+                        Text("Custom OpenAI-compatible endpoint saved for the local Codex server.")
+                            .litterFont(.caption)
+                            .foregroundColor(LitterTheme.textSecondary)
+                    } else {
+                        Text("Optional OpenAI-compatible endpoint for local models.")
+                            .litterFont(.caption)
+                            .foregroundColor(LitterTheme.textSecondary)
+                    }
+                    HStack(spacing: 8) {
+                        TextField("http://host:port/v1", text: $openAIBaseURL)
+                            .litterFont(.footnote)
+                            .foregroundColor(LitterTheme.textPrimary)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                            .keyboardType(.URL)
+                        Button {
+                            let baseURL = openAIBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+                            Task {
+                                isAuthWorking = true
+                                await saveBaseURL(baseURL)
+                                isAuthWorking = false
+                            }
+                        } label: {
+                            Text(hasStoredBaseURL ? "Update Base URL" : "Save Base URL")
+                        }
+                        .litterFont(.caption)
+                        .foregroundColor(LitterTheme.accent)
+                        .disabled(openAIBaseURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isAuthWorking)
+                    }
+                    if hasStoredBaseURL {
+                        Button("Clear Base URL") {
+                            Task {
+                                isAuthWorking = true
+                                await clearBaseURL()
+                                isAuthWorking = false
+                            }
+                        }
+                        .litterFont(.caption)
+                        .foregroundColor(LitterTheme.danger)
+                        .disabled(isAuthWorking)
+                    }
                 }
                 .listRowBackground(LitterTheme.surface.opacity(0.6))
             }
@@ -484,6 +539,7 @@ private struct SettingsConnectionAccountSection: View {
 
     private func refreshStoredCredentialFlags() {
         hasStoredApiKey = OpenAIApiKeyStore.shared.hasStoredKey
+        hasStoredBaseURL = OpenAIApiKeyStore.shared.hasStoredBaseURL
         do {
             hasStoredChatGPTTokens = try ChatGPTOAuthTokenStore.shared.load() != nil
         } catch let error as ChatGPTOAuthError where error.isTransientKeychainAvailabilityFailure {
@@ -534,6 +590,57 @@ private struct SettingsConnectionAccountSection: View {
         } catch {
             authError = error.localizedDescription
         }
+    }
+
+    private func saveBaseURL(_ rawBaseURL: String) async {
+        guard server.isLocal else {
+            authError = "Base URL can only be saved for the local server."
+            return
+        }
+        guard let baseURL = normalizedOpenAIBaseURL(rawBaseURL) else {
+            authError = "Enter a valid http or https base URL."
+            return
+        }
+        do {
+            authError = nil
+            try OpenAIApiKeyStore.shared.saveBaseURL(baseURL)
+            try await appModel.restartLocalServer()
+            refreshStoredCredentialFlags()
+            guard hasStoredBaseURL else {
+                authError = "Base URL did not persist locally."
+                return
+            }
+            openAIBaseURL = ""
+        } catch {
+            authError = error.localizedDescription
+        }
+    }
+
+    private func clearBaseURL() async {
+        guard server.isLocal else {
+            authError = "Base URL can only be cleared for the local server."
+            return
+        }
+        do {
+            authError = nil
+            try OpenAIApiKeyStore.shared.clearBaseURL()
+            try await appModel.restartLocalServer()
+            refreshStoredCredentialFlags()
+            openAIBaseURL = ""
+        } catch {
+            authError = error.localizedDescription
+        }
+    }
+
+    private func normalizedOpenAIBaseURL(_ rawValue: String) -> String? {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let url = URL(string: trimmed),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              url.host != nil else {
+            return nil
+        }
+        return trimmed.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
     }
 
     private func logout() async {

--- a/shared/rust-bridge/codex-mobile-client/src/local_server/mod.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/local_server/mod.rs
@@ -42,6 +42,7 @@ const READINESS_POLL_INTERVAL: Duration = Duration::from_millis(250);
 /// re-run `npm install @openai/codex@latest` on next spawn. Mirrors
 /// `CODEX_UPDATE_CHECK_INTERVAL_SECS` in `ssh.rs`.
 const MANAGED_CODEX_MAX_AGE_SECS: u64 = 24 * 60 * 60;
+const OPENAI_BASE_URL_ENV_KEY: &str = "OPENAI_BASE_URL";
 
 // ---------------------------------------------------------------------------
 // Shared path list
@@ -453,9 +454,16 @@ async fn spawn_local_server(
 ) -> Result<LocalServerHandle, LocalServerError> {
     let listen_url = format!("ws://127.0.0.1:{port}");
     let mut cmd = Command::new(codex_path);
-    cmd.arg("--enable")
-        .arg("goals")
-        .arg("app-server")
+    cmd.arg("--enable").arg("goals");
+
+    if let Some(base_url) = openai_base_url_from_env() {
+        cmd.arg("--config").arg(format!(
+            "openai_base_url={}",
+            toml_string_literal(&base_url)
+        ));
+    }
+
+    cmd.arg("app-server")
         .arg("--listen")
         .arg(&listen_url)
         .stdin(Stdio::null())
@@ -631,6 +639,39 @@ async fn install_codex_via_local_npm() -> Result<(), String> {
     Ok(())
 }
 
+fn openai_base_url_from_env() -> Option<String> {
+    std::env::var(OPENAI_BASE_URL_ENV_KEY)
+        .ok()
+        .map(|value| value.trim().trim_end_matches('/').to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn toml_string_literal(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len() + 2);
+    escaped.push('"');
+    for ch in value.chars() {
+        match ch {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            ch if ch.is_control() => {
+                use std::fmt::Write as _;
+                let codepoint = ch as u32;
+                if codepoint <= 0xFFFF {
+                    let _ = write!(escaped, "\\u{codepoint:04X}");
+                } else {
+                    let _ = write!(escaped, "\\U{codepoint:08X}");
+                }
+            }
+            ch => escaped.push(ch),
+        }
+    }
+    escaped.push('"');
+    escaped
+}
+
 // ---------------------------------------------------------------------------
 // Attach result
 // ---------------------------------------------------------------------------
@@ -677,6 +718,18 @@ mod tests {
         assert!(shell.contains(".local/bin/codex"));
         assert!(shell.contains("/opt/homebrew/bin/codex"));
         assert!(shell.contains("/usr/local/bin/codex"));
+    }
+
+    #[test]
+    fn toml_string_literal_escapes_base_url_value() {
+        assert_eq!(
+            toml_string_literal("http://localhost:11434/v1"),
+            "\"http://localhost:11434/v1\""
+        );
+        assert_eq!(
+            toml_string_literal("http://host/quote\"slash\\"),
+            "\"http://host/quote\\\"slash\\\\\""
+        );
     }
 
     #[tokio::test]

--- a/shared/rust-bridge/codex-mobile-client/src/session/connection.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/session/connection.rs
@@ -31,6 +31,7 @@ use crate::types::AgentRuntimeKind;
 
 const REMOTE_RECONNECT_MAX_ATTEMPTS: u32 = 5;
 const REMOTE_RECONNECT_DELAY: Duration = Duration::from_secs(1);
+const OPENAI_BASE_URL_ENV_KEY: &str = "OPENAI_BASE_URL";
 
 #[derive(Clone)]
 pub(crate) struct SshReconnectTransport {
@@ -50,6 +51,13 @@ fn append_android_debug_log(line: &str) {
         line.to_string(),
         None,
     );
+}
+
+fn openai_base_url_from_env() -> Option<String> {
+    std::env::var(OPENAI_BASE_URL_ENV_KEY)
+        .ok()
+        .map(|value| value.trim().trim_end_matches('/').to_string())
+        .filter(|value| !value.is_empty())
 }
 
 // ---------------------------------------------------------------------------
@@ -559,7 +567,7 @@ impl ServerSession {
             }
         }
 
-        let cli_overrides = vec![
+        let mut cli_overrides = vec![
             ("features.goals".to_string(), true.into()),
             ("features.realtime_conversation".to_string(), true.into()),
             (
@@ -572,6 +580,9 @@ impl ServerSession {
                 "conversational".to_string().into(),
             ),
         ];
+        if let Some(base_url) = openai_base_url_from_env() {
+            cli_overrides.push(("openai_base_url".to_string(), base_url.into()));
+        }
 
         let mut base_builder = ConfigBuilder::default().cli_overrides(cli_overrides.clone());
         if let Some(ref codex_home) = in_process.codex_home {
@@ -2146,6 +2157,34 @@ mod tests {
         assert_eq!(config.channel_capacity, 256);
         assert!(config.codex_home.is_none());
         assert!(config.working_directory.is_none());
+    }
+
+    #[test]
+    fn openai_base_url_from_env_trims_empty_and_trailing_slashes() {
+        let _guard = env_lock().lock().expect("env lock should not be poisoned");
+        let original = std::env::var_os(OPENAI_BASE_URL_ENV_KEY);
+
+        unsafe {
+            std::env::set_var(OPENAI_BASE_URL_ENV_KEY, " http://localhost:11434/v1/// ");
+        }
+        assert_eq!(
+            openai_base_url_from_env(),
+            Some("http://localhost:11434/v1".to_string())
+        );
+
+        unsafe {
+            std::env::set_var(OPENAI_BASE_URL_ENV_KEY, "   ");
+        }
+        assert_eq!(openai_base_url_from_env(), None);
+
+        match original {
+            Some(value) => unsafe {
+                std::env::set_var(OPENAI_BASE_URL_ENV_KEY, value);
+            },
+            None => unsafe {
+                std::env::remove_var(OPENAI_BASE_URL_ENV_KEY);
+            },
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a configurable OpenAI-compatible base URL alongside the existing API key setting on iOS and Android
- persist the base URL securely and expose it to the local Codex runtime via `OPENAI_BASE_URL`
- pass the configured URL into both local-server launch paths, including `codex app-server --config openai_base_url=...`
- make Mobile CI skip `sccache` when fork PRs do not have cache credentials

## Impact
Users can point Litter at a local or third-party OpenAI-compatible endpoint from settings without changing environment files. Fork PRs can also compile without failing on missing cache secrets.

## Validation
- `git diff --check`
- `cargo fmt --manifest-path shared/rust-bridge/Cargo.toml --package codex-mobile-client`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/mobile-ci.yml"); puts "yaml ok"'`

## Notes
Supersedes #113, which was closed because it was created as a draft and the connector could not mark it ready for review.

Focused Rust tests for the new base URL helpers were attempted, but the current checkout fails before running them due unrelated upstream/submodule API drift in `codex-mobile-client`. Android Kotlin compilation was also blocked locally by the shell JDK being older than the required JDK 17+ runtime.