### PR TITLE
bridge: support ultra reasoning effort + unknown reasoning levels

### DIFF
--- a/apps/android/app/src/main/java/com/litter/android/state/VoiceRuntimeController.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/VoiceRuntimeController.kt
@@ -527,6 +527,7 @@ class VoiceRuntimeController {
             "high" -> ReasoningEffort.HIGH
             "xhigh", "x-high" -> ReasoningEffort.X_HIGH
             "max" -> ReasoningEffort.MAX
+            "ultra" -> ReasoningEffort.ULTRA
             else -> null
         }
 

--- a/apps/android/app/src/main/java/com/litter/android/ui/common/ModelSelectorPanel.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/common/ModelSelectorPanel.kt
@@ -458,6 +458,7 @@ internal fun effortLabel(value: ReasoningEffort): String = when (value) {
     ReasoningEffort.HIGH -> "high"
     ReasoningEffort.X_HIGH -> "xhigh"
     ReasoningEffort.MAX -> "max"
+    ReasoningEffort.ULTRA -> "ultra"
 }
 
 private fun ModelInfo.defaultReasoningEffortSelection(): String? =

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ComposerBar.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ComposerBar.kt
@@ -1377,6 +1377,7 @@ private fun reasoningEffortFromServerValue(value: String): ReasoningEffort? =
         "high" -> ReasoningEffort.HIGH
         "xhigh" -> ReasoningEffort.X_HIGH
         "max" -> ReasoningEffort.MAX
+        "ultra" -> ReasoningEffort.ULTRA
         else -> null
     }
 

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationScreen.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationScreen.kt
@@ -1175,6 +1175,7 @@ private fun collaborationModeEffortLabel(
         uniffi.codex_mobile_client.ReasoningEffort.HIGH -> "High"
         uniffi.codex_mobile_client.ReasoningEffort.X_HIGH -> "XHigh"
         uniffi.codex_mobile_client.ReasoningEffort.MAX -> "Max"
+        uniffi.codex_mobile_client.ReasoningEffort.ULTRA -> "Ultra"
     }
 
 private data class PinnedContextData(

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/HeaderBar.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/HeaderBar.kt
@@ -380,4 +380,5 @@ private fun effortLabelLocal(value: uniffi.codex_mobile_client.ReasoningEffort):
         uniffi.codex_mobile_client.ReasoningEffort.HIGH -> "high"
         uniffi.codex_mobile_client.ReasoningEffort.X_HIGH -> "xhigh"
         uniffi.codex_mobile_client.ReasoningEffort.MAX -> "max"
+        uniffi.codex_mobile_client.ReasoningEffort.ULTRA -> "ultra"
     }

--- a/apps/android/app/src/main/java/com/litter/android/ui/home/HomeComposerBar.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/home/HomeComposerBar.kt
@@ -676,6 +676,7 @@ private fun reasoningEffortFromServerValue(value: String): ReasoningEffort? =
         "high" -> ReasoningEffort.HIGH
         "xhigh" -> ReasoningEffort.X_HIGH
         "max" -> ReasoningEffort.MAX
+        "ultra" -> ReasoningEffort.ULTRA
         else -> null
     }
 

--- a/apps/ios/Sources/Litter/Bridge/AppSpecificTypes.swift
+++ b/apps/ios/Sources/Litter/Bridge/AppSpecificTypes.swift
@@ -266,6 +266,8 @@ extension ReasoningEffort {
             self = .xHigh
         case "max":
             self = .max
+        case "ultra":
+            self = .ultra
         default:
             return nil
         }
@@ -280,6 +282,7 @@ extension ReasoningEffort {
         case .high: return "high"
         case .xHigh: return "xhigh"
         case .max: return "max"
+        case .ultra: return "ultra"
         }
     }
 }

--- a/apps/ios/Sources/Litter/Views/ConversationView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationView.swift
@@ -2651,6 +2651,8 @@ private func collaborationModeEffortLabel(_ effort: ReasoningEffort) -> String {
         return "XHigh"
     case .max:
         return "Max"
+    case .ultra:
+        return "Ultra"
     }
 }
 

