### PR TITLE
fix(android): reject stale shell backlog + always-visible keyboard toggle

### DIFF
--- a/apps/android/app/src/main/java/com/litter/android/ui/terminal/GhosttySurfaceView.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/terminal/GhosttySurfaceView.kt
@@ -431,7 +431,12 @@ private class GhosttyAndroidSurfaceView(
             }
 
             override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
-                val renderer = terminalRenderer ?: return false
+                // ponytail: pop the IME on every confirmed tap, even before
+                // the renderer binds. The prior guard returned false when
+                // terminalRenderer was null, so tapping the black surface
+                // during startup never summoned the keyboard.
+                showIme()
+                val renderer = terminalRenderer ?: return true
                 if (currentSelectionRange() != null) {
                     clearSelection()
                     return true
@@ -444,7 +449,6 @@ private class GhosttyAndroidSurfaceView(
                     runCatching { context.startActivity(intent) }
                     return true
                 }
-                showIme()
                 return true
             }
         },
@@ -457,9 +461,20 @@ private class GhosttyAndroidSurfaceView(
         isFocusableInTouchMode = true
         isLongClickable = true
         isHapticFeedbackEnabled = true
+        activeSurface = java.lang.ref.WeakReference(this)
     }
 
+    internal fun forceShowIme() = showIme()
+
     override fun onCheckIsTextEditor(): Boolean = true
+
+    companion object {
+        // ponytail: process-wide handle so the terminal header's keyboard
+        // button can summon the IME without threading a callback through
+        // every Composable. Weak so the view can be GC'd normally.
+        @Volatile
+        internal var activeSurface: java.lang.ref.WeakReference<GhosttyAndroidSurfaceView>? = null
+    }
 
     override fun onCreateInputConnection(outAttrs: EditorInfo): InputConnection {
         outAttrs.inputType = (
@@ -916,4 +931,11 @@ private object KeyEventTranslator {
         KeyEvent.KEYCODE_INSERT -> 15
         else -> 0
     }
+}
+
+// ponytail: top-level entry so the terminal header (or any Composable in
+// the terminal package) can pop the IME on the current SurfaceView without
+// exposing the private view class.
+internal fun showTerminalKeyboard() {
+    GhosttyAndroidSurfaceView.activeSurface?.get()?.forceShowIme()
 }

--- a/apps/android/app/src/main/java/com/litter/android/ui/terminal/TerminalScreen.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/terminal/TerminalScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Keyboard
 import androidx.compose.material.icons.outlined.PhoneIphone
 import androidx.compose.material.icons.outlined.Storage
 import androidx.compose.material3.DropdownMenu
@@ -539,6 +540,20 @@ private fun TerminalHeader(
             }
         }
         Spacer(Modifier.weight(1f))
+        // ponytail: explicit keyboard toggle — the tap-to-focus path on
+        // the SurfaceView is easy to miss (users often tap chrome, not
+        // the black viewport) and some devices/IMEs never restore focus
+        // after a reconnect.
+        IconButton(
+            onClick = { showTerminalKeyboard() },
+            modifier = Modifier.size(40.dp),
+        ) {
+            Icon(
+                Icons.Outlined.Keyboard,
+                contentDescription = "Show keyboard",
+                tint = LitterTheme.accent,
+            )
+        }
         TextButton(
             onClick = onConfigClick,
             contentPadding = PaddingValues(horizontal = 10.dp, vertical = 0.dp),

--- a/shared/rust-bridge/codex-mobile-client/src/terminal/remote_alleycat.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/terminal/remote_alleycat.rs
@@ -321,7 +321,12 @@ async fn should_accept_session(
 ) -> bool {
     match expected_session_id.lock().await.as_deref() {
         Some(expected) => expected == actual_session_id,
-        None => true,
+        // ponytail: drop replayed backlog frames from prior killed shell
+        // sessions until our own shell/spawn returns and sets the expected
+        // id. Without this a stale shell/exit in the ring breaks the read
+        // loop and the terminal reports "JSON-RPC stream closed" on every
+        // reconnect.
+        None => false,
     }
 }
 


### PR DESCRIPTION
## Summary
1. **Terminal breakage on reconnect** (\`v1-Backend: terminal JSON-RPC stream closed\`): the shared \`remote_alleycat\` read loop was accepting replayed backlog frames from a prior killed shell session while its own \`shell_session_id\` was still \`None\`. A stale \`shell/exit\` in the ring then broke the loop before \`initialize\` returned. Guard by treating an unset expected id as reject-until-spawned instead of accept-all.
2. **Keyboard never appearing on Android**: \`onSingleTapConfirmed\` returned false when \`terminalRenderer\` was null, so tapping the black surface during startup never called \`showIme()\`. Users had no other way to summon the IME. Fix by popping the IME on every confirmed tap, and add an \`Icons.Outlined.Keyboard\` \`IconButton\` in the terminal header wired to a new file-local \`showTerminalKeyboard()\` helper (via a \`WeakReference\` to the active \`GhosttyAndroidSurfaceView\`).

Pairs with dnakov/alleycat#PR (server-side session-replay fix for the shell agent). Either patch alone fixes the reconnect breakage; both together are the belt-and-suspenders.

## Test plan
- [x] Reject-on-null-session verified: Android app opens terminal, backgrounds, reconnects — every attach is Fresh with the server-side fix and no stale exit interrupts \`initialize\`.
- [ ] Manual: tap black viewport during startup — keyboard appears.
- [ ] Manual: tap the new keyboard icon in the terminal header — keyboard appears.
- [ ] Manual: reconnect after wifi flip — keyboard button still summons IME.