### PR TITLE
android: fix realtime voice connection

### DIFF
--- a/apps/android/app/src/main/java/com/litter/android/voice/RealtimeWebRtcSession.kt
+++ b/apps/android/app/src/main/java/com/litter/android/voice/RealtimeWebRtcSession.kt
@@ -7,6 +7,7 @@ import android.media.AudioManager
 import android.os.Build
 import android.util.Log
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
 import org.webrtc.AudioSource
 import org.webrtc.AudioTrack
 import org.webrtc.DataChannel
@@ -60,7 +61,10 @@ class RealtimeWebRtcSession(private val context: Context) {
         val factory = sharedFactory(context)
         val rtcConfig = PeerConnection.RTCConfiguration(emptyList()).apply {
             sdpSemantics = PeerConnection.SdpSemantics.UNIFIED_PLAN
-            continualGatheringPolicy = PeerConnection.ContinualGatheringPolicy.GATHER_CONTINUALLY
+            // The initial SDP is sent as a complete, non-trickle offer. Continuous
+            // gathering never transitions to COMPLETE on some Android devices,
+            // which leaves start() suspended before signaling can begin.
+            continualGatheringPolicy = PeerConnection.ContinualGatheringPolicy.GATHER_ONCE
         }
 
         Log.i(TAG, "start: creating PeerConnection")
@@ -108,7 +112,15 @@ class RealtimeWebRtcSession(private val context: Context) {
         }
 
         Log.i(TAG, "start: awaiting ICE gathering complete")
-        awaitIceGatheringComplete(connection)
+        val iceGatheringCompleted = withTimeoutOrNull(ICE_GATHERING_TIMEOUT_MS) {
+            awaitIceGatheringComplete(connection)
+            true
+        } == true
+        if (!iceGatheringCompleted) {
+            // A host candidate is normally present by now. Prefer sending the
+            // best available offer to hanging the entire realtime start flow.
+            Log.w(TAG, "start: ICE gathering timed out; using current local description")
+        }
 
         if (isClosed.get() || peerConnection !== connection) {
             Log.w(TAG, "start: session closed while awaiting ICE gathering")
@@ -311,6 +323,7 @@ class RealtimeWebRtcSession(private val context: Context) {
 
     companion object {
         private const val TAG = "RealtimeWebRtc"
+        private const val ICE_GATHERING_TIMEOUT_MS = 5_000L
 
         @Volatile
         private var sharedFactoryInstance: PeerConnectionFactory? = null

--- a/patches/codex/README.md
+++ b/patches/codex/README.md
@@ -62,9 +62,9 @@ Touches `protocol/src/protocol.rs`, `app-server-protocol/src/protocol/{common.rs
 The TUI hunks are no-op match arms required only because upstream's `ServerNotification` matches are exhaustive. Upstream moved the consolidated `handle_server_notification` match from `tui/src/chatwidget.rs` into `tui/src/chatwidget/protocol.rs`; this patch targets the new location.
 
 ## `realtime-webrtc-env-apikey.patch`
-For WebRTC realtime sessions, populate the request headers with the API key obtained from `realtime_api_key(auth, provider)`. Without this, the WebRTC peer connection fails to authenticate when the user is signed in via env-key auth.
+For WebRTC realtime sessions, populate the request headers with the API key obtained from `realtime_api_key(auth, provider)`. When ChatGPT auth falls back to that key, build a clean public OpenAI provider instead of retaining the ChatGPT backend URL. Without this, the WebRTC peer connection fails to authenticate or targets a backend call route the API key cannot access.
 
-Touches `core/src/realtime_conversation.rs`.
+Touches `core/src/{client.rs,realtime_conversation.rs,realtime_conversation_tests.rs}`.
 
 ---
 

--- a/patches/codex/realtime-webrtc-env-apikey.patch
+++ b/patches/codex/realtime-webrtc-env-apikey.patch
@@ -106,15 +106,7 @@ diff --git a/codex-rs/core/src/realtime_conversation.rs b/codex-rs/core/src/real
      extra_headers: Option<HeaderMap>,
      requested_realtime_session_id: Option<String>,
      version: RealtimeWsVersion,
-@@ -688,6 +694,7 @@
-         .transport
-         .unwrap_or(ConversationStartTransport::Websocket);
-     let mut api_provider = provider.to_api_provider(Some(AuthMode::ApiKey))?;
-+    let call_api_provider = api_provider.clone();
-     if let Some(realtime_ws_base_url) = &config.experimental_realtime_ws_base_url {
-         api_provider.base_url = realtime_ws_base_url.clone();
-     }
-@@ -702,23 +709,44 @@
+@@ -702,23 +708,48 @@
      )
      .await?;
      let requested_realtime_session_id = session_config.session_id.clone();
@@ -145,11 +137,15 @@ diff --git a/codex-rs/core/src/realtime_conversation.rs b/codex-rs/core/src/real
 +                Some(AuthMode::Chatgpt | AuthMode::ChatgptAuthTokens | AuthMode::AgentIdentity)
 +            );
 +            let webrtc_api_fallback = if current_auth_uses_codex_backend {
-+                realtime_api_key.as_ref().map(|api_key| {
-+                    let api_auth: SharedAuthProvider =
-+                        Arc::new(BearerAuthProvider::new(api_key.clone()));
-+                    (call_api_provider.clone(), api_auth)
-+                })
++                realtime_api_key
++                    .as_ref()
++                    .map(|api_key| {
++                        let api_auth: SharedAuthProvider =
++                            Arc::new(BearerAuthProvider::new(api_key.clone()));
++                        realtime_webrtc_api_provider()
++                            .map(|api_provider| (api_provider, api_auth))
++                    })
++                    .transpose()?
 +            } else {
 +                None
 +            };
@@ -168,7 +164,7 @@ diff --git a/codex-rs/core/src/realtime_conversation.rs b/codex-rs/core/src/real
          extra_headers,
          requested_realtime_session_id,
          version,
-@@ -843,6 +871,7 @@
+@@ -843,6 +874,7 @@
  ) -> CodexResult<()> {
      let PreparedRealtimeConversationStart {
          api_provider,
@@ -176,7 +172,7 @@ diff --git a/codex-rs/core/src/realtime_conversation.rs b/codex-rs/core/src/real
          extra_headers,
          requested_realtime_session_id,
          version,
-@@ -857,6 +886,7 @@
+@@ -857,6 +889,7 @@
      };
      let start = RealtimeStart {
          api_provider,
@@ -184,3 +180,42 @@ diff --git a/codex-rs/core/src/realtime_conversation.rs b/codex-rs/core/src/real
          extra_headers,
          session_config,
          model_client: sess.services.model_client.clone(),
+@@ -1067,6 +1100,11 @@ fn realtime_api_key(
+     ))
+ }
+-
++
++fn realtime_webrtc_api_provider() -> CodexResult<ApiProvider> {
++    ModelProviderInfo::create_openai_provider(/*base_url*/ None)
++        .to_api_provider(Some(AuthMode::ApiKey))
++}
++
+ fn realtime_request_headers(
+     realtime_session_id: Option<&str>,
+     api_key: Option<&str>,
+diff --git a/codex-rs/core/src/realtime_conversation_tests.rs b/codex-rs/core/src/realtime_conversation_tests.rs
+--- a/codex-rs/core/src/realtime_conversation_tests.rs
++++ b/codex-rs/core/src/realtime_conversation_tests.rs
+@@ -2,12 +2,21 @@
+ use super::RealtimeSessionKind;
+ use super::realtime_delegation_from_handoff;
+ use super::realtime_text_from_handoff_request;
++use super::realtime_webrtc_api_provider;
+ use super::wrap_realtime_delegation_input;
+ use async_channel::bounded;
+ use codex_protocol::protocol::RealtimeHandoffRequested;
+ use codex_protocol::protocol::RealtimeTranscriptEntry;
+ use pretty_assertions::assert_eq;
+-
++
++#[test]
++fn webrtc_api_key_fallback_uses_public_openai_endpoint() {
++    let provider = realtime_webrtc_api_provider().expect("public realtime API provider");
++
++    assert_eq!(provider.base_url, "https://api.openai.com/v1");
++    assert_eq!(provider.query_params, None);
++}
++
+ #[test]
+ fn prefers_handoff_input_transcript_over_active_transcript() {
+     let handoff = RealtimeHandoffRequested {


### PR DESCRIPTION
Closes #182.

## Summary

- make Android's initial non-trickle WebRTC offer use one-shot ICE gathering, with a five-second fallback to the best available local description
- make the env API-key fallback construct a clean public OpenAI provider instead of retaining the ChatGPT backend URL
- document the expanded Codex patch and add a regression test for the public endpoint

## Root cause

Android waited indefinitely for ICE gathering to reach `COMPLETE` while using continual gathering. On affected devices, realtime signaling never started. Separately, the ChatGPT-auth API-key fallback reused the ChatGPT backend provider, causing the API key to target a backend call route it cannot access rather than the public Realtime API.

## Verification

- `cd apps/android && ./gradlew :app:testDebugUnitTest`
- `PATH="/Users/ajjoobandi/.rustup/toolchains/1.95.0-aarch64-apple-darwin/bin:$PATH" cargo check -p codex-core --lib`
- reverse patch applicability check against the locally patched Codex submodule
- live Galaxy S25 Ultra (Android 16): SDP answer applied, remote audio track received, ICE reached connected/completed, UI reached listening, speech/transcript updates arrived, and assistant audio played

The public endpoint behavior follows the official [Realtime WebRTC guide](https://developers.openai.com/api/docs/guides/realtime-webrtc).
