### PR TITLE
ci: validate Play credentials before builds

### DIFF
--- a/.github/workflows/android-play-release.yml
+++ b/.github/workflows/android-play-release.yml
@@ -56,6 +56,7 @@ jobs:
           LITTER_UPLOAD_KEY_ALIAS: ${{ secrets.LITTER_UPLOAD_KEY_ALIAS }}
           LITTER_UPLOAD_KEY_PASSWORD: ${{ secrets.LITTER_UPLOAD_KEY_PASSWORD }}
           LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64: ${{ secrets.LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64 }}
+          GOOGLE_SERVICES_JSON_B64: ${{ secrets.GOOGLE_SERVICES_JSON_B64 }}
         run: |
           set -euo pipefail
           required=(
@@ -68,6 +69,20 @@ jobs:
           for name in "${required[@]}"; do
             if [[ -z "${!name:-}" ]]; then
               echo "Missing required secret: $name" >&2
+              exit 1
+            fi
+          done
+
+          encoded=(
+            ANDROID_UPLOAD_KEYSTORE_B64
+            LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64
+          )
+          if [[ -n "${GOOGLE_SERVICES_JSON_B64:-}" ]]; then
+            encoded+=(GOOGLE_SERVICES_JSON_B64)
+          fi
+          for name in "${encoded[@]}"; do
+            if ! printf '%s' "${!name}" | base64 --decode >/dev/null; then
+              echo "Secret is not valid base64: $name" >&2
               exit 1
             fi
           done
@@ -263,10 +278,10 @@ jobs:
           set -euo pipefail
           store_file="$RUNNER_TEMP/litter-upload.jks"
           service_account_json="$RUNNER_TEMP/play-service-account.json"
-          echo "$ANDROID_UPLOAD_KEYSTORE_B64" | base64 --decode > "$store_file"
-          echo "$LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64" | base64 --decode > "$service_account_json"
+          printf '%s' "$ANDROID_UPLOAD_KEYSTORE_B64" | base64 --decode > "$store_file"
+          printf '%s' "$LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64" | base64 --decode > "$service_account_json"
           if [ -n "${GOOGLE_SERVICES_JSON_B64:-}" ]; then
-            echo "$GOOGLE_SERVICES_JSON_B64" | base64 --decode > apps/android/app/google-services.json
+            printf '%s' "$GOOGLE_SERVICES_JSON_B64" | base64 --decode > apps/android/app/google-services.json
           fi
           echo "LITTER_UPLOAD_STORE_FILE=$store_file" >> "$GITHUB_ENV"
           echo "LITTER_PLAY_SERVICE_ACCOUNT_JSON=$service_account_json" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Purpose

Fail the Play release immediately with the exact malformed credential name instead of spending runner time and failing later in an unlabeled decode step.

## Changes

- validate every required base64 release credential in preflight
- validate the optional Firebase client config when present
- use `printf` instead of `echo` for exact secret decoding

## Verification

- workflow YAML parses successfully
- `git diff --check` passes
- live release runs 30645951457 and 30646578880 both reached the unlabeled `base64: invalid input` failure this change makes actionable