--- a/apps/ios/scripts/sync-codex.sh
+++ b/apps/ios/scripts/sync-codex.sh
@@ -8,6 +8,7 @@ SUBMODULE_DIR="$REPO_DIR/shared/third_party/codex"
 PATCH_FILES=(
     "$REPO_DIR/patches/codex/ios-exec-hook.patch"
     "$REPO_DIR/patches/codex/mobile-code-mode-stub.patch"
+    "$REPO_DIR/patches/codex/reasoning-effort-forward-compat.patch"
     "$REPO_DIR/patches/codex/thread-read-permissions.patch"
     "$REPO_DIR/patches/codex/mobile-shell-snapshot-timeout.patch"
     "$REPO_DIR/patches/codex/remote-app-server-websocket-cap.patch"

--- a/patches/codex/reasoning-effort-forward-compat.patch
+++ b/patches/codex/reasoning-effort-forward-compat.patch
@@ -1,0 +1,36 @@
+diff --git a/codex-rs/protocol/src/openai_models.rs b/codex-rs/protocol/src/openai_models.rs
+--- a/codex-rs/protocol/src/openai_models.rs
++++ b/codex-rs/protocol/src/openai_models.rs
+@@ -48,4 +48,10 @@ pub enum ReasoningEffort {
+     Medium,
+     High,
+     XHigh,
++    Max,
++    Ultra,
++    /// A future server-defined effort that this client does not know yet.
++    /// Mobile clients degrade this sentinel instead of rejecting model/list.
++    #[serde(other)]
++    Unknown,
+ }
+@@ -546,5 +552,8 @@ fn effort_rank(effort: ReasoningEffort) -> i32 {
+         ReasoningEffort::Medium => 3,
+         ReasoningEffort::High => 4,
+         ReasoningEffort::XHigh => 5,
++        ReasoningEffort::Max => 6,
++        ReasoningEffort::Ultra => 7,
++        ReasoningEffort::Unknown => 8,
+     }
+ }
+diff --git a/codex-rs/model-provider/src/amazon_bedrock/catalog.rs b/codex-rs/model-provider/src/amazon_bedrock/catalog.rs
+--- a/codex-rs/model-provider/src/amazon_bedrock/catalog.rs
++++ b/codex-rs/model-provider/src/amazon_bedrock/catalog.rs
+@@ -139,6 +139,9 @@ fn reasoning_effort_preset(effort: ReasoningEffort) -> ReasoningEffortPreset {
+             ReasoningEffort::Medium => "Balances speed and reasoning depth for everyday tasks",
+             ReasoningEffort::High => "Greater reasoning depth for complex problems",
+             ReasoningEffort::XHigh => "Extra high reasoning depth for complex problems",
++            ReasoningEffort::Max => "Maximum reasoning depth for complex problems",
++            ReasoningEffort::Ultra => "Ultra reasoning depth for complex problems",
++            ReasoningEffort::Unknown => "Model-defined reasoning depth",
+         }
+         .to_string(),
+     }

--- a/shared/rust-bridge/codex-mobile-client/src/ffi/client.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/ffi/client.rs
@@ -2956,6 +2956,7 @@ fn inherited_settings_for_origin(
             "high" => Some(ReasoningEffort::High),
             "xhigh" | "x-high" => Some(ReasoningEffort::XHigh),
             "max" => Some(ReasoningEffort::Max),
+            "ultra" => Some(ReasoningEffort::Ultra),
             _ => None,
         }
     });

--- a/shared/rust-bridge/codex-mobile-client/src/mobile_client/tests.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/mobile_client/tests.rs
@@ -118,6 +118,10 @@ mod mobile_client_tests {
             reasoning_effort_from_string(" high "),
             Some(crate::types::ReasoningEffort::High)
         );
+        assert_eq!(
+            reasoning_effort_from_string("ULTRA"),
+            Some(crate::types::ReasoningEffort::Ultra)
+        );
         assert_eq!(reasoning_effort_from_string(""), None);
     }
 

--- a/shared/rust-bridge/codex-mobile-client/src/mobile_client/thread_projection.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/mobile_client/thread_projection.rs
@@ -487,6 +487,7 @@ pub fn reasoning_effort_string(value: crate::types::ReasoningEffort) -> String {
         crate::types::ReasoningEffort::High => "high".to_string(),
         crate::types::ReasoningEffort::XHigh => "xhigh".to_string(),
         crate::types::ReasoningEffort::Max => "max".to_string(),
+        crate::types::ReasoningEffort::Ultra => "ultra".to_string(),
     }
 }
 
@@ -499,6 +500,7 @@ pub fn reasoning_effort_from_string(value: &str) -> Option<crate::types::Reasoni
         "high" => Some(crate::types::ReasoningEffort::High),
         "xhigh" => Some(crate::types::ReasoningEffort::XHigh),
         "max" => Some(crate::types::ReasoningEffort::Max),
+        "ultra" => Some(crate::types::ReasoningEffort::Ultra),
         _ => None,
     }
 }
