### PR TITLE
android: retry model picker metadata

### DIFF
--- a/apps/android/app/src/main/java/com/litter/android/state/AppModel.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/AppModel.kt
@@ -549,7 +549,10 @@ class AppModel private constructor(context: android.content.Context) {
     suspend fun loadAvailableModelsIfNeeded(serverId: String) {
         val server = snapshot.value?.servers?.firstOrNull { it.serverId == serverId } ?: return
         if (!server.isConnected) return
-        if (server.availableModels != null) return
+        // An empty list can be the result of a transient model/list failure.
+        // Do not let that poison the cache permanently: the picker should be
+        // able to retry once the server/runtime is healthy again.
+        if (!server.availableModels.isNullOrEmpty()) return
         if (!loadingModelServerIds.add(serverId)) return
         try {
             client.refreshModels(
@@ -1567,9 +1570,16 @@ class AppModel private constructor(context: android.content.Context) {
 
     private fun hasFreshConversationMetadata(serverId: String): Boolean {
         val server = snapshot.value?.servers?.firstOrNull { it.serverId == serverId } ?: return false
-        val hasModels = server.availableModels != null
+        val hasModels = !server.availableModels.isNullOrEmpty()
         val hasRateLimits = server.account == null || server.rateLimits != null
         if (hasModels && hasRateLimits) return true
+
+        // An empty model list is not a successful metadata load. In
+        // particular, refreshModels can publish an empty list after a
+        // transient runtime/model-list failure. Keep the short debounce for
+        // rate-limit-only retries, but let the picker retry models
+        // immediately when it is opened again.
+        if (!hasModels) return false
 
         val lastLoad = recentConversationMetadataLoads[serverId] ?: return false
         return System.currentTimeMillis() - lastLoad < 10_000L

--- a/apps/android/app/src/main/java/com/litter/android/ui/home/HomeModelChip.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/home/HomeModelChip.kt
@@ -55,6 +55,7 @@ fun HomeModelChip(
     val appModel = LocalAppModel.current
     val snapshot by appModel.snapshot.collectAsState()
     val launchState by appModel.launchState.snapshot.collectAsState()
+    var showSheet by remember { mutableStateOf(false) }
 
     val server = remember(snapshot, serverId) {
         snapshot?.servers?.firstOrNull { it.serverId == serverId }
@@ -74,13 +75,21 @@ fun HomeModelChip(
             ?: selectedId.ifBlank { "model" }
     }
 
-    LaunchedEffect(serverId) {
+    LaunchedEffect(serverId, server?.transportState, showSheet) {
         if (!serverId.isNullOrBlank()) {
-            runCatching { appModel.loadConversationMetadataIfNeeded(serverId) }
+            if (showSheet) {
+                // Opening the picker is an explicit retry opportunity. The
+                // first preload can run before the selected server finishes
+                // connecting, or can leave an empty list after a transient
+                // model/list failure.
+                runCatching { appModel.loadAvailableModelsIfNeeded(serverId) }
+                runCatching { appModel.loadRateLimitsIfNeeded(serverId) }
+            } else {
+                runCatching { appModel.loadConversationMetadataIfNeeded(serverId) }
+            }
         }
     }
 
-    var showSheet by remember { mutableStateOf(false) }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     LaunchedEffect(showSheet) {


### PR DESCRIPTION
## What changed

- Retry model metadata loading when the server publishes an empty model list.
- Retry model and rate-limit loading when the home model picker is opened, including after connection-state changes.

## Why

An empty model list can come from a transient runtime or `model/list` failure. Android treated that empty result as cached metadata, leaving the picker stuck on `Loading models...` until a later lifecycle event.

## Validation

- `./gradlew :app:compileDebugKotlin --no-daemon`
- `./gradlew :app:testDebugUnitTest --no-daemon`
- `cargo test -p codex-mobile-client ffi::client::tests --lib`
- Verified model loading and selection on a connected Android device.
