### PR TITLE
ci: keep Android release version codes monotonic

### DIFF
--- a/.github/workflows/android-play-release.yml
+++ b/.github/workflows/android-play-release.yml
@@ -312,7 +312,17 @@ jobs:
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
           set -euo pipefail
-          VERSION_CODE="$((200000000 + GITHUB_RUN_NUMBER))"
+          CURRENT_VERSION_CODE="$(sed -n 's/.*versionCode = \([0-9][0-9]*\).*/\1/p' apps/android/app/build.gradle.kts | head -1)"
+          if [[ -z "$CURRENT_VERSION_CODE" ]]; then
+            echo "Unable to resolve the current Android versionCode" >&2
+            exit 1
+          fi
+          RUN_VERSION_CODE="$((200000000 + GITHUB_RUN_NUMBER))"
+          VERSION_CODE="$RUN_VERSION_CODE"
+          if (( VERSION_CODE <= CURRENT_VERSION_CODE )); then
+            VERSION_CODE="$((CURRENT_VERSION_CODE + 1))"
+          fi
+          echo "Android versionCode: current=$CURRENT_VERSION_CODE run=$RUN_VERSION_CODE selected=$VERSION_CODE"
           echo "LITTER_VERSION_CODE_OVERRIDE=$VERSION_CODE" >> "$GITHUB_ENV"
 
       - name: Apply Android versionCode

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -421,7 +421,17 @@ jobs:
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
           set -euo pipefail
-          VERSION_CODE="$((200000000 + GITHUB_RUN_NUMBER))"
+          CURRENT_VERSION_CODE="$(sed -n 's/.*versionCode = \([0-9][0-9]*\).*/\1/p' apps/android/app/build.gradle.kts | head -1)"
+          if [[ -z "$CURRENT_VERSION_CODE" ]]; then
+            echo "Unable to resolve the current Android versionCode" >&2
+            exit 1
+          fi
+          RUN_VERSION_CODE="$((200000000 + GITHUB_RUN_NUMBER))"
+          VERSION_CODE="$RUN_VERSION_CODE"
+          if (( VERSION_CODE <= CURRENT_VERSION_CODE )); then
+            VERSION_CODE="$((CURRENT_VERSION_CODE + 1))"
+          fi
+          echo "Android versionCode: current=$CURRENT_VERSION_CODE run=$RUN_VERSION_CODE selected=$VERSION_CODE"
           echo "LITTER_VERSION_CODE_OVERRIDE=$VERSION_CODE" >> "$GITHUB_ENV"
 
       - name: Apply Android versionCode


### PR DESCRIPTION
Purpose

Prevent the Android-only release workflow from generating a versionCode lower than the version already published in Google Play.

Key changes

- Read the committed Android versionCode before selecting a CI override.
- Use the workflow run-based value only when it is higher; otherwise select current + 1.
- Apply the same rule in both Android release workflows.

Verification

- `git diff --check`
- YAML parsed with Ruby Psych
- `actionlint .github/workflows/android-play-release.yml .github/workflows/mobile-release.yml`
- Shell cases: run 21 selects 200000255 from current 200000254; run 300 selects 200000300.