@@ -519,7 +521,12 @@ pub(super) fn core_reasoning_effort_from_mobile(
         crate::types::ReasoningEffort::XHigh => {
             codex_protocol::openai_models::ReasoningEffort::XHigh
         }
-        crate::types::ReasoningEffort::Max => codex_protocol::openai_models::ReasoningEffort::XHigh,
+        crate::types::ReasoningEffort::Max => "max"
+            .parse()
+            .unwrap_or(codex_protocol::openai_models::ReasoningEffort::XHigh),
+        crate::types::ReasoningEffort::Ultra => "ultra"
+            .parse()
+            .unwrap_or(codex_protocol::openai_models::ReasoningEffort::XHigh),
     }
 }
 

--- a/shared/rust-bridge/codex-mobile-client/src/types/models.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/types/models.rs
@@ -746,10 +746,12 @@ pub enum ReasoningEffort {
     High,
     XHigh,
     Max,
+    Ultra,
 }
 
 impl From<codex_protocol::openai_models::ReasoningEffort> for ReasoningEffort {
     fn from(value: codex_protocol::openai_models::ReasoningEffort) -> Self {
+        let wire_value = value.to_string();
         match value {
             codex_protocol::openai_models::ReasoningEffort::None => Self::None,
             codex_protocol::openai_models::ReasoningEffort::Minimal => Self::Minimal,
@@ -757,10 +759,12 @@ impl From<codex_protocol::openai_models::ReasoningEffort> for ReasoningEffort {
             codex_protocol::openai_models::ReasoningEffort::Medium => Self::Medium,
             codex_protocol::openai_models::ReasoningEffort::High => Self::High,
             codex_protocol::openai_models::ReasoningEffort::XHigh => Self::XHigh,
-            // Newer/local codex checkouts may expose Max before the pinned
-            // submodule advances. Do not name that upstream variant here, so
-            // clean checkouts at the committed gitlink still compile.
+            // The pinned Codex compatibility patch accepts Max, Ultra, and an
+            // unknown-value sentinel. Match Ultra by its wire value so this
+            // bridge still compiles against both older and newer checkouts;
+            // everything else degrades to Max without blocking model/list.
             #[allow(unreachable_patterns)]
+            _ if wire_value == "ultra" => Self::Ultra,
             _ => Self::Max,
         }
     }
@@ -1499,6 +1503,17 @@ impl From<upstream::ThreadRealtimeSdpNotification> for AppRealtimeSdpNotificatio
 mod tests {
     use super::*;
     use crate::types::enums::ThreadSummaryStatus;
+
+    #[test]
+    fn reasoning_effort_accepts_ultra_and_degrades_future_values() {
+        let ultra: codex_protocol::openai_models::ReasoningEffort =
+            serde_json::from_str("\"ultra\"").expect("ultra should deserialize");
+        assert_eq!(ReasoningEffort::from(ultra), ReasoningEffort::Ultra);
+
+        let future: codex_protocol::openai_models::ReasoningEffort =
+            serde_json::from_str("\"future-effort\"").expect("future values should deserialize");
+        assert_eq!(ReasoningEffort::from(future), ReasoningEffort::Max);
+    }
 
     #[test]
     fn thread_info_roundtrip() {

--- a/shared/rust-bridge/codex-mobile-client/src/types/server_requests.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/types/server_requests.rs
@@ -79,10 +79,10 @@ pub(crate) fn reasoning_effort_into_upstream(value: ReasoningEffort) -> CoreReas
         ReasoningEffort::Medium => CoreReasoningEffort::Medium,
         ReasoningEffort::High => CoreReasoningEffort::High,
         ReasoningEffort::XHigh => CoreReasoningEffort::XHigh,
-        // The committed codex submodule does not expose a Max effort. Keep the
-        // mobile value for runtime-specific UI, but degrade to the strongest
-        // upstream effort available for Codex requests.
-        ReasoningEffort::Max => CoreReasoningEffort::XHigh,
+        // Parsing keeps this source compatible before the Codex compatibility
+        // patch is applied; older checkouts safely degrade to XHigh.
+        ReasoningEffort::Max => "max".parse().unwrap_or(CoreReasoningEffort::XHigh),
+        ReasoningEffort::Ultra => "ultra".parse().unwrap_or(CoreReasoningEffort::XHigh),
     }
 }
 


### PR DESCRIPTION
Solves https://github.com/0xSero/litter/issues/180

  - Recognizes ultra throughout the Rust bridge, iOS, and Android.
  - Makes pinned Codex accept max, ultra, and unknown future reasoning-effort values.
  - Degrades unknown values to Litter’s strongest known option (max) instead of failing the entire model/
    list response.
  - Leaves generated bindings untouched.
  - Adds focused assertions for eventual CI coverage

