### PR TITLE
android: accept OAuth callbacks on IPv6 loopback

### DIFF
--- a/apps/android/app/src/main/java/com/litter/android/auth/ChatGPTOAuthLoopbackServer.kt
+++ b/apps/android/app/src/main/java/com/litter/android/auth/ChatGPTOAuthLoopbackServer.kt
@@ -10,20 +10,36 @@ import java.net.InetSocketAddress
 import java.net.ServerSocket
 import java.net.Socket
 import java.net.SocketException
+import java.net.SocketTimeoutException
 import java.net.URI
 import kotlinx.coroutines.CancellationException
 
 internal class ChatGPTOAuthLoopbackServer private constructor(
     private val redirectUri: Uri,
-    private val serverSocket: ServerSocket,
+    private val serverSockets: List<ServerSocket>,
     private val appReturnUri: Uri,
 ) : AutoCloseable {
     fun awaitCallback(): Uri {
-        val socket = try {
-            serverSocket.accept()
-        } catch (error: SocketException) {
-            throw CancellationException("ChatGPT login loopback server closed.", error)
+        while (true) {
+            for (serverSocket in serverSockets) {
+                val socket = try {
+                    serverSocket.accept()
+                } catch (_: SocketTimeoutException) {
+                    null
+                } catch (error: SocketException) {
+                    if (serverSockets.all { it.isClosed }) {
+                        throw CancellationException("ChatGPT login loopback server closed.", error)
+                    }
+                    null
+                }
+                if (socket != null) {
+                    return handleCallbackSocket(socket)
+                }
+            }
         }
+    }
+
+    private fun handleCallbackSocket(socket: Socket): Uri {
         socket.use { client ->
             val requestTarget = readRequestTarget(client)
                 ?: throw ChatGPTOAuthException("ChatGPT login callback was malformed.")
@@ -38,10 +54,14 @@ internal class ChatGPTOAuthLoopbackServer private constructor(
     }
 
     override fun close() {
-        runCatching { serverSocket.close() }
+        serverSockets.forEach { socket ->
+            runCatching { socket.close() }
+        }
     }
 
     companion object {
+        private const val ACCEPT_POLL_TIMEOUT_MS = 250
+
         fun create(
             redirectUri: String,
             appReturnUri: Uri,
@@ -52,28 +72,46 @@ internal class ChatGPTOAuthLoopbackServer private constructor(
             val port = parsedRedirect.port.takeIf { it > 0 }
                 ?: throw ChatGPTOAuthException("ChatGPT login redirect URI is missing a port.")
 
-            val socket = ServerSocket().apply {
-                reuseAddress = true
-                bind(
-                    InetSocketAddress(
-                        InetAddress.getByName(
-                            if (host.equals("localhost", ignoreCase = true)) {
-                                "127.0.0.1"
-                            } else {
-                                host
-                            },
+            val sockets = mutableListOf<ServerSocket>()
+            val errors = mutableListOf<String>()
+            for (bindHost in bindHostsForRedirectHost(host)) {
+                val socket = ServerSocket().apply {
+                    reuseAddress = true
+                    soTimeout = ACCEPT_POLL_TIMEOUT_MS
+                }
+                try {
+                    socket.bind(
+                        InetSocketAddress(
+                            InetAddress.getByName(bindHost),
+                            port,
                         ),
-                        port,
-                    ),
-                    1,
+                        1,
+                    )
+                    sockets += socket
+                } catch (error: Exception) {
+                    runCatching { socket.close() }
+                    errors += "$bindHost: ${error.localizedMessage ?: error.message ?: error::class.java.simpleName}"
+                }
+            }
+
+            if (sockets.isEmpty()) {
+                throw ChatGPTOAuthException(
+                    "ChatGPT login could not bind a localhost callback server. ${errors.joinToString("; ")}",
                 )
             }
 
             return ChatGPTOAuthLoopbackServer(
                 redirectUri = parsedRedirect,
-                serverSocket = socket,
+                serverSockets = sockets,
                 appReturnUri = appReturnUri,
             )
+        }
+
+        internal fun bindHostsForRedirectHost(host: String): List<String> {
+            if (!host.equals("localhost", ignoreCase = true)) {
+                return listOf(host)
+            }
+            return listOf("127.0.0.1", "::1")
         }
 
         internal fun requestTargetFromLine(requestLine: String): String? {

--- a/apps/android/app/src/test/java/com/litter/android/auth/ChatGPTOAuthLoopbackServerTest.kt
+++ b/apps/android/app/src/test/java/com/litter/android/auth/ChatGPTOAuthLoopbackServerTest.kt
@@ -7,6 +7,26 @@ import java.net.URI
 
 class ChatGPTOAuthLoopbackServerTest {
     @Test
+    fun bindHostsForRedirectHost_supportsIpv4AndIpv6LoopbackForLocalhost() {
+        assertEquals(
+            listOf("127.0.0.1", "::1"),
+            ChatGPTOAuthLoopbackServer.bindHostsForRedirectHost("localhost"),
+        )
+        assertEquals(
+            listOf("127.0.0.1", "::1"),
+            ChatGPTOAuthLoopbackServer.bindHostsForRedirectHost("LOCALHOST"),
+        )
+    }
+
+    @Test
+    fun bindHostsForRedirectHost_keepsExplicitHosts() {
+        assertEquals(
+            listOf("127.0.0.1"),
+            ChatGPTOAuthLoopbackServer.bindHostsForRedirectHost("127.0.0.1"),
+        )
+    }
+
+    @Test
     fun requestTargetFromLine_parsesGetRequests() {
         assertEquals(
             "/auth/callback?code=abc&state=xyz",


### PR DESCRIPTION
## Summary
- keep the existing ChatGPT OAuth localhost redirect URI
- bind the Android loopback callback server on both 127.0.0.1 and ::1
- poll both sockets so Chrome/browser localhost resolution works for IPv4 or IPv6

Fixes #131

## Verification
- `git diff --check`
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" ./gradlew :app:compileDebugKotlin`

## Note
- Targeted `:app:testDebugUnitTest --tests com.litter.android.auth.ChatGPTOAuthLoopbackServerTest` currently gets past app compile but fails during test-source compile on existing `SnapshotExtensionsTest` unresolved `AgentRuntimeKind` references, before this OAuth test runs.