### PR TITLE
ios: initialize absent Codex submodule correctly

### DIFF
--- a/apps/ios/scripts/sync-codex.sh
+++ b/apps/ios/scripts/sync-codex.sh
@@ -39,7 +39,10 @@ case "$SYNC_MODE" in
 esac
 
 echo "==> Syncing codex submodule..."
-if ! git -C "$SUBMODULE_DIR" rev-parse --verify HEAD >/dev/null 2>&1; then
+# An uninitialized submodule is an empty directory without its own .git file.
+# `git -C` alone is not sufficient here: Git walks up to the parent worktree
+# and can incorrectly report the superproject's HEAD as the submodule HEAD.
+if [ ! -e "$SUBMODULE_DIR/.git" ] || ! git -C "$SUBMODULE_DIR" rev-parse --verify HEAD >/dev/null 2>&1; then
     git -C "$REPO_DIR" submodule update --init --recursive shared/third_party/codex
 elif [ "$SYNC_MODE" = "--recorded-gitlink" ]; then
     git -C "$REPO_DIR" submodule update --init --recursive shared/third_party/codex


### PR DESCRIPTION
## Purpose
Fix fresh-worktree iOS builds that fail because an empty Codex submodule directory is mistaken for an initialized checkout.

## Changes
- Require the submodule own `.git` marker before trusting `git -C ... rev-parse`
- Fall back to `git submodule update --init --recursive` when the marker is absent

## Verification
- `bash -n apps/ios/scripts/sync-codex.sh`
- Ran the script from an uninitialized worktree: Codex cloned at the recorded gitlink and all mobile patches applied
- Ran the script again: it detected the recorded gitlink and all patches idempotently