### PR TITLE
ci: accept raw Play service account JSON

### DIFF
--- a/.github/workflows/android-play-release.yml
+++ b/.github/workflows/android-play-release.yml
@@ -75,7 +75,6 @@ jobs:
 
           encoded=(
             ANDROID_UPLOAD_KEYSTORE_B64
-            LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64
           )
           if [[ -n "${GOOGLE_SERVICES_JSON_B64:-}" ]]; then
             encoded+=(GOOGLE_SERVICES_JSON_B64)
@@ -86,6 +85,21 @@ jobs:
               exit 1
             fi
           done
+
+          validate_json_secret() {
+            local name="$1"
+            local value="${!name}"
+            if printf '%s' "$value" | base64 --decode 2>/dev/null | jq -e . >/dev/null 2>&1; then
+              return 0
+            fi
+            if printf '%s' "$value" | jq -e . >/dev/null 2>&1; then
+              echo "::notice::$name is stored as raw JSON; accepting it for compatibility"
+              return 0
+            fi
+            echo "Secret is neither base64-encoded JSON nor raw JSON: $name" >&2
+            return 1
+          }
+          validate_json_secret LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64
 
   shared-prep:
     needs: release-preflight
@@ -279,7 +293,13 @@ jobs:
           store_file="$RUNNER_TEMP/litter-upload.jks"
           service_account_json="$RUNNER_TEMP/play-service-account.json"
           printf '%s' "$ANDROID_UPLOAD_KEYSTORE_B64" | base64 --decode > "$store_file"
-          printf '%s' "$LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64" | base64 --decode > "$service_account_json"
+          if printf '%s' "$LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64" | base64 --decode 2>/dev/null > "$service_account_json" \
+            && jq -e . "$service_account_json" >/dev/null 2>&1; then
+            :
+          else
+            printf '%s' "$LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64" > "$service_account_json"
+            jq -e . "$service_account_json" >/dev/null
+          fi
           if [ -n "${GOOGLE_SERVICES_JSON_B64:-}" ]; then
             printf '%s' "$GOOGLE_SERVICES_JSON_B64" | base64 --decode > apps/android/app/google-services.json
           fi


### PR DESCRIPTION
## Purpose
Unblock the Android Play release when the Firebase service-account secret was stored as raw JSON under the legacy `_B64` name.

## Changes
- validate the service-account secret as either base64 JSON or raw JSON
- decode base64 when present and otherwise write the raw JSON credential securely
- keep keystore and google-services inputs strictly base64

## Verification
- `git diff --check`
- workflow YAML parse
- local shell coverage for raw JSON, base64 JSON, and invalid input

No secret values are logged.