### PR TITLE
discovery: allow pasted pairing payloads

### DIFF
--- a/apps/android/app/src/main/java/com/litter/android/ui/discovery/AlleycatAddServerSheet.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/discovery/AlleycatAddServerSheet.kt
@@ -50,6 +50,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -69,7 +70,6 @@ import com.litter.android.ui.LitterTheme
 import com.litter.android.ui.LocalAppModel
 import com.litter.android.ui.common.BetaBadge
 import com.litter.android.ui.common.isBetaAgentName
-import com.sigkitten.litter.android.BuildConfig
 import java.util.concurrent.Executors
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -98,6 +98,7 @@ fun AlleycatAddServerSheet(
 ) {
     val appModel = LocalAppModel.current
     val context = LocalContext.current
+    val clipboardManager = LocalClipboardManager.current
     val scope = rememberCoroutineScope()
     val credentialStore = remember(context) {
         AlleycatCredentialStore(context.applicationContext)
@@ -301,39 +302,60 @@ fun AlleycatAddServerSheet(
         }
         if (cameraDenied) {
             Text(
-                text = "Camera permission is required to scan a pairing QR. Grant access in system Settings, or paste the JSON below in debug builds.",
+                text = "Camera permission is required to scan a pairing QR. Grant access in system Settings, or paste the JSON below.",
                 color = LitterTheme.warning,
                 fontSize = 11.sp,
             )
         }
 
-        if (BuildConfig.DEBUG) {
-            DisclosureRow(
-                expanded = showPaste,
-                label = "Paste JSON (debug)",
-                onToggle = { showPaste = !showPaste },
+        DisclosureRow(
+            expanded = showPaste,
+            label = "Paste Pairing JSON",
+            onToggle = { showPaste = !showPaste },
+        )
+        if (showPaste) {
+            OutlinedTextField(
+                value = pasteJson,
+                onValueChange = { pasteJson = it },
+                placeholder = {
+                    Text(
+                        text = "{\"v\":1,\"node_id\":\"...\",\"token\":\"...\",\"relay\":\"https://...\"}",
+                        color = LitterTheme.textMuted,
+                        fontFamily = FontFamily.Monospace,
+                        fontSize = 11.sp,
+                    )
+                },
+                minLines = 3,
+                maxLines = 6,
+                modifier = Modifier.fillMaxWidth(),
             )
-            if (showPaste) {
-                OutlinedTextField(
-                    value = pasteJson,
-                    onValueChange = { pasteJson = it },
-                    placeholder = {
-                        Text(
-                            text = "{\"v\":1,\"node_id\":\"...\",\"token\":\"...\",\"relay\":\"https://...\"}",
-                            color = LitterTheme.textMuted,
-                            fontFamily = FontFamily.Monospace,
-                            fontSize = 11.sp,
-                        )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(
+                    onClick = {
+                        clipboardManager.getText()?.text?.let { pasteJson = it }
                     },
-                    minLines = 3,
-                    maxLines = 6,
-                    modifier = Modifier.fillMaxWidth(),
-                )
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.ContentCopy,
+                        contentDescription = null,
+                        tint = LitterTheme.accent,
+                        modifier = Modifier.size(16.dp),
+                    )
+                    Spacer(Modifier.width(6.dp))
+                    Text("Paste from Clipboard", color = LitterTheme.accent)
+                }
                 TextButton(
                     onClick = { handleScannedPayload(pasteJson) },
                     enabled = pasteJson.trim().isNotEmpty(),
                 ) {
-                    Text("Parse JSON", color = LitterTheme.accent)
+                    Text(
+                        text = if (parsedParams == null) "Parse JSON" else "Reparse JSON",
+                        color = LitterTheme.accent,
+                    )
                 }
             }
         }

--- a/apps/ios/Sources/Litter/Views/AlleycatAddServerSheet.swift
+++ b/apps/ios/Sources/Litter/Views/AlleycatAddServerSheet.swift
@@ -30,9 +30,7 @@ struct AlleycatAddServerSheet: View {
     @State private var didRequestInitialScan = false
     @State private var cameraDenied = false
     // pasteJSON / showPaste are used by the Mac paste-JSON UI
-    // (Catalyst + iOS-on-Mac) and the iOS DEBUG disclosure group.
-    // Keep them declared unconditionally so the runtime branch in
-    // `pairingSection` compiles on every platform.
+    // (Catalyst + iOS-on-Mac) and the iOS QR fallback.
     @State private var pasteJSON: String = ""
     @State private var showPaste: Bool = false
 
@@ -130,11 +128,9 @@ struct AlleycatAddServerSheet: View {
 
     private var pairingSection: some View {
         Section {
-            // Mac (Catalyst + iOS-on-Mac) shows paste-JSON only — the
-            // QR scanner UX is awkward on a desktop-class display, and
-            // the host running `npx kittylitter` already prints the JSON
-            // payload. iOS shows the QR scanner with a DEBUG-only paste
-            // disclosure for testing.
+            // Mac (Catalyst + iOS-on-Mac) shows paste-JSON only; iOS shows
+            // QR scanning first, with paste available as a production fallback
+            // for users who already copied the pairing payload.
             if LitterPlatform.rendersAsMacApp {
                 pasteJSONPairingControls
             } else {
@@ -154,11 +150,43 @@ struct AlleycatAddServerSheet: View {
             .foregroundColor(LitterTheme.textSecondary)
             .fixedSize(horizontal: false, vertical: true)
 
+        pasteJSONEntryControls(minHeight: 110)
+    }
+
+    @ViewBuilder
+    private var qrPairingControls: some View {
+        Button {
+            requestCameraAndScan()
+        } label: {
+            HStack {
+                Image(systemName: "qrcode.viewfinder")
+                    .foregroundColor(LitterTheme.accent)
+                Text(parsedParams == nil ? "Scan Pairing QR" : "Rescan QR")
+                    .litterFont(.subheadline)
+                    .foregroundColor(LitterTheme.accent)
+            }
+        }
+
+        DisclosureGroup(
+            isExpanded: $showPaste,
+            content: {
+                pasteJSONEntryControls(minHeight: 90)
+            },
+            label: {
+                Text("Paste Pairing JSON")
+                    .litterFont(.footnote)
+                    .foregroundColor(LitterTheme.textSecondary)
+            }
+        )
+    }
+
+    @ViewBuilder
+    private func pasteJSONEntryControls(minHeight: CGFloat) -> some View {
         TextEditor(text: $pasteJSON)
             .litterFont(.caption)
             .foregroundColor(LitterTheme.textPrimary)
             .scrollContentBackground(.hidden)
-            .frame(minHeight: 110)
+            .frame(minHeight: minHeight)
             .overlay(alignment: .topLeading) {
                 if pasteJSON.isEmpty {
                     Text(#"{"v":1,"node_id":"...","token":"...","relay":"https://..."}"#)
@@ -188,55 +216,6 @@ struct AlleycatAddServerSheet: View {
             .foregroundColor(LitterTheme.accent)
             .disabled(pasteJSON.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         }
-    }
-
-    @ViewBuilder
-    private var qrPairingControls: some View {
-        Button {
-            requestCameraAndScan()
-        } label: {
-            HStack {
-                Image(systemName: "qrcode.viewfinder")
-                    .foregroundColor(LitterTheme.accent)
-                Text(parsedParams == nil ? "Scan Pairing QR" : "Rescan QR")
-                    .litterFont(.subheadline)
-                    .foregroundColor(LitterTheme.accent)
-            }
-        }
-
-        #if DEBUG
-        DisclosureGroup(
-            isExpanded: $showPaste,
-            content: {
-                TextEditor(text: $pasteJSON)
-                    .litterFont(.caption)
-                    .foregroundColor(LitterTheme.textPrimary)
-                    .scrollContentBackground(.hidden)
-                    .frame(minHeight: 90)
-                    .overlay(alignment: .topLeading) {
-                        if pasteJSON.isEmpty {
-                            Text(#"{"v":1,"node_id":"...","token":"...","relay":"https://..."}"#)
-                                .litterFont(.caption)
-                                .foregroundColor(LitterTheme.textMuted)
-                                .padding(.top, 8)
-                                .padding(.leading, 4)
-                                .allowsHitTesting(false)
-                        }
-                    }
-                Button("Parse JSON") {
-                    handleScannedPayload(pasteJSON)
-                }
-                .litterFont(.footnote)
-                .foregroundColor(LitterTheme.accent)
-                .disabled(pasteJSON.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-            },
-            label: {
-                Text("Paste JSON (debug)")
-                    .litterFont(.footnote)
-                    .foregroundColor(LitterTheme.textSecondary)
-            }
-        )
-        #endif
     }
 
     private static let pairCommandLabel = "npx kittylitter"


### PR DESCRIPTION
Fixes #134.

## Summary
- Make paste-pairing JSON available in production on iOS instead of hiding it behind the debug-only disclosure.
- Make Android show the paste pairing fallback in production and add a clipboard paste action.
- Keep QR scanning as the primary path on phones, with paste as the fallback for copied QR payloads.

## Verification
- git diff --check
