### PR TITLE
ci: preserve Android release artifacts on upload failure

### DIFF
--- a/.github/workflows/android-play-release.yml
+++ b/.github/workflows/android-play-release.yml
@@ -337,6 +337,7 @@ jobs:
           sccache --show-stats || true
 
       - name: Build Android release APK
+        id: build_android_release
         env:
           JAVA_HOME: ${{ env.JAVA_HOME }}
           ANDROID_SDK_ROOT: ${{ env.ANDROID_HOME }}
@@ -399,6 +400,7 @@ jobs:
           sccache --show-stats || true
 
       - name: Generate checksums
+        if: always() && steps.build_android_release.outcome == 'success'
         run: |
           set -euo pipefail
           APK_PATH="apps/android/app/build/outputs/apk/release/app-release.apk"
@@ -407,6 +409,7 @@ jobs:
           sha256sum "$AAB_PATH" > "${AAB_PATH}.sha256"
 
       - name: Upload Android release artifacts
+        if: always() && steps.build_android_release.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
           name: android-play-release-${{ github.run_number }}

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -446,6 +446,7 @@ jobs:
           sccache --show-stats || true
 
       - name: Build Android release APK
+        id: build_android_release
         env:
           JAVA_HOME: ${{ env.JAVA_HOME }}
           ANDROID_SDK_ROOT: ${{ env.ANDROID_HOME }}
@@ -513,6 +514,7 @@ jobs:
           sccache --show-stats || true
 
       - name: Generate checksums
+        if: always() && steps.build_android_release.outcome == 'success'
         run: |
           set -euo pipefail
           APK_PATH="apps/android/app/build/outputs/apk/release/app-release.apk"
@@ -521,6 +523,7 @@ jobs:
           sha256sum "$AAB_PATH" > "${AAB_PATH}.sha256"
 
       - name: Upload Android release artifacts
+        if: always() && steps.build_android_release.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
           name: android-play-release-${{ github.run_number }}


### PR DESCRIPTION
## Purpose
Keep the signed Android APK/AAB available when Google Play rejects the upload, so release operators can inspect or manually upload the exact built artifact without rebuilding.

## Changes
- Give the signed Android build step a stable step id.
- Run checksum and artifact-upload steps after a Play publish failure when the signed build succeeded.
- Apply the behavior to both automatic Mobile Release and manual Android Play Release workflows.

## Verification
- `git diff --check`
- Both workflow YAML files parse successfully with Ruby Psych.
- `actionlint` passes when available.