### PR TITLE
feat(ios): add transcript display controls

### DIFF
--- a/apps/ios/Litter.xcodeproj/project.pbxproj
+++ b/apps/ios/Litter.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		1EA8B49CBF1C15347F3A221D /* ServerPillRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F98A952845B6690CEC61680E /* ServerPillRow.swift */; };
 		1FE369FFE3EBD593E13DF33F /* dark-plus-B1yOZ-Hy.json in Resources */ = {isa = PBXBuildFile; fileRef = 9A59EFF7219CFC315A13C34D /* dark-plus-B1yOZ-Hy.json */; };
 		200625E357DD536744735D21 /* AppsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD7A57CD59F1F3C8300A9ECE /* AppsListView.swift */; };
+		2069AFB53272955792833B7C /* ConversationDisplayUITestHarnessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6DD020815AD85C874D0DFEB /* ConversationDisplayUITestHarnessView.swift */; };
 		2079821AAFA0AB0D5D4E429C /* BerkeleyMono-Oblique.otf in Resources */ = {isa = PBXBuildFile; fileRef = ACD06DF72574CDDF16E1E41B /* BerkeleyMono-Oblique.otf */; };
 		20949942F84F8EFDAADF2F75 /* ComputerUseToolCallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A00D8BD24DF9E3C4F5EA2C /* ComputerUseToolCallView.swift */; };
 		20AB59324F9B55851C0D567D /* lobster-dark-dxSKfHK-.json in Resources */ = {isa = PBXBuildFile; fileRef = 64A9C3848F4142EF67DD23D3 /* lobster-dark-dxSKfHK-.json */; };
@@ -200,6 +201,7 @@
 		52C9C8C4692470EC7B2CC9E5 /* DynamicTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4874A6712A57F780064DB0E /* DynamicTools.swift */; };
 		5342E9DEE1FB318F01E27F7E /* ChatTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 125E05AE5CC346C8D2ED2FED /* ChatTypes.swift */; };
 		535331FCBDF1337FABF60189 /* SessionsTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F1AA9A960B33D4BF4DEA49 /* SessionsTypes.swift */; };
+		536D80B942E8F4E7A5C4D0C8 /* ConversationDisplayUITestHarnessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6DD020815AD85C874D0DFEB /* ConversationDisplayUITestHarnessView.swift */; };
 		5380A526444F33B701903335 /* MacCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DFE934B56ED67FA473EA25A /* MacCommands.swift */; };
 		559D9CFDF4AAC8C5E5FC4452 /* StreamingRendererCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ECDF838BCE5FEBFE5B80DCC /* StreamingRendererCoordinator.swift */; };
 		55C3EEE366FD3ABE9BCFA271 /* ConversationScreenModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91A1B7B1207FAD81D940DA8 /* ConversationScreenModel.swift */; };
@@ -1000,6 +1002,7 @@
 		F3474B8EA8D3148C94A7583F /* AppStatePermissionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatePermissionTests.swift; sourceTree = "<group>"; };
 		F503F51C28F35CF80376D9FD /* CloudKVSBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudKVSBridge.swift; sourceTree = "<group>"; };
 		F5CAE8D1301B5643D9510273 /* HomeAnchor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeAnchor.swift; sourceTree = "<group>"; };
+		F6DD020815AD85C874D0DFEB /* ConversationDisplayUITestHarnessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationDisplayUITestHarnessView.swift; sourceTree = "<group>"; };
 		F7B0CCBCA4896FF05C5CEDDC /* LitterWatchShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LitterWatchShortcuts.swift; sourceTree = "<group>"; };
 		F834CA5079226BE75FF8DC9E /* usgc-highk.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "usgc-highk.json"; sourceTree = "<group>"; };
 		F8A12810E0889BDD245C2379 /* VoiceCallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceCallView.swift; sourceTree = "<group>"; };
@@ -1471,6 +1474,7 @@
 				ED83627330437842851BBC07 /* ConversationComposerModalCoordinator.swift */,
 				25F1267B79425E5A42068216 /* ConversationComposerPopupOverlayView.swift */,
 				75F91259F006987853B6929F /* ConversationComposerTextView.swift */,
+				F6DD020815AD85C874D0DFEB /* ConversationDisplayUITestHarnessView.swift */,
 				73215C881883BBD745011412 /* ConversationInfoView.swift */,
 				BE81AFDF90E8ED46203AF90C /* ConversationOptionsSheet.swift */,
 				C91A1B7B1207FAD81D940DA8 /* ConversationScreenModel.swift */,
@@ -2113,6 +2117,7 @@
 				A6FF1F7811A4B6626BD440F5 /* ConversationComposerModalCoordinator.swift in Sources */,
 				F8FA54A11D223E760DD20173 /* ConversationComposerPopupOverlayView.swift in Sources */,
 				2B9DD5A54D6958BFE4369B38 /* ConversationComposerTextView.swift in Sources */,
+				536D80B942E8F4E7A5C4D0C8 /* ConversationDisplayUITestHarnessView.swift in Sources */,
 				F8591B754C9A672031DC87D4 /* ConversationInfoView.swift in Sources */,
 				E010B8AEEBFF38A28018121D /* ConversationItem.swift in Sources */,
 				B1A9E717B758EA0236262500 /* ConversationOptionsSheet.swift in Sources */,
@@ -2296,6 +2301,7 @@
 				150F9E7AC8934D8CB833123B /* ConversationComposerModalCoordinator.swift in Sources */,
 				EC0E8F1D7EEFB3766BF4F7C7 /* ConversationComposerPopupOverlayView.swift in Sources */,
 				D3E787742DD8E385535CD033 /* ConversationComposerTextView.swift in Sources */,
+				2069AFB53272955792833B7C /* ConversationDisplayUITestHarnessView.swift in Sources */,
 				4EE9B243F412CF5364E3FCA6 /* ConversationInfoView.swift in Sources */,
 				F6FB99D609C05B4F1DE81875 /* ConversationItem.swift in Sources */,
 				2130D006C3D67861E5488F0C /* ConversationOptionsSheet.swift in Sources */,

--- a/apps/ios/Litter.xcodeproj/project.pbxproj
+++ b/apps/ios/Litter.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		2D55E0EA12B02EB7072FBCC0 /* PetSpriteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FBFD15DB4FF368195848F2D /* PetSpriteView.swift */; };
 		2DBCCE766D2356AB34EA47CF /* brand_logo.png in Resources */ = {isa = PBXBuildFile; fileRef = 17BD69B0550C63596995AC18 /* brand_logo.png */; };
 		2E6FF89E7700C83B948A1976 /* WatchChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = E002B30249FFDB3567BD8326 /* WatchChrome.swift */; };
