### PR TITLE
android: emit padded image data URLs

### DIFF
--- a/apps/android/app/src/main/java/com/litter/android/state/RpcParams.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/RpcParams.kt
@@ -20,7 +20,7 @@ data class ComposerImageAttachment(
     val mimeType: String,
 ) {
     val dataUri: String
-        get() = "data:$mimeType;base64,${Base64.getEncoder().withoutPadding().encodeToString(data)}"
+        get() = "data:$mimeType;base64,${Base64.getEncoder().encodeToString(data)}"
 
     fun toUserInput(): AppUserInput.Image = AppUserInput.Image(url = dataUri)
 }

--- a/apps/android/app/src/test/java/com/litter/android/state/AppComposerPayloadTest.kt
+++ b/apps/android/app/src/test/java/com/litter/android/state/AppComposerPayloadTest.kt
@@ -1,7 +1,6 @@
 package com.litter.android.state
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import uniffi.codex_mobile_client.AbsolutePath
 import uniffi.codex_mobile_client.AppUserInput
@@ -16,7 +15,7 @@ class AppComposerPayloadTest {
                     listOf(
                         AppUserInput.Skill(name = "swiftui-pro", path = AbsolutePath("/Users/sigkitten/.codex/skills/swiftui-pro/SKILL.md")),
                         ComposerImageAttachment(
-                            data = byteArrayOf(0x01, 0x02, 0x03),
+                            data = byteArrayOf(0x01, 0x02),
                             mimeType = "image/png",
                         ).toUserInput(),
                         AppUserInput.Mention(name = "helper", path = "app://agent"),
@@ -35,7 +34,7 @@ class AppComposerPayloadTest {
         assertEquals("/Users/sigkitten/.codex/skills/swiftui-pro/SKILL.md", skillInput.path.value)
 
         val imageInput = params.input[2] as AppUserInput.Image
-        assertTrue(imageInput.url.startsWith("data:image/png;base64,"))
+        assertEquals("data:image/png;base64,AQI=", imageInput.url)
 
         val mentionInput = params.input[3] as AppUserInput.Mention
         assertEquals("helper", mentionInput.name)
@@ -60,6 +59,6 @@ class AppComposerPayloadTest {
 
         assertEquals(1, params.input.size)
         val imageInput = params.input.single() as AppUserInput.Image
-        assertTrue(imageInput.url.startsWith("data:image/jpeg;base64,"))
+        assertEquals("data:image/jpeg;base64,Cgs=", imageInput.url)
     }
 }


### PR DESCRIPTION
## Summary
- Emit standard padded base64 for Android composer image data URLs
- Tighten composer payload tests to assert exact padded data URLs

## Verification
- `ANDROID_SDK_ROOT="$HOME/Android/Sdk" ANDROID_HOME="$HOME/Android/Sdk" ./gradlew :app:testDebugUnitTest --tests com.litter.android.state.AppComposerPayloadTest`
- Installed the debug APK on device and confirmed a new thread can send the same image successfully
- Repaired the existing test thread history separately and also confirmed the same image got trough.

bug before: 
<img width="1080" height="2227" alt="image" src="https://github.com/user-attachments/assets/6af41326-36d0-4d23-8c7b-4b35e7e5f61c" />

after fix (same thread) 
<img width="1078" height="2181" alt="image" src="https://github.com/user-attachments/assets/755b63a1-9e72-41d6-8185-4273cea07646" />

