### PR TITLE
Fix Photos image preview paths

### DIFF
--- a/apps/ios/Sources/Litter/Models/ConversationAttachmentSupport.swift
+++ b/apps/ios/Sources/Litter/Models/ConversationAttachmentSupport.swift
@@ -24,7 +24,7 @@ enum ConversationAttachmentSupport {
         .png,
         .jpeg,
         .gif,
-    ] + [UTType(filenameExtension: "webp")].compactMap { $0 }
+    ] + ["webp", "heic", "heif"].compactMap { UTType(filenameExtension: $0) }
 
     static let supportedFileContentTypes: [UTType] = [.data]
 
@@ -55,9 +55,11 @@ enum ConversationAttachmentSupport {
             }
         }
 
-        if isSupportedImageFile(url),
-           let data = try? Data(contentsOf: url),
-           let image = UIImage(data: data) {
+        if shouldLoadAsImageOnly(url) {
+            guard let data = try? Data(contentsOf: url),
+                  let image = UIImage(data: data) else {
+                return nil
+            }
             return .image(image)
         }
 
@@ -93,7 +95,22 @@ enum ConversationAttachmentSupport {
 
     private static func isSupportedImageFile(_ url: URL) -> Bool {
         let pathExtension = url.pathExtension.lowercased()
-        return ["png", "jpg", "jpeg", "gif", "webp"].contains(pathExtension)
+        return ["png", "jpg", "jpeg", "gif", "webp", "heic", "heif"].contains(pathExtension)
+    }
+
+    private static func shouldLoadAsImageOnly(_ url: URL) -> Bool {
+        isSupportedImageFile(url) || isPhotosLibraryInternalURL(url)
+    }
+
+    static func isPhotosLibraryInternalURL(_ url: URL) -> Bool {
+        isPhotosLibraryInternalPath(url.path)
+    }
+
+    static func isPhotosLibraryInternalPath(_ path: String) -> Bool {
+        let path = path.lowercased()
+        return path.contains(".photoslibrary/")
+            || path.contains(".photoslibrary\\")
+            || path.hasSuffix(".photoslibrary")
     }
 
     private static func fileLabel(for url: URL) -> String {

--- a/apps/ios/Sources/Litter/Views/ToolCallCardView.swift
+++ b/apps/ios/Sources/Litter/Views/ToolCallCardView.swift
@@ -463,13 +463,14 @@ struct ToolCallCardView: View {
         if trimmed.hasPrefix("file://"),
            let url = URL(string: trimmed),
            url.isFileURL {
-            return url.path(percentEncoded: false)
+            let path = url.path(percentEncoded: false)
+            return ConversationAttachmentSupport.isPhotosLibraryInternalPath(path) ? nil : path
         }
         if trimmed.hasPrefix("/") || trimmed.hasPrefix("~/") || trimmed.hasPrefix("\\\\") {
-            return trimmed
+            return ConversationAttachmentSupport.isPhotosLibraryInternalPath(trimmed) ? nil : trimmed
         }
         if trimmed.range(of: #"^[A-Za-z]:[\\/]"#, options: .regularExpression) != nil {
-            return trimmed
+            return ConversationAttachmentSupport.isPhotosLibraryInternalPath(trimmed) ? nil : trimmed
         }
 
         return nil

--- a/apps/ios/Tests/LitterTests/ConversationAttachmentSupportTests.swift
+++ b/apps/ios/Tests/LitterTests/ConversationAttachmentSupportTests.swift
@@ -60,4 +60,47 @@ final class ConversationAttachmentSupportTests: XCTestCase {
         XCTAssertEqual(attachment?.mimeType, "image/jpeg")
         XCTAssertNotNil(attachment?.data)
     }
+
+    func testUnreadableImagePathDoesNotFallBackToFileAttachment() {
+        let url = URL(fileURLWithPath: "/tmp/litter-missing-image.jpeg")
+
+        let picked = ConversationAttachmentSupport.loadPickedFile(at: url)
+
+        XCTAssertNil(picked)
+    }
+
+    func testPhotosLibraryInternalPathDoesNotBecomeFileAttachment() {
+        let url = URL(
+            fileURLWithPath: "/Users/example/Pictures/Photos Library.photoslibrary/resources/derivatives/4/photo.txt"
+        )
+
+        let picked = ConversationAttachmentSupport.loadPickedFile(at: url)
+
+        XCTAssertNil(picked)
+    }
+
+    func testPhotosLibraryInternalPathDetection() {
+        XCTAssertTrue(
+            ConversationAttachmentSupport.isPhotosLibraryInternalPath(
+                "/Users/example/Pictures/Photos Library.photoslibrary/resources/derivatives/4/photo.jpeg"
+            )
+        )
+        XCTAssertFalse(
+            ConversationAttachmentSupport.isPhotosLibraryInternalPath(
+                "/Users/example/Desktop/photo.jpeg"
+            )
+        )
+    }
+
+    func testUnreadableNonImagePathCanStillBeMentionedAsFileAttachment() {
+        let url = URL(fileURLWithPath: "/tmp/litter-missing-file.txt")
+
+        let picked = ConversationAttachmentSupport.loadPickedFile(at: url)
+
+        guard case .file(let attachment)? = picked else {
+            return XCTFail("Expected file attachment")
+        }
+        XCTAssertEqual(attachment.label, "litter-missing-file")
+        XCTAssertEqual(attachment.path, "/tmp/litter-missing-file.txt")
+    }
 }


### PR DESCRIPTION
## Summary
- Treat Photos library internal paths as transient iOS-only paths, not durable file attachments.
- Prevent restored image-view cards from auto-resolving `.photoslibrary` derivative paths on app open.
- Add regression coverage for Photos-library path detection and image fallback behavior.

## Verification
- `make ios-device-fast` reached Xcode but failed due to missing signing profiles/accounts for the app, live activity, watch app, and complications targets.
- Focused simulator test was attempted after installing watchOS 26.2, but simulator Rust artifact generation failed because the disk filled up (`No space left on device`).