+		2F28DA245F84E87318A4D7E4 /* ConversationDisplayPreferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77969543FA36FEA8B621A3B9 /* ConversationDisplayPreferenceTests.swift */; };
 		2F94C28698B270EB04C00D65 /* BerkeleyMono-Oblique.otf in Resources */ = {isa = PBXBuildFile; fileRef = ACD06DF72574CDDF16E1E41B /* BerkeleyMono-Oblique.otf */; };
 		2FEF13A44B76BF75E18632B7 /* SessionReplySwipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0BEC32BA18EED58DFB1D9D7 /* SessionReplySwipe.swift */; };
 		308721608A70A7E679A1737C /* ToolCallModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB0858848FDF680B63C2432 /* ToolCallModels.swift */; };
@@ -829,6 +830,7 @@
 		7705BE9E4D681844D5FB6C20 /* RealtimeWebRtcSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeWebRtcSession.swift; sourceTree = "<group>"; };
 		7779BD02F3B304F9C3AD32A1 /* DiscoveredServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveredServer.swift; sourceTree = "<group>"; };
 		779157C60F55F38A05F3CD1A /* absolutely-dark.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "absolutely-dark.json"; sourceTree = "<group>"; };
+		77969543FA36FEA8B621A3B9 /* ConversationDisplayPreferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationDisplayPreferenceTests.swift; sourceTree = "<group>"; };
 		77D950991BD0F0199209EB68 /* ExperimentalFeaturesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentalFeaturesView.swift; sourceTree = "<group>"; };
 		77F28A803AA2BF325B0F88B9 /* ChatGPTOAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGPTOAuth.swift; sourceTree = "<group>"; };
 		78076308EEAAE64BC3BFDC1F /* AnimatedSplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedSplashView.swift; sourceTree = "<group>"; };
@@ -1085,6 +1087,7 @@
 				F3474B8EA8D3148C94A7583F /* AppStatePermissionTests.swift */,
 				33402D8F29D5CAA2DD07ED9F /* ChatGPTOAuthTests.swift */,
 				347FEEBE4E54174740D93E9D /* ConversationAttachmentSupportTests.swift */,
+				77969543FA36FEA8B621A3B9 /* ConversationDisplayPreferenceTests.swift */,
 				B0C1A0569B4424123A37B0DA /* ConversationPlanSemanticsTests.swift */,
 				B66383694E80CDCBCF582C67 /* ConversationScreenModelTests.swift */,
 				018779F7529B6CAAC3A2B896 /* HomeDashboardSupportTests.swift */,
@@ -2027,6 +2030,7 @@
 				620FC2343DCFADD1034E9CCB /* AppStatePermissionTests.swift in Sources */,
 				46C5F0B53F9EF54FE8F311A4 /* ChatGPTOAuthTests.swift in Sources */,
 				46B24CBC2FD5FD3799BE207D /* ConversationAttachmentSupportTests.swift in Sources */,
+				2F28DA245F84E87318A4D7E4 /* ConversationDisplayPreferenceTests.swift in Sources */,
 				9C44ABDBA2399DD2C0B1E9E2 /* ConversationPlanSemanticsTests.swift in Sources */,
 				F1535DE46C8E5A530A8C131E /* ConversationScreenModelTests.swift in Sources */,
 				6EF7AFD103A68CDEA1A94612 /* HomeDashboardSupportTests.swift in Sources */,

