### PR TITLE
docs(release): add App Store 1.6.0 notes

### DIFF
--- a/apps/ios/fastlane/metadata/en-US/release_notes.txt
+++ b/apps/ios/fastlane/metadata/en-US/release_notes.txt
@@ -1,1 +1,7 @@
-Bug fixes and improvements.
+Pair Litter with Local Studio and use its Pi agents from your phone.
+
+- See and continue the same sessions in Litter and Local Studio.
+- Enjoy smoother reasoning, text, and tool-call streaming.
+- Create files with tools while reasoning, content, and tool events stay in order.
+- Resume sessions more reliably after compaction, reconnecting, or restarting.
+- Open localstudio.ai directly from Settings > Local AI.


### PR DESCRIPTION
## Purpose
Replace the placeholder App Store release note with the tested Litter 1.6.0 user-facing changes before submission.

## Verification
- metadata file is 413 bytes, below App Store limits
- `git diff --check` passes
- wording matches the detailed TestFlight and Google Play notes already merged in #193