### PR TITLE
Use /usr/bin/env for commands on posix.

### DIFF
--- a/shared/rust-bridge/codex-mobile-client/src/ffi/client.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/ffi/client.rs
@@ -1304,7 +1304,7 @@ impl AppClient {
             if let Ok(resp) = exec_command_simple(
                 c.as_ref(),
                 &server_id,
-                &["/bin/sh", "-lc", r#"printf %s "$HOME""#],
+                &["/usr/bin/env", "sh", "-lc", r#"printf %s "$HOME""#],
                 Some("/tmp"),
             )
             .await
@@ -1362,7 +1362,7 @@ impl AppClient {
             let resp = exec_command_simple(
                 c.as_ref(),
                 &server_id,
-                &["/bin/sh", "-lc", &cmd],
+                &["/usr/bin/env", "sh", "-lc", &cmd],
                 Some(&project_root),
             )
             .await?;
@@ -1416,7 +1416,7 @@ impl AppClient {
                 // `dir /b /ad` in cwd — avoids path quoting issues
                 (vec!["cmd.exe", "/c", "dir", "/b", "/ad"], &normalized)
             } else {
-                (vec!["/bin/ls", "-1ap", &normalized], &normalized)
+                (vec!["/usr/bin/env", "ls", "-1ap", &normalized], &normalized)
             };
 
             let resp = exec_command_simple(c.as_ref(), &server_id, &command, Some(cwd)).await?;
@@ -1471,7 +1471,7 @@ impl AppClient {
                     &normalized,
                 ]
             } else {
-                vec!["/bin/mkdir", "-p", &normalized]
+                vec!["/usr/bin/env", "mkdir", "-p", &normalized]
             };
 
             let resp = exec_command_simple(c.as_ref(), &server_id, &command, None).await?;
@@ -1916,7 +1916,8 @@ fn image_read_command(path: &str) -> Vec<String> {
     }
 
     vec![
-        "/bin/sh".to_string(),
+        "/usr/bin/env".to_string(),
+        "sh".to_string(),
         "-lc".to_string(),
         r#"path="$1"; case "$path" in "~/"*) path="$HOME/${path#~/}" ;; esac; base64 < "$path""#
             .to_string(),
@@ -1957,7 +1958,12 @@ done"#;
     let response = exec_command_simple_owned(
         client,
         server_id,
-        vec!["/bin/sh".to_string(), "-lc".to_string(), script.to_string()],
+        vec![
+            "/usr/bin/env".to_string(),
+            "sh".to_string(),
+            "-lc".to_string(),
+            script.to_string(),
+        ],
         None,
     )
     .await?;
@@ -2071,7 +2077,8 @@ fn file_exists_command(path: &str) -> Vec<String> {
         ];
     }
     vec![
-        "/bin/sh".to_string(),
+        "/usr/bin/env".to_string(),
+        "sh".to_string(),
         "-lc".to_string(),
         r#"path="$1"; case "$path" in "~/"*) path="$HOME/${path#~/}" ;; esac; test -f "$path""#
             .to_string(),
@@ -3212,8 +3219,9 @@ mod tests {
     #[test]
     fn builds_posix_image_read_command_with_remote_tilde_expansion() {
         let command = image_read_command("~/image.png");
-        assert_eq!(command[0], "/bin/sh");
-        assert!(command[2].contains(r#"${path#~/}"#));
+        assert_eq!(command[0], "/usr/bin/env");
+        assert_eq!(command[1], "sh");
+        assert!(command[3].contains(r#"${path#~/}"#));
     }
 
     mod plugin_list {

--- a/shared/rust-bridge/codex-mobile-client/src/remote_path.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/remote_path.rs
@@ -245,7 +245,7 @@ pub fn parse_directory_listing(stdout: &str, is_windows: bool) -> Vec<String> {
             .map(|l| l.to_string())
             .collect()
     } else {
-        // `/bin/ls -1ap` marks directories with trailing `/`
+        // `ls -1ap` marks directories with trailing `/`
         stdout
             .lines()
             .map(|l| l.trim())

--- a/shared/rust-bridge/codex-mobile-client/src/ssh/exec.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/ssh/exec.rs
@@ -4,7 +4,7 @@
 //! - [`SshClient::open_exec_child`] — streaming; returns an
 //!   [`SshExecChild`] for caller-managed I/O.
 //! - [`SshClient::exec_shell`] — picks the right shell wrapper. POSIX runs
-//!   the command through `/bin/sh -c '…'`; PowerShell uses
+//!   the command through `/usr/bin/env sh -c '…'`; PowerShell uses
 //!   `-EncodedCommand` (UTF-16LE base64) to avoid every cmd.exe escaping
 //!   pothole, then strips CLIXML noise from the response.
 //! - [`SshClient::upload`] — write a file to the remote via `cat > path`,
@@ -26,7 +26,7 @@ use super::{
 };
 
 pub(crate) fn build_posix_exec_command(command: &str) -> String {
-    format!("/bin/sh -c {}", shell_quote(command))
+    format!("/usr/bin/env sh -c {}", shell_quote(command))
 }
 
 impl SshClient {

--- a/shared/rust-bridge/codex-mobile-client/src/ssh/tests.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/ssh/tests.rs
@@ -101,7 +101,7 @@ fn test_shell_quote_path() {
 fn test_build_posix_exec_command_uses_non_login_sh() {
     assert_eq!(
         build_posix_exec_command("echo 'hi' && printf '%s' \"$HOME\""),
-        "/bin/sh -c 'echo '\\''hi'\\'' && printf '\\''%s'\\'' \"$HOME\"'"
+        "/usr/bin/env sh -c 'echo '\\''hi'\\'' && printf '\\''%s'\\'' \"$HOME\"'"
     );
 }
 

--- a/shared/rust-bridge/codex-mobile-client/src/ssh_scripts/posix/detached_spawn.sh
+++ b/shared/rust-bridge/codex-mobile-client/src/ssh_scripts/posix/detached_spawn.sh
@@ -18,9 +18,9 @@ mkfifo {{INPUT}}
 nohup sh -c 'exec 0<>"$1"; while :; do sleep 3600; done' sh {{INPUT}} </dev/null >/dev/null 2>&1 &
 echo $! > {{KEEPER_PID}}
 if command -v setsid >/dev/null 2>&1; then
-  nohup setsid /bin/sh -c {{COMMAND}} < {{INPUT}} > {{OUT_LOG}} 2> {{ERR_LOG}} &
+  nohup setsid /usr/bin/env sh -c {{COMMAND}} < {{INPUT}} > {{OUT_LOG}} 2> {{ERR_LOG}} &
 else
-  nohup /bin/sh -c {{COMMAND}} < {{INPUT}} > {{OUT_LOG}} 2> {{ERR_LOG}} &
+  nohup /usr/bin/env sh -c {{COMMAND}} < {{INPUT}} > {{OUT_LOG}} 2> {{ERR_LOG}} &
 fi
 agent_pid=$!
 echo "$agent_pid" > {{AGENT_PID}}


### PR DESCRIPTION
Fixes command errors on non FHS compliant systems, like NixOS.

It might be worthwhile to include a note in agent docs somewhere? I wasn't sure, so I didn't.