### PR TITLE
fix(ios): composer cursor jumping after dictation

### DIFF
--- a/apps/ios/Sources/Litter/Views/ConversationComposerTextView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationComposerTextView.swift
@@ -70,9 +70,10 @@ struct ConversationComposerTextView: UIViewRepresentable {
             uiView.text = text
             context.coordinator.applySelectedRange(to: uiView)
             context.coordinator.isSynchronizingText = false
+        } else if !uiView.isFirstResponder {
+            context.coordinator.applySelectedRange(to: uiView)
         }
 
-        context.coordinator.applySelectedRange(to: uiView)
         context.coordinator.updateScrollState(for: uiView)
         context.coordinator.syncFocus(for: uiView)
     }


### PR DESCRIPTION
When using iOS native dictation the cursor jumps back to the start of the dictation after pressing the "123" key. This is due to a stale selected range in SwiftUI. My change avoids applying the selected range while the composer is active and the text hasn't changed from SwiftUI.


Bugged:

https://github.com/user-attachments/assets/7755bc7e-f84b-44c4-9283-e4cfb1f9bdab



Fixed:

https://github.com/user-attachments/assets/b27e0484-22bf-4d44-911d-f5d8771b4355