--- a/apps/ios/Sources/Litter/LitterApp.swift
+++ b/apps/ios/Sources/Litter/LitterApp.swift
@@ -414,51 +414,30 @@ struct ContentView: View {
             ZStack {
                 LitterTheme.backgroundGradient.ignoresSafeArea()
 
-                HomeNavigationView(
+                #if DEBUG
+                if ConversationDisplayUITestHarnessView.isEnabled {
+                    ConversationDisplayUITestHarnessView()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    standardHomeNavigationView(
+                        topInset: geometry.safeAreaInsets.top,
+                        bottomInset: composerBottomInset
+                    )
+                }
+                #else
+                standardHomeNavigationView(
                     topInset: geometry.safeAreaInsets.top,
                     bottomInset: composerBottomInset
                 )
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .ignoresSafeArea(.container, edges: [.top, .bottom])
-                .id(themeManager.themeVersion)
-                .onAppear {
-                    if !splashDismissed {
-                        splashDismissed = true
-                        (UIApplication.shared.delegate as? AppDelegate)?.signalContentReady()
-                    }
-                }
+                #endif
 
-                if petOverlay.visible, let pet = petOverlay.selectedPet {
-                    PetOverlayView(
-                        pet: pet,
-                        state: petOverlay.avatarState(snapshot: appModel.snapshot),
-                        message: petOverlay.avatarMessage(snapshot: appModel.snapshot),
-                        reduceMotion: UIAccessibility.isReduceMotionEnabled
-                    )
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                #if DEBUG
+                if !ConversationDisplayUITestHarnessView.isEnabled {
+                    standardOverlays
                 }
-
-                if let approval = appModel.snapshot?.pendingApprovals.first(where: {
-                    $0.kind != .mcpElicitation
-                }) {
-                    ApprovalPromptView(approval: approval) { decision in
-                        Task {
-                            try? await appModel.store.respondToApproval(
-                                requestId: approval.id,
-                                decision: decision
-                            )
-                        }
-                    } onViewThread: { threadKey in
-                        appState.pendingThreadNavigation = threadKey
-                    }
-                }
-
-                if let warmupID = conversationWarmup.activeWarmupID {
-                    ConversationWarmupView(warmupID: warmupID) {
-                        conversationWarmup.finishWarmup()
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                }
+                #else
+                standardOverlays
+                #endif
 
             }
             .ignoresSafeArea(.container)
@@ -551,6 +530,57 @@ struct ContentView: View {
             appState.showSettings = true
         }
         #endif
+    }
+
+    private func standardHomeNavigationView(topInset: CGFloat, bottomInset: CGFloat) -> some View {
+        HomeNavigationView(
+            topInset: topInset,
+            bottomInset: bottomInset
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .ignoresSafeArea(.container, edges: [.top, .bottom])
+        .id(themeManager.themeVersion)
+        .onAppear {
+            if !splashDismissed {
+                splashDismissed = true
+                (UIApplication.shared.delegate as? AppDelegate)?.signalContentReady()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var standardOverlays: some View {
+        if petOverlay.visible, let pet = petOverlay.selectedPet {
+            PetOverlayView(
+                pet: pet,
+                state: petOverlay.avatarState(snapshot: appModel.snapshot),
+                message: petOverlay.avatarMessage(snapshot: appModel.snapshot),
+                reduceMotion: UIAccessibility.isReduceMotionEnabled
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        }
+
+        if let approval = appModel.snapshot?.pendingApprovals.first(where: {
+            $0.kind != .mcpElicitation
+        }) {
+            ApprovalPromptView(approval: approval) { decision in
+                Task {
+                    try? await appModel.store.respondToApproval(
+                        requestId: approval.id,
+                        decision: decision
+                    )
+                }
+            } onViewThread: { threadKey in
+                appState.pendingThreadNavigation = threadKey
+            }
+        }
+
+        if let warmupID = conversationWarmup.activeWarmupID {
+            ConversationWarmupView(warmupID: warmupID) {
+                conversationWarmup.finishWarmup()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        }
     }
 }
 

--- a/apps/ios/Sources/Litter/Models/AppLifecycleController.swift
+++ b/apps/ios/Sources/Litter/Models/AppLifecycleController.swift
@@ -303,6 +303,12 @@ final class AppLifecycleController {
 
     func requestNotificationPermissionIfNeeded() {
         guard !notificationPermissionRequested else { return }
+        #if DEBUG
+        if ProcessInfo.processInfo.arguments.contains("--ui-test-conversation-display") {
+            notificationPermissionRequested = true
+            return
+        }
+        #endif
         notificationPermissionRequested = true
         LLog.info("push", "requesting notification permission")
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }

--- a/apps/ios/Sources/Litter/Models/ConversationItem.swift
+++ b/apps/ios/Sources/Litter/Models/ConversationItem.swift
@@ -389,6 +389,30 @@ struct ConversationItem: Identifiable, Equatable {
         return nil
     }
 
+    func isVisible(
+        reasoningDisplayMode: ConversationDetailDisplayMode,
+        commandDisplayMode: ConversationDetailDisplayMode,
+        toolDisplayMode: ConversationDetailDisplayMode
+    ) -> Bool {
+        switch content {
+        case .reasoning:
+            return reasoningDisplayMode.rendersRows
+        case .commandExecution:
+            return commandDisplayMode.rendersRows
+        case .fileChange,
+             .turnDiff,
+             .mcpToolCall,
+             .dynamicToolCall,
+             .multiAgentAction,
+             .webSearch,
+             .imageView,
+             .imageGeneration:
+            return toolDisplayMode.rendersRows
+        default:
+            return true
+        }
+    }
+
     mutating func refreshRenderDigest() {
         renderDigest = Self.computeRenderDigest(
             id: id,

--- a/apps/ios/Sources/Litter/Views/AgentRuntimePresentation.swift
+++ b/apps/ios/Sources/Litter/Views/AgentRuntimePresentation.swift
@@ -18,6 +18,11 @@ enum AgentRuntimeMetadataProvider {
 }
 
 extension AgentRuntimeKind {
+    static let claude: AgentRuntimeKind = "claude"
+    static let codex: AgentRuntimeKind = "codex"
+    static let droid: AgentRuntimeKind = "droid"
+    static let opencode: AgentRuntimeKind = "opencode"
+
     /// Presentation order surfaced by `AgentMetadataStore` (sorted by
     /// each agent's `presentation.sort_order` from the alleycat
     /// manifest). Empty when no probe has populated the cache yet —

--- a/apps/ios/Sources/Litter/Views/ConversationDisplayUITestHarnessView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationDisplayUITestHarnessView.swift
@@ -1,0 +1,163 @@
+import SwiftUI
+
+#if DEBUG
+struct ConversationDisplayUITestHarnessView: View {
+    @Environment(AppModel.self) private var appModel
+    @Environment(AppState.self) private var appState
+    @Environment(ThemeManager.self) private var themeManager
+    @AppStorage(ConversationDisplayPreferenceKey.reasoning) private var reasoningDisplayMode = ConversationDetailDisplayMode.collapsed.rawValue
+    @AppStorage(ConversationDisplayPreferenceKey.commands) private var commandDisplayMode = ConversationDetailDisplayMode.collapsed.rawValue
+    @AppStorage(ConversationDisplayPreferenceKey.tools) private var toolDisplayMode = ConversationDetailDisplayMode.collapsed.rawValue
+    @State private var showSettings = false
+
+    static var isEnabled: Bool {
+        ProcessInfo.processInfo.arguments.contains("--ui-test-conversation-display")
+    }
+
+    static var opensSettingsOnLaunch: Bool {
+        ProcessInfo.processInfo.arguments.contains("--ui-test-open-settings")
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text("Conversation Display Test")
+                        .litterFont(.title3, weight: .semibold)
+                        .foregroundColor(LitterTheme.textPrimary)
+                        .accessibilityIdentifier("conversationDisplayHarness.title")
+
+                    ConversationTurnTimeline(
+                        items: Self.seedItems,
+                        isLive: false,
+                        serverId: "ui-test-server",
+                        originThreadId: nil,
+                        agentDirectoryVersion: 0,
+                        messageActionsDisabled: true,
+                        onStreamingSnapshotRendered: nil,
+                        onLiveContentLayoutChanged: nil,
+                        resolveTargetLabel: { _ in nil },
+                        onWidgetPrompt: { _ in },
+                        onEditUserItem: { _ in },
+                        onForkFromUserItem: { _ in }
+                    )
+                    .accessibilityIdentifier("conversationDisplayHarness.timeline")
+                }
+                .padding(16)
+            }
+            .background(LitterTheme.backgroundGradient.ignoresSafeArea())
+            .navigationTitle("Display Harness")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        showSettings = true
+                    } label: {
+                        Image(systemName: "gearshape")
+                    }
+                    .accessibilityLabel("Settings")
+                    .accessibilityIdentifier("conversationDisplayHarness.settingsButton")
+                }
+            }
+        }
+        .sheet(isPresented: $showSettings) {
+            SettingsView()
+                .environment(appModel)
+                .environment(appState)
+                .environment(themeManager)
+        }
+        .onAppear {
+            applyLaunchDisplayModes()
+            if Self.opensSettingsOnLaunch {
+                DispatchQueue.main.async {
+                    showSettings = true
+                }
+            }
+            (UIApplication.shared.delegate as? AppDelegate)?.signalContentReady()
+        }
+    }
+
+    private func applyLaunchDisplayModes() {
+        let environment = ProcessInfo.processInfo.environment
+        reasoningDisplayMode = validatedMode(environment["CODEXIOS_UI_TEST_REASONING_MODE"])
+        commandDisplayMode = validatedMode(environment["CODEXIOS_UI_TEST_COMMAND_MODE"])
+        toolDisplayMode = validatedMode(environment["CODEXIOS_UI_TEST_TOOL_MODE"])
+    }
+
+    private func validatedMode(_ rawValue: String?) -> String {
+        guard let rawValue,
+              ConversationDetailDisplayMode(rawValue: rawValue) != nil else {
+            return ConversationDetailDisplayMode.collapsed.rawValue
+        }
+        return rawValue
+    }
+
+    private static let seedItems: [ConversationItem] = [
+        ConversationItem(
+            id: "ui-test-user",
+            content: .user(ConversationUserMessageData(
+                text: "UITEST_USER_MESSAGE",
+                images: []
+            ))
+        ),
+        ConversationItem(
+            id: "ui-test-assistant",
+            content: .assistant(ConversationAssistantMessageData(
+                text: "UITEST_ASSISTANT_MESSAGE",
+                agentNickname: nil,
+                agentRole: nil,
+                phase: nil
+            ))
+        ),
+        ConversationItem(
+            id: "ui-test-reasoning",
+            content: .reasoning(ConversationReasoningData(
+                summary: ["UITEST_REASONING_DETAIL"],
+                content: []
+            ))
+        ),
+        ConversationItem(
+            id: "ui-test-command",
+            content: .commandExecution(ConversationCommandExecutionData(
+                command: "printf UITEST_COMMAND_HEADER",
+                cwd: "/tmp",
+                status: .completed,
+                output: "UITEST_COMMAND_OUTPUT",
+                exitCode: 0,
+                durationMs: 25,
+                processId: nil,
+                actions: []
+            ))
+        ),
+        ConversationItem(
+            id: "ui-test-tool",
+            content: .mcpToolCall(ConversationMcpToolCallData(
+                server: "uiTest",
+                tool: "fixtureTool",
+                status: .completed,
+                durationMs: 30,
+                argumentsJSON: "{\"fixture\":\"UITEST_TOOL_ARGUMENT\"}",
+                contentSummary: "UITEST_TOOL_DETAIL",
+                structuredContentJSON: nil,
+                rawOutputJSON: nil,
+                errorMessage: nil,
+                progressMessages: [],
+                computerUse: nil
+            ))
+        ),
+        ConversationItem(
+            id: "ui-test-live-command",
+            content: .commandExecution(ConversationCommandExecutionData(
+                command: "sleep 10 && echo UITEST_LIVE_COMMAND_HEADER",
+                cwd: "/tmp",
+                status: .inProgress,
+                output: "UITEST_LIVE_COMMAND_OUTPUT",
+                exitCode: nil,
+                durationMs: nil,
+                processId: nil,
+                actions: []
+            ))
+        )
+    ]
+}
+#endif

--- a/apps/ios/Sources/Litter/Views/ConversationTimelineView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationTimelineView.swift
@@ -22,6 +22,10 @@ enum ConversationLiveDetailRetentionPolicy {
 }
 
 struct ConversationTurnTimeline: View {
+    @AppStorage(ConversationDisplayPreferenceKey.reasoning) private var reasoningDisplayModeRaw = ConversationDetailDisplayMode.collapsed.rawValue
+    @AppStorage(ConversationDisplayPreferenceKey.commands) private var commandDisplayModeRaw = ConversationDetailDisplayMode.collapsed.rawValue
+    @AppStorage(ConversationDisplayPreferenceKey.tools) private var toolDisplayModeRaw = ConversationDetailDisplayMode.collapsed.rawValue
+
     let items: [ConversationItem]
     let isLive: Bool
     let serverId: String
@@ -43,6 +47,7 @@ struct ConversationTurnTimeline: View {
     private var timelineContent: some View {
         let rows = rowDescriptors
         let retainedRichDetailItemIDs = ConversationLiveDetailRetentionPolicy.retainedRichDetailItemIDs(for: items)
+        let commandDisplayMode = ConversationDetailDisplayMode.resolve(commandDisplayModeRaw)
         let latestCommandExecutionItemId = rows.reversed().compactMap { row -> String? in
             guard case .item(let item) = row,
                   case .commandExecution(let data) = item.content,
@@ -56,7 +61,8 @@ struct ConversationTurnTimeline: View {
                     row,
                     isLastRow: index == rows.indices.last,
                     isPreferredExpandedCommandRow: row.preferredExpandedCommandRow(
-                        latestCommandExecutionItemId: latestCommandExecutionItemId
+                        latestCommandExecutionItemId: latestCommandExecutionItemId,
+                        commandDisplayMode: commandDisplayMode
                     ),
                     retainedRichDetailItemIDs: retainedRichDetailItemIDs
                 )
@@ -76,11 +82,30 @@ struct ConversationTurnTimeline: View {
         ConversationTimelineRowDescriptor.mergeConsecutiveExplorationRows(
             ConversationTimelineRowDescriptor.build(from: items)
         )
+        .filter {
+            $0.isVisible(
+                reasoningDisplayMode: reasoningDisplayMode,
+                commandDisplayMode: commandDisplayMode,
+                toolDisplayMode: toolDisplayMode
+            )
+        }
     }
 
     private var streamingAssistantItemId: String? {
         guard isLive else { return nil }
         return items.last(where: \.isAssistantItem)?.id
+    }
+
+    private var reasoningDisplayMode: ConversationDetailDisplayMode {
+        ConversationDetailDisplayMode.resolve(reasoningDisplayModeRaw)
+    }
+
+    private var commandDisplayMode: ConversationDetailDisplayMode {
+        ConversationDetailDisplayMode.resolve(commandDisplayModeRaw)
+    }
+
+    private var toolDisplayMode: ConversationDetailDisplayMode {
+        ConversationDetailDisplayMode.resolve(toolDisplayModeRaw)
     }
 
     // Returns AnyView rather than `some View` with @ViewBuilder so the result
@@ -106,6 +131,9 @@ struct ConversationTurnTimeline: View {
                     isLiveTurn: isLive,
                     isStreamingMessage: item.id == streamingAssistantItemId,
                     shouldPreserveRichDetail: retainedRichDetailItemIDs.contains(item.id),
+                    reasoningDisplayMode: reasoningDisplayMode,
+                    commandDisplayMode: commandDisplayMode,
+                    toolDisplayMode: toolDisplayMode,
                     messageActionsDisabled: messageActionsDisabled,
                     onStreamingSnapshotRendered: item.id == streamingAssistantItemId ? onStreamingSnapshotRendered : nil,
                     onLiveContentLayoutChanged: onLiveContentLayoutChanged,
@@ -122,7 +150,8 @@ struct ConversationTurnTimeline: View {
                 ConversationExplorationGroupRow(
                     id: id,
                     items: items,
-                    showsCollapsedPreview: isLastRow
+                    showsCollapsedPreview: isLastRow,
+                    displayMode: commandDisplayMode
                 )
             )
         case .subagentGroup(_, let merged, _):
@@ -157,13 +186,38 @@ private enum ConversationTimelineRowDescriptor: Identifiable, Equatable {
         return item.isAssistantItem
     }
 
-    func preferredExpandedCommandRow(latestCommandExecutionItemId: String?) -> Bool {
+    func preferredExpandedCommandRow(
+        latestCommandExecutionItemId: String?,
+        commandDisplayMode: ConversationDetailDisplayMode
+    ) -> Bool {
+        guard commandDisplayMode == .collapsed else {
+            return commandDisplayMode == .expanded
+        }
         guard case .item(let item) = self,
               case .commandExecution(let data) = item.content,
               !data.isPureExploration else {
             return false
         }
         return item.id == latestCommandExecutionItemId
+    }
+
+    func isVisible(
+        reasoningDisplayMode: ConversationDetailDisplayMode,
+        commandDisplayMode: ConversationDetailDisplayMode,
+        toolDisplayMode: ConversationDetailDisplayMode
+    ) -> Bool {
+        switch self {
+        case .item(let item):
+            return item.isVisible(
+                reasoningDisplayMode: reasoningDisplayMode,
+                commandDisplayMode: commandDisplayMode,
+                toolDisplayMode: toolDisplayMode
+            )
+        case .exploration:
+            return commandDisplayMode.rendersRows
+        case .subagentGroup:
+            return toolDisplayMode.rendersRows
+        }
     }
 
     static func build(from items: [ConversationItem]) -> [ConversationTimelineRowDescriptor] {
@@ -377,6 +431,9 @@ private struct ConversationTimelineItemRow: View, Equatable {
     let isLiveTurn: Bool
     let isStreamingMessage: Bool
     let shouldPreserveRichDetail: Bool
+    let reasoningDisplayMode: ConversationDetailDisplayMode
+    let commandDisplayMode: ConversationDetailDisplayMode
+    let toolDisplayMode: ConversationDetailDisplayMode
     let messageActionsDisabled: Bool
     let onStreamingSnapshotRendered: (() -> Void)?
     let onLiveContentLayoutChanged: (() -> Void)?
@@ -403,6 +460,9 @@ private struct ConversationTimelineItemRow: View, Equatable {
             lhs.agentDirectoryVersion == rhs.agentDirectoryVersion &&
             lhs.isPreferredExpandedCommandRow == rhs.isPreferredExpandedCommandRow &&
             lhs.isLiveTurn == rhs.isLiveTurn &&
+            lhs.reasoningDisplayMode == rhs.reasoningDisplayMode &&
+            lhs.commandDisplayMode == rhs.commandDisplayMode &&
+            lhs.toolDisplayMode == rhs.toolDisplayMode &&
             lhs.messageActionsDisabled == rhs.messageActionsDisabled
         return result
     }
@@ -420,36 +480,43 @@ private struct ConversationTimelineItemRow: View, Equatable {
         case .codeReview(let data):
             return AnyView(ConversationCodeReviewRow(data: data))
         case .reasoning(let data):
-            return AnyView(ConversationReasoningRow(data: data))
+            guard reasoningDisplayMode.rendersRows else { return AnyView(EmptyView()) }
+            return AnyView(ConversationReasoningRow(data: data, displayMode: reasoningDisplayMode))
         case .todoList(let data):
             return AnyView(ConversationTodoListRow(data: data))
         case .proposedPlan(let data):
             return AnyView(ConversationProposedPlanRow(data: data))
         case .commandExecution(let data):
+            guard commandDisplayMode.rendersRows else { return AnyView(EmptyView()) }
             return AnyView(commandExecutionRow(data))
         case .fileChange(let data):
+            guard toolDisplayMode.rendersRows else { return AnyView(EmptyView()) }
             return AnyView(toolCallRow(makeFileChangeModel(data)))
         case .turnDiff(let data):
+            guard toolDisplayMode.rendersRows else { return AnyView(EmptyView()) }
             return AnyView(ConversationTurnDiffRow(data: data))
         case .mcpToolCall(let data):
+            guard toolDisplayMode.rendersRows else { return AnyView(EmptyView()) }
             if let view = data.computerUse {
                 return AnyView(
                     ComputerUseToolCallView(
                         data: data,
                         view: view,
-                        externalExpanded: !isLiveTurn && shouldPreserveRichDetail
+                        externalExpanded: toolDefaultExpanded(isFailed: data.status == .failed)
                     )
                 )
             } else {
                 return AnyView(toolCallRow(makeMcpModel(data)))
             }
         case .dynamicToolCall(let data):
+            guard toolDisplayMode.rendersRows else { return AnyView(EmptyView()) }
             if CrossServerTools.isRichTool(data.tool) {
                 return AnyView(CrossServerToolResultView(data: data))
             } else {
                 return AnyView(toolCallRow(makeDynamicToolModel(data)))
             }
         case .multiAgentAction(let data):
+            guard toolDisplayMode.rendersRows else { return AnyView(EmptyView()) }
             return AnyView(
                 SubagentCardView(
                     data: data,
@@ -457,14 +524,17 @@ private struct ConversationTimelineItemRow: View, Equatable {
                 )
             )
         case .webSearch(let data):
+            guard toolDisplayMode.rendersRows else { return AnyView(EmptyView()) }
             return AnyView(toolCallRow(makeWebSearchModel(data)))
         case .imageView(let data):
+            guard toolDisplayMode.rendersRows else { return AnyView(EmptyView()) }
             return AnyView(toolCallRow(makeImageViewModel(data)))
         case .imageGeneration(let data):
+            guard toolDisplayMode.rendersRows else { return AnyView(EmptyView()) }
             return AnyView(
                 ImageGenerationToolCallView(
                     data: data,
-                    externalExpanded: !isLiveTurn && shouldPreserveRichDetail
+                    externalExpanded: toolDefaultExpanded(isFailed: data.status == .failed)
                 )
             )
         case .widget(let data):
@@ -504,9 +574,8 @@ private struct ConversationTimelineItemRow: View, Equatable {
     private func commandExecutionRow(_ data: ConversationCommandExecutionData) -> some View {
         ConversationCommandExecutionRow(
             data: data,
-            isPreferredExpanded: isPreferredExpandedCommandRow
-                || data.isInProgress
-                || (!isLiveTurn && shouldPreserveRichDetail)
+            isPreferredExpanded: commandDefaultExpanded(data),
+            displayMode: commandDisplayMode
         )
     }
 
@@ -515,8 +584,28 @@ private struct ConversationTimelineItemRow: View, Equatable {
         ToolCallCardView(
             model: model,
             serverId: serverId,
-            externalExpanded: !isLiveTurn && shouldPreserveRichDetail
+            externalExpanded: toolDefaultExpanded(isFailed: model.status == .failed)
         )
+    }
+
+    private func toolDefaultExpanded(isFailed: Bool) -> Bool {
+        if toolDisplayMode == .collapsed,
+           !isLiveTurn,
+           shouldPreserveRichDetail {
+            return true
+        }
+        return toolDisplayMode.defaultExpanded(isFailed: isFailed)
+    }
+
+    private func commandDefaultExpanded(_ data: ConversationCommandExecutionData) -> Bool {
+        switch commandDisplayMode {
+        case .expanded:
+            return true
+        case .collapsed:
+            return data.isInProgress || data.status == .failed
+        case .hidden:
+            return false
+        }
     }
 
     private func userRow(_ data: ConversationUserMessageData) -> some View {
@@ -794,6 +883,7 @@ private struct ConversationExplorationGroupRow: View {
     let id: String
     let items: [ConversationItem]
     let showsCollapsedPreview: Bool
+    let displayMode: ConversationDetailDisplayMode
 
     @State private var expanded = false
 
@@ -884,6 +974,9 @@ private struct ConversationExplorationGroupRow: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
+        .opacity(displayMode.rendersRows ? 1 : 0)
+        .frame(height: displayMode.rendersRows ? nil : 0)
+        .clipped()
         .onChange(of: showsCollapsedPreview) { _, newValue in
             guard !newValue else { return }
             expanded = false
@@ -1057,16 +1150,57 @@ private struct ExplorationDisplayEntry: Identifiable {
 
 private struct ConversationReasoningRow: View {
     let data: ConversationReasoningData
+    let displayMode: ConversationDetailDisplayMode
+
+    @State private var expanded: Bool
+
+    init(data: ConversationReasoningData, displayMode: ConversationDetailDisplayMode) {
+        self.data = data
+        self.displayMode = displayMode
+        _expanded = State(initialValue: displayMode.defaultExpanded())
+    }
 
     var body: some View {
-        HStack(alignment: .top, spacing: 0) {
-            Text(reasoningText)
-                .litterFont(.footnote)
-                .italic()
-                .foregroundColor(LitterTheme.textSecondary)
-                .textSelection(.enabled)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            Spacer(minLength: 20)
+        VStack(alignment: .leading, spacing: expanded ? 8 : 0) {
+            Button(action: toggleExpanded) {
+                HStack(spacing: 8) {
+                    Image(systemName: "brain.head.profile")
+                        .litterFont(size: 12, weight: .semibold)
+                        .foregroundColor(LitterTheme.textSecondary)
+                    Text("Thinking")
+                        .litterFont(.caption, weight: .semibold)
+                        .foregroundColor(LitterTheme.textSecondary)
+                    if !expanded {
+                        Text(collapsedSummary)
+                            .litterFont(.caption)
+                            .italic()
+                            .foregroundColor(LitterTheme.textMuted)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                    Spacer(minLength: 8)
+                    Image(systemName: expanded ? "chevron.up" : "chevron.down")
+                        .litterFont(size: 11, weight: .medium)
+                        .foregroundColor(LitterTheme.textMuted)
+                }
+            }
+            .buttonStyle(.plain)
+
+            if expanded {
+                Text(reasoningText)
+                    .litterFont(.footnote)
+                    .italic()
+                    .foregroundColor(LitterTheme.textSecondary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .transition(.sectionReveal)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 7)
+        .animation(.spring(duration: 0.32, bounce: 0.12), value: expanded)
+        .onChange(of: displayMode) { _, newValue in
+            expanded = newValue.defaultExpanded()
         }
     }
 
@@ -1074,6 +1208,20 @@ private struct ConversationReasoningRow: View {
         (data.summary + data.content)
             .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
             .joined(separator: "\n\n")
+    }
+
+    private var collapsedSummary: String {
+        let collapsed = reasoningText
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return collapsed.isEmpty ? "Internal reasoning" : collapsed
+    }
+
+    private func toggleExpanded() {
+        withAnimation(.easeInOut(duration: 0.2)) {
+            expanded.toggle()
+        }
     }
 }
 
@@ -1263,12 +1411,18 @@ private struct ConversationTurnDiffRow: View {
 private struct ConversationCommandExecutionRow: View {
     let data: ConversationCommandExecutionData
     let isPreferredExpanded: Bool
+    let displayMode: ConversationDetailDisplayMode
 
     @State private var expanded: Bool
 
-    init(data: ConversationCommandExecutionData, isPreferredExpanded: Bool) {
+    init(
+        data: ConversationCommandExecutionData,
+        isPreferredExpanded: Bool,
+        displayMode: ConversationDetailDisplayMode
+    ) {
         self.data = data
         self.isPreferredExpanded = isPreferredExpanded
+        self.displayMode = displayMode
         _expanded = State(initialValue: isPreferredExpanded)
     }
 
@@ -1294,6 +1448,9 @@ private struct ConversationCommandExecutionRow: View {
         .animation(.spring(duration: 0.35, bounce: 0.15), value: expanded)
         .onChange(of: isPreferredExpanded) { _, newValue in
             expanded = newValue
+        }
+        .onChange(of: displayMode) { _, newValue in
+            expanded = newValue == .expanded || data.isInProgress || data.status == .failed
         }
     }
 

--- a/apps/ios/Sources/Litter/Views/ConversationTimelineView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationTimelineView.swift
@@ -1173,7 +1173,6 @@ private struct ConversationReasoningRow: View {
                     if !expanded {
                         Text(collapsedSummary)
                             .litterFont(.caption)
-                            .italic()
                             .foregroundColor(LitterTheme.textMuted)
                             .lineLimit(1)
                             .truncationMode(.tail)
@@ -1211,11 +1210,10 @@ private struct ConversationReasoningRow: View {
     }
 
     private var collapsedSummary: String {
-        let collapsed = reasoningText
-            .replacingOccurrences(of: "\n", with: " ")
-            .replacingOccurrences(of: "\r", with: " ")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return collapsed.isEmpty ? "Internal reasoning" : collapsed
+        let itemCount = (data.summary + data.content).filter {
+            !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }.count
+        return itemCount == 1 ? "Internal reasoning" : "\(itemCount) reasoning notes"
     }
 
     private func toggleExpanded() {

--- a/apps/ios/Sources/Litter/Views/SettingsView.swift
+++ b/apps/ios/Sources/Litter/Views/SettingsView.swift
@@ -7,6 +7,9 @@ struct SettingsView: View {
     @Environment(\.textScale) private var textScale
     @AppStorage("fontFamily") private var fontFamily = FontFamilyOption.mono.rawValue
     @AppStorage("collapseTurns") private var collapseTurns = false
+    @AppStorage(ConversationDisplayPreferenceKey.reasoning) private var reasoningDisplayMode = ConversationDetailDisplayMode.collapsed.rawValue
+    @AppStorage(ConversationDisplayPreferenceKey.commands) private var commandDisplayMode = ConversationDetailDisplayMode.collapsed.rawValue
+    @AppStorage(ConversationDisplayPreferenceKey.tools) private var toolDisplayMode = ConversationDetailDisplayMode.collapsed.rawValue
     @State private var showAddServer = false
 
     private var localServer: AppServerSnapshot? {
@@ -104,10 +107,61 @@ struct SettingsView: View {
             }
             .tint(LitterTheme.accent)
             .listRowBackground(LitterTheme.surface.opacity(0.6))
+
+            transcriptDisplayPicker(
+                title: "Internal Thinking",
+                subtitle: "Reasoning and analysis blocks",
+                systemImage: "brain.head.profile",
+                selection: $reasoningDisplayMode
+            )
+
+            transcriptDisplayPicker(
+                title: "Commands",
+                subtitle: "Shell commands and command output",
+                systemImage: "terminal",
+                selection: $commandDisplayMode
+            )
+
+            transcriptDisplayPicker(
+                title: "Tools",
+                subtitle: "MCP, web, image, and file-change cards",
+                systemImage: "wrench.and.screwdriver",
+                selection: $toolDisplayMode
+            )
         } header: {
             Text("Conversation")
                 .foregroundColor(LitterTheme.textSecondary)
         }
+    }
+
+    private func transcriptDisplayPicker(
+        title: String,
+        subtitle: String,
+        systemImage: String,
+        selection: Binding<String>
+    ) -> some View {
+        Picker(selection: selection) {
+            ForEach(ConversationDetailDisplayMode.allCases) { mode in
+                Text(mode.displayName).tag(mode.rawValue)
+            }
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: systemImage)
+                    .foregroundColor(LitterTheme.accent)
+                    .frame(width: 20)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .litterFont(.subheadline)
+                        .foregroundColor(LitterTheme.textPrimary)
+                    Text(subtitle)
+                        .litterFont(.caption)
+                        .foregroundColor(LitterTheme.textSecondary)
+                }
+            }
+        }
+        .pickerStyle(.menu)
+        .tint(LitterTheme.accent)
+        .listRowBackground(LitterTheme.surface.opacity(0.6))
     }
 
     // MARK: - Font Section

--- a/apps/ios/Sources/Litter/Views/ToolCallModels.swift
+++ b/apps/ios/Sources/Litter/Views/ToolCallModels.swift
@@ -1,5 +1,52 @@
 import Foundation
 
+enum ConversationDetailDisplayMode: String, CaseIterable, Identifiable, Equatable {
+    case expanded
+    case collapsed
+    case hidden
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .expanded: return "Show"
+        case .collapsed: return "Collapse"
+        case .hidden: return "Hide"
+        }
+    }
+
+    var detailText: String {
+        switch self {
+        case .expanded: return "Details are open by default"
+        case .collapsed: return "Details stay behind a disclosure"
+        case .hidden: return "Details are removed from the transcript"
+        }
+    }
+
+    var rendersRows: Bool { self != .hidden }
+
+    static func resolve(_ rawValue: String) -> ConversationDetailDisplayMode {
+        ConversationDetailDisplayMode(rawValue: rawValue) ?? .collapsed
+    }
+
+    func defaultExpanded(isFailed: Bool = false) -> Bool {
+        switch self {
+        case .expanded:
+            return true
+        case .collapsed:
+            return isFailed
+        case .hidden:
+            return false
+        }
+    }
+}
+
+enum ConversationDisplayPreferenceKey {
+    static let reasoning = "conversationReasoningDisplayMode"
+    static let commands = "conversationCommandDisplayMode"
+    static let tools = "conversationToolDisplayMode"
+}
+
 enum ToolCallKind: String, Equatable {
     case commandExecution
     case commandOutput

--- a/apps/ios/Tests/LitterTests/ConversationDisplayPreferenceTests.swift
+++ b/apps/ios/Tests/LitterTests/ConversationDisplayPreferenceTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import Litter
+
+final class ConversationDisplayPreferenceTests: XCTestCase {
+    func testDisplayModeResolvesUnknownValuesToCollapsed() {
+        XCTAssertEqual(ConversationDetailDisplayMode.resolve("expanded"), .expanded)
+        XCTAssertEqual(ConversationDetailDisplayMode.resolve("hidden"), .hidden)
+        XCTAssertEqual(ConversationDetailDisplayMode.resolve("not-a-mode"), .collapsed)
+    }
+
+    func testCollapsedModeOnlyExpandsFailuresByDefault() {
+        XCTAssertTrue(ConversationDetailDisplayMode.expanded.defaultExpanded())
+        XCTAssertFalse(ConversationDetailDisplayMode.collapsed.defaultExpanded())
+        XCTAssertTrue(ConversationDetailDisplayMode.collapsed.defaultExpanded(isFailed: true))
+        XCTAssertFalse(ConversationDetailDisplayMode.hidden.defaultExpanded(isFailed: true))
+    }
+
+    func testConversationItemsHonorHiddenDetailModes() {
+        let reasoning = ConversationItem(
+            id: "reasoning",
+            content: .reasoning(ConversationReasoningData(summary: ["thinking"], content: []))
+        )
+        let command = ConversationItem(
+            id: "command",
+            content: .commandExecution(
+                ConversationCommandExecutionData(
+                    command: "echo hi",
+                    cwd: "",
+                    status: .completed,
+                    output: "hi",
+                    exitCode: 0,
+                    durationMs: nil,
+                    processId: nil,
+                    actions: []
+                )
+            )
+        )
+        let assistant = ConversationItem(
+            id: "assistant",
+            content: .assistant(
+                ConversationAssistantMessageData(
+                    text: "Done",
+                    agentNickname: nil,
+                    agentRole: nil,
+                    phase: nil
+                )
+            )
+        )
+
+        XCTAssertFalse(reasoning.isVisible(
+            reasoningDisplayMode: .hidden,
+            commandDisplayMode: .collapsed,
+            toolDisplayMode: .collapsed
+        ))
+        XCTAssertFalse(command.isVisible(
+            reasoningDisplayMode: .collapsed,
+            commandDisplayMode: .hidden,
+            toolDisplayMode: .collapsed
+        ))
+        XCTAssertTrue(assistant.isVisible(
+            reasoningDisplayMode: .hidden,
+            commandDisplayMode: .hidden,
+            toolDisplayMode: .hidden
+        ))
+    }
+}

--- a/apps/ios/Tests/LitterUITests/LitterUITests.swift
+++ b/apps/ios/Tests/LitterUITests/LitterUITests.swift
@@ -6,6 +6,69 @@ final class LitterUITests: XCTestCase {
     }
 
     @MainActor
+    func testConversationDisplaySettingsRowsAreReachable() throws {
+        let app = conversationDisplayHarnessApp()
+        app.launch()
+
+        XCTAssertTrue(
+            app.staticTexts["conversationDisplayHarness.title"].waitForExistence(timeout: 10),
+            "Conversation display harness did not launch"
+        )
+
+        app.buttons["conversationDisplayHarness.settingsButton"].tap()
+        XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Conversation"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Internal Thinking"].exists)
+        XCTAssertTrue(app.staticTexts["Commands"].exists)
+        XCTAssertTrue(findStaticText("Tools", in: app))
+    }
+
+    @MainActor
+    func testConversationDisplayExpandedModeShowsAllDetails() throws {
+        let app = conversationDisplayHarnessApp(reasoning: "expanded", commands: "expanded", tools: "expanded")
+        app.launch()
+
+        XCTAssertTrue(app.staticTexts["UITEST_USER_MESSAGE"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["UITEST_ASSISTANT_MESSAGE"].exists)
+        XCTAssertTrue(app.staticTexts["UITEST_REASONING_DETAIL"].exists)
+        XCTAssertTrue(app.staticTexts["UITEST_COMMAND_OUTPUT"].exists)
+        XCTAssertTrue(app.staticTexts["UITEST_TOOL_DETAIL"].exists)
+    }
+
+    @MainActor
+    func testConversationDisplayCollapsedModeKeepsRowsAndRetainsRecentDetails() throws {
+        let app = conversationDisplayHarnessApp(reasoning: "collapsed", commands: "collapsed", tools: "collapsed")
+        app.launch()
+
+        XCTAssertTrue(app.staticTexts["UITEST_USER_MESSAGE"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["UITEST_ASSISTANT_MESSAGE"].exists)
+        XCTAssertTrue(app.staticTexts["Thinking"].exists)
+        XCTAssertTrue(app.staticTexts["Internal reasoning"].exists)
+        XCTAssertTrue(app.staticTexts["printf UITEST_COMMAND_HEADER"].exists)
+        XCTAssertTrue(app.staticTexts["uiTest.fixtureTool"].exists)
+        XCTAssertFalse(app.staticTexts["UITEST_REASONING_DETAIL"].exists)
+        XCTAssertFalse(app.staticTexts["UITEST_COMMAND_OUTPUT"].exists)
+        XCTAssertTrue(app.staticTexts["UITEST_TOOL_DETAIL"].exists)
+        XCTAssertTrue(app.staticTexts["UITEST_LIVE_COMMAND_OUTPUT"].exists)
+    }
+
+    @MainActor
+    func testConversationDisplayHiddenModeRemovesDetailRows() throws {
+        let app = conversationDisplayHarnessApp(reasoning: "hidden", commands: "hidden", tools: "hidden")
+        app.launch()
+
+        XCTAssertTrue(app.staticTexts["UITEST_USER_MESSAGE"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["UITEST_ASSISTANT_MESSAGE"].exists)
+        XCTAssertFalse(app.staticTexts["Thinking"].exists)
+        XCTAssertFalse(app.staticTexts["Internal reasoning"].exists)
+        XCTAssertFalse(app.staticTexts["printf UITEST_COMMAND_HEADER"].exists)
+        XCTAssertFalse(app.staticTexts["uiTest.fixtureTool"].exists)
+        XCTAssertFalse(app.staticTexts["UITEST_REASONING_DETAIL"].exists)
+        XCTAssertFalse(app.staticTexts["UITEST_COMMAND_OUTPUT"].exists)
+        XCTAssertFalse(app.staticTexts["UITEST_TOOL_DETAIL"].exists)
+    }
+
+    @MainActor
     func testCaptureAppStoreScreenshots() throws {
         let app = XCUIApplication()
         setupSnapshot(app)
@@ -299,5 +362,35 @@ final class LitterUITests: XCTestCase {
 
     private func sshDiscoveryRows(in app: XCUIApplication) -> XCUIElementQuery {
         app.buttons.matching(NSPredicate(format: "identifier BEGINSWITH %@", "discovery.server.ssh."))
+    }
+
+    @MainActor
+    private func conversationDisplayHarnessApp(
+        reasoning: String = "collapsed",
+        commands: String = "collapsed",
+        tools: String = "collapsed"
+    ) -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments.append("--ui-test-conversation-display")
+        app.launchEnvironment["CODEXIOS_UI_TEST_REASONING_MODE"] = reasoning
+        app.launchEnvironment["CODEXIOS_UI_TEST_COMMAND_MODE"] = commands
+        app.launchEnvironment["CODEXIOS_UI_TEST_TOOL_MODE"] = tools
+        return app
+    }
+
+    private func findStaticText(_ label: String, in app: XCUIApplication) -> Bool {
+        let text = app.staticTexts[label]
+        if text.exists {
+            return true
+        }
+
+        for _ in 0..<4 {
+            app.swipeUp()
+            if text.waitForExistence(timeout: 1) {
+                return true
+            }
+        }
+
+        return false
     }
 }

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -72,6 +72,7 @@ targets:
       - path: Sources/Litter
         excludes:
           - "**/*.h"
+      - path: Sources/Litter/Bridge/UniFFICodexClient.generated.swift
       - path: Resources/fs
         type: folder
         buildPhase: resources
@@ -170,6 +171,7 @@ targets:
           - Views/RealtimeVoiceScreen.swift
           - Views/VoiceCallView.swift
           - "**/*.h"
+      - path: Sources/Litter/Bridge/UniFFICodexClient.generated.swift
     resources:
       - path: Sources/Litter/Resources/Fonts
       - path: Sources/Litter/Resources/Themes


### PR DESCRIPTION
## Summary

- Add iOS conversation settings for Internal Thinking, Commands, and Tools with Show, Collapse, and Hide modes.
- Apply those preferences in the transcript timeline so reasoning, command execution, and tool-detail rows can default collapsed or be removed from the transcript.
- Add a debug-only conversation-display UI harness plus focused UI tests for Settings reachability, expanded mode, collapsed mode, and hidden mode.
- Keep collapsed reasoning summaries generic so the collapsed row does not leak internal reasoning text.
- Explicitly include the generated UniFFI Swift binding and the UI harness in XcodeGen output so simulator builds include the needed files.

## Verification

- `git diff --check`
- `xcrun swiftc -parse apps/ios/Sources/Litter/Views/ToolCallModels.swift apps/ios/Sources/Litter/Models/AppLifecycleController.swift apps/ios/Sources/Litter/Views/ConversationTimelineView.swift apps/ios/Sources/Litter/Views/ConversationDisplayUITestHarnessView.swift apps/ios/Tests/LitterUITests/LitterUITests.swift`
- Tart macOS VM with Xcode 26.4 / iOS 26.4 simulator:
  - `xcodebuild build-for-testing -project apps/ios/Litter.xcodeproj -scheme Litter -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4" -only-testing:LitterTests/ConversationDisplayPreferenceTests -only-testing:LitterUITests/LitterUITests/testConversationDisplaySettingsRowsAreReachable -only-testing:LitterUITests/LitterUITests/testConversationDisplayExpandedModeShowsAllDetails -only-testing:LitterUITests/LitterUITests/testConversationDisplayCollapsedModeKeepsRowsAndRetainsRecentDetails -only-testing:LitterUITests/LitterUITests/testConversationDisplayHiddenModeRemovesDetailRows -derivedDataPath "$HOME/litter-pr130-dd" CODE_SIGNING_ALLOWED=NO` → `** TEST BUILD SUCCEEDED **`
  - `xcodebuild test-without-building -project apps/ios/Litter.xcodeproj -scheme Litter -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4" -only-testing:LitterUITests/LitterUITests/testConversationDisplaySettingsRowsAreReachable -only-testing:LitterUITests/LitterUITests/testConversationDisplayExpandedModeShowsAllDetails -only-testing:LitterUITests/LitterUITests/testConversationDisplayCollapsedModeKeepsRowsAndRetainsRecentDetails -only-testing:LitterUITests/LitterUITests/testConversationDisplayHiddenModeRemovesDetailRows -derivedDataPath "$HOME/litter-pr130-dd" CODE_SIGNING_ALLOWED=NO` → 4 UI tests, 0 failures
  - `xcodebuild test-without-building -project apps/ios/Litter.xcodeproj -scheme Litter -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4" -only-testing:LitterTests/ConversationDisplayPreferenceTests -derivedDataPath "$HOME/litter-pr130-dd" CODE_SIGNING_ALLOWED=NO` → 3 unit tests, 0 failures
- Direct simulator smoke screenshots captured from the built app for expanded, collapsed, hidden, and Settings harness states.

Refs #129