### PR TITLE
android: render markdown math formulas

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -146,6 +146,8 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-service:2.8.6")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
     implementation("io.noties.markwon:core:4.6.2")
+    implementation("io.noties.markwon:ext-latex:4.6.2")
+    implementation("io.noties.markwon:inline-parser:4.6.2")
     implementation("io.noties.markwon:syntax-highlight:4.6.2") {
         exclude(group = "org.jetbrains", module = "annotations-java5")
     }

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationTimeline.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationTimeline.kt
@@ -495,10 +495,16 @@ private fun AssistantRenderBlocks(
         blocks.forEachIndexed { index, block ->
             when (block) {
                 is AppMessageRenderBlock.Markdown -> MarkdownText(text = block.markdown)
-                is AppMessageRenderBlock.CodeBlock -> CodeBlockSegment(
-                    language = block.language,
-                    code = block.code,
-                )
+                is AppMessageRenderBlock.CodeBlock -> {
+                    if (isMathLanguage(block.language)) {
+                        MarkdownText(text = mathMarkdownBlock(block.code))
+                    } else {
+                        CodeBlockSegment(
+                            language = block.language,
+                            code = block.code,
+                        )
+                    }
+                }
                 is AppMessageRenderBlock.InlineImage -> {
                     val bitmap = remember(block.data) {
                         BitmapFactory.decodeByteArray(block.data, 0, block.data.size)

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/MathMarkdown.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/MathMarkdown.kt
@@ -1,0 +1,115 @@
+package com.litter.android.ui.conversation
+
+internal fun normalizeMathMarkdown(markdown: String): String {
+    if (!markdown.mayContainMath()) {
+        return markdown
+    }
+
+    return markdown
+        .replaceFencedMathBlocks()
+        .replaceDisplayMathDelimiters()
+        .replaceInlineParenMathDelimiters()
+        .replaceSingleDollarInlineMath()
+}
+
+internal fun isMathLanguage(language: String?): Boolean =
+    when (language?.trim()?.lowercase()) {
+        "math", "latex", "tex" -> true
+        else -> false
+    }
+
+internal fun mathMarkdownBlock(latex: String): String {
+    val trimmed = latex.trim()
+    return if (trimmed.isEmpty()) "" else "$MathDelimiter\n$trimmed\n$MathDelimiter"
+}
+
+private fun String.mayContainMath(): Boolean =
+    contains('$') || contains("\\[") || contains("\\(") || contains("```")
+
+private fun String.replaceFencedMathBlocks(): String =
+    FencedMathBlockRegex.replace(this) { match ->
+        mathMarkdownBlock(match.groupValues[2])
+    }
+
+private fun String.replaceDisplayMathDelimiters(): String =
+    DisplayMathRegex.replace(this) { match ->
+        mathMarkdownBlock(match.groupValues[1])
+    }
+
+private fun String.replaceInlineParenMathDelimiters(): String =
+    InlineParenMathRegex.replace(this) { match ->
+        "$MathDelimiter${match.groupValues[1].trim()}$MathDelimiter"
+    }
+
+private fun String.replaceSingleDollarInlineMath(): String {
+    val builder = StringBuilder(length)
+    var index = 0
+    while (index < length) {
+        val start = findSingleDollar(index, opening = true) ?: break
+        val end = findSingleDollar(start + 1, opening = false) ?: break
+        builder.append(this, index, start)
+        builder.append(MathDelimiter)
+        builder.append(this, start + 1, end)
+        builder.append(MathDelimiter)
+        index = end + 1
+    }
+    if (index == 0) {
+        return this
+    }
+    builder.append(this, index, length)
+    return builder.toString()
+}
+
+private fun String.findSingleDollar(fromIndex: Int, opening: Boolean): Int? {
+    var index = fromIndex
+    while (index < length) {
+        if (this[index] == '$' && isSingleDollarMathDelimiter(index, opening)) {
+            return index
+        }
+        index += 1
+    }
+    return null
+}
+
+private fun String.isSingleDollarMathDelimiter(index: Int, opening: Boolean): Boolean {
+    if (isEscaped(index) || hasAdjacentDollar(index)) {
+        return false
+    }
+    return if (opening) {
+        val next = getOrNull(index + 1)
+        next != null && !next.isWhitespace() && !next.isDigit()
+    } else {
+        val previous = getOrNull(index - 1)
+        previous != null && !previous.isWhitespace()
+    }
+}
+
+private fun String.isEscaped(index: Int): Boolean {
+    var slashCount = 0
+    var cursor = index - 1
+    while (cursor >= 0 && this[cursor] == '\\') {
+        slashCount += 1
+        cursor -= 1
+    }
+    return slashCount % 2 == 1
+}
+
+private fun String.hasAdjacentDollar(index: Int): Boolean =
+    getOrNull(index - 1) == '$' || getOrNull(index + 1) == '$'
+
+private const val MathDelimiter = "\$\$"
+
+private val FencedMathBlockRegex = Regex(
+    pattern = "(?ms)^```[ \\t]*(math|latex|tex)[^\\n]*\\n(.*?)\\n```[ \\t]*$",
+    options = setOf(RegexOption.MULTILINE),
+)
+
+private val DisplayMathRegex = Regex(
+    pattern = "\\\\\\[(.*?)\\\\\\]",
+    options = setOf(RegexOption.DOT_MATCHES_ALL),
+)
+
+private val InlineParenMathRegex = Regex(
+    pattern = "\\\\\\((.*?)\\\\\\)",
+    options = setOf(RegexOption.DOT_MATCHES_ALL),
+)

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/SelectableConversationText.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/SelectableConversationText.kt
@@ -17,6 +17,8 @@ import com.litter.android.ui.LocalTextScale
 import io.noties.markwon.AbstractMarkwonPlugin
 import io.noties.markwon.Markwon
 import io.noties.markwon.core.MarkwonTheme
+import io.noties.markwon.ext.latex.JLatexMathPlugin
+import io.noties.markwon.inlineparser.MarkwonInlineParserPlugin
 import io.noties.markwon.syntax.SyntaxHighlightPlugin
 import io.noties.prism4j.Prism4j
 
@@ -40,6 +42,8 @@ internal fun SelectableMarkdownText(
 ) {
     val context = LocalContext.current
     val textScale = LocalTextScale.current
+    val resolvedTextSize = bodySize * textScale
+    val textColor = LitterTheme.textBody.toArgb()
     val useMono = LitterThemeManager.monoFontEnabled
     val typeface = remember(context, useMono) {
         if (useMono) {
@@ -53,16 +57,25 @@ internal fun SelectableMarkdownText(
             android.graphics.Typeface.DEFAULT
         }
     }
-    val markwon = rememberConversationMarkwon(context, typeface)
+    val markdownTextSizePx = remember(context, resolvedTextSize, usePhysicalDpTextSize) {
+        resolvedTextSize.toTextSizePx(context, usePhysicalDpTextSize)
+    }
+    val markwon = rememberConversationMarkwon(
+        context = context,
+        typeface = typeface,
+        markdownTextSizePx = markdownTextSizePx,
+        textColor = textColor,
+    )
+    val markdown = remember(text) { normalizeMathMarkdown(text) }
 
     AndroidView(
         factory = { ctx ->
             TextView(ctx).apply {
                 configureSelectableMarkdownTextView(
                     textView = this,
-                    textColor = LitterTheme.textBody.toArgb(),
+                    textColor = textColor,
                     linkColor = LitterTheme.accent.toArgb(),
-                    textSize = bodySize * textScale,
+                    textSize = resolvedTextSize,
                     typeface = typeface,
                     usePhysicalDpTextSize = usePhysicalDpTextSize,
                 )
@@ -72,13 +85,13 @@ internal fun SelectableMarkdownText(
         update = { tv ->
             configureSelectableMarkdownTextView(
                 textView = tv,
-                textColor = LitterTheme.textBody.toArgb(),
+                textColor = textColor,
                 linkColor = LitterTheme.accent.toArgb(),
-                textSize = bodySize * textScale,
+                textSize = resolvedTextSize,
                 typeface = typeface,
                 usePhysicalDpTextSize = usePhysicalDpTextSize,
             )
-            markwon.setMarkdown(tv, text)
+            markwon.setMarkdown(tv, markdown)
         },
         modifier = modifier,
     )
@@ -110,7 +123,9 @@ internal fun configureSelectableMarkdownTextView(
 private fun rememberConversationMarkwon(
     context: android.content.Context,
     typeface: android.graphics.Typeface?,
-): Markwon = remember(context, typeface) {
+    markdownTextSizePx: Float,
+    textColor: Int,
+): Markwon = remember(context, typeface, markdownTextSizePx, textColor) {
     try {
         val prism4j = Prism4j(com.litter.android.ui.Prism4jGrammarLocator())
         Markwon.builder(context)
@@ -125,8 +140,28 @@ private fun rememberConversationMarkwon(
                     io.noties.markwon.syntax.Prism4jThemeDarkula.create(),
                 ),
             )
+            .usePlugin(MarkwonInlineParserPlugin.create())
+            .usePlugin(
+                JLatexMathPlugin.create(markdownTextSizePx, markdownTextSizePx * 1.12f) { builder ->
+                    builder.inlinesEnabled(true)
+                    builder.blocksEnabled(true)
+                    builder.theme().textColor(textColor)
+                },
+            )
             .build()
     } catch (_: Exception) {
         Markwon.create(context)
     }
+}
+
+private fun Float.toTextSizePx(
+    context: android.content.Context,
+    usePhysicalDpTextSize: Boolean,
+): Float {
+    val unit = if (usePhysicalDpTextSize) {
+        TypedValue.COMPLEX_UNIT_DIP
+    } else {
+        TypedValue.COMPLEX_UNIT_SP
+    }
+    return TypedValue.applyDimension(unit, this, context.resources.displayMetrics)
 }

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/StreamingMarkdownView.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/StreamingMarkdownView.kt
@@ -106,12 +106,20 @@ private fun StreamingRenderBlocks(
                 }
             }
             is AppMessageRenderBlock.CodeBlock -> {
-                StreamingCodeBlock(
-                    language = block.language,
-                    code = block.code,
-                    modifier = Modifier.alpha(alpha),
-                    bodySize = bodySize,
-                )
+                if (isMathLanguage(block.language)) {
+                    StreamingMarkdownText(
+                        text = mathMarkdownBlock(block.code),
+                        modifier = Modifier.alpha(alpha),
+                        bodySize = bodySize,
+                    )
+                } else {
+                    StreamingCodeBlock(
+                        language = block.language,
+                        code = block.code,
+                        modifier = Modifier.alpha(alpha),
+                        bodySize = bodySize,
+                    )
+                }
             }
             is AppMessageRenderBlock.InlineImage -> {
                 val bitmap = remember(block.data) {

--- a/apps/android/app/src/test/java/com/litter/android/ui/conversation/MathMarkdownTest.kt
+++ b/apps/android/app/src/test/java/com/litter/android/ui/conversation/MathMarkdownTest.kt
@@ -1,0 +1,61 @@
+package com.litter.android.ui.conversation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MathMarkdownTest {
+    @Test
+    fun normalizesCommonInlineDelimiters() {
+        val markdown = "Energy is \$E = mc^2\$ and area is \\(a^2\\)."
+
+        assertEquals(
+            "Energy is \$\$E = mc^2\$\$ and area is \$\$a^2\$\$.",
+            normalizeMathMarkdown(markdown),
+        )
+    }
+
+    @Test
+    fun normalizesDisplayDelimiters() {
+        val markdown = "Before\n\\[\n\\int_0^1 x^2 dx\n\\]\nAfter"
+
+        assertEquals(
+            "Before\n\$\$\n\\int_0^1 x^2 dx\n\$\$\nAfter",
+            normalizeMathMarkdown(markdown),
+        )
+    }
+
+    @Test
+    fun normalizesFencedMathBlocks() {
+        val markdown = "```math\n\\frac{1}{3}\n```"
+
+        assertEquals(
+            "\$\$\n\\frac{1}{3}\n\$\$",
+            normalizeMathMarkdown(markdown),
+        )
+    }
+
+    @Test
+    fun leavesDoubleDollarMathAlone() {
+        val markdown = "\$\$\n\\alpha\n\$\$"
+
+        assertEquals(markdown, normalizeMathMarkdown(markdown))
+    }
+
+    @Test
+    fun ignoresLikelyCurrency() {
+        val markdown = "Costs are \$5 and \$6."
+
+        assertEquals(markdown, normalizeMathMarkdown(markdown))
+    }
+
+    @Test
+    fun detectsMathLanguages() {
+        assertTrue(isMathLanguage("math"))
+        assertTrue(isMathLanguage(" LaTeX "))
+        assertTrue(isMathLanguage("tex"))
+        assertFalse(isMathLanguage("kotlin"))
+        assertFalse(isMathLanguage(null))
+    }
+}


### PR DESCRIPTION
## Summary
- add Markwon LaTeX + inline parser support to Android Markdown rendering
- normalize common math delimiters (`$...$`, `\(...\)`, `\[...\]`) into Markwon-renderable math
- render fenced `math`/`latex`/`tex` code blocks as formulas in both stable and streaming assistant messages

Fixes #98

## Verification
- `git diff --check`
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" ./gradlew :app:compileDebugKotlin`

## Known validation gap
- `./gradlew :app:testDebugUnitTest --tests com.litter.android.ui.conversation.MathMarkdownTest` currently fails before running the new test because existing `SnapshotExtensionsTest` references generated `AgentRuntimeKind` symbols that are not present in the local generated UniFFI file.