### PR TITLE
fix(mobile): stabilize Local Studio agent scan

### DIFF
--- a/apps/android/app/src/androidTest/java/com/litter/android/NativeContextInitTest.kt
+++ b/apps/android/app/src/androidTest/java/com/litter/android/NativeContextInitTest.kt
@@ -36,7 +36,7 @@ class NativeContextInitTest {
 
             try {
                 ServerBridge().use { bridge ->
-                    bridge.listAlleycatAgents(params)
+                    bridge.listAlleycatAgents(params, waitForRegistration = false)
                 }
             } catch (error: ClientException) {
                 assertFalse(

--- a/apps/android/app/src/main/java/com/litter/android/ui/discovery/AlleycatAddServerSheet.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/discovery/AlleycatAddServerSheet.kt
@@ -137,7 +137,10 @@ fun AlleycatAddServerSheet(
             try {
                 val loaded = withContext(Dispatchers.IO) {
                     UniffiInit.ensure(context.applicationContext)
-                    appModel.serverBridge.listAlleycatAgents(params)
+                    appModel.serverBridge.listAlleycatAgents(
+                        params,
+                        waitForRegistration = pairingMode == AlleycatPairingMode.LocalStudio,
+                    )
                 }
                 if (parsedParams?.nodeId == params.nodeId) {
                     agents = loaded

--- a/apps/ios/Sources/Litter/Views/AlleycatAddServerSheet.swift
+++ b/apps/ios/Sources/Litter/Views/AlleycatAddServerSheet.swift
@@ -424,7 +424,10 @@ struct AlleycatAddServerSheet: View {
         isLoadingAgents = true
         Task {
             do {
-                let loaded = try await appModel.serverBridge.listAlleycatAgents(params: params)
+                let loaded = try await appModel.serverBridge.listAlleycatAgents(
+                    params: params,
+                    waitForRegistration: pairingMode == .localStudio
+                )
                 await MainActor.run {
                     guard parsedParams?.nodeId == params.nodeId else { return }
                     agents = loaded

--- a/shared/rust-bridge/codex-mobile-client/src/ffi/discovery.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/ffi/discovery.rs
@@ -288,10 +288,11 @@ impl ServerBridge {
     pub async fn list_alleycat_agents(
         &self,
         params: crate::ffi::alleycat::AppAlleycatPairPayload,
+        wait_for_registration: bool,
     ) -> Result<Vec<crate::ffi::alleycat::AppAlleycatAgentInfo>, ClientError> {
         let parsed: crate::alleycat::ParsedPairPayload = params.into();
         blocking_async!(self.rt, self.inner, |c| {
-            c.list_alleycat_agents(parsed)
+            c.list_alleycat_agents(parsed, wait_for_registration)
                 .await
                 .map(|agents| agents.into_iter().map(Into::into).collect())
                 .map_err(|e| ClientError::Transport(e.to_string()))

--- a/shared/rust-bridge/codex-mobile-client/src/mobile_client/mod.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/mobile_client/mod.rs
@@ -722,6 +722,14 @@ fn merge_alleycat_agent_inventory(
     }
 }
 
+fn alleycat_inventory_refresh_delays(wait_for_registration: bool) -> &'static [u64] {
+    if wait_for_registration {
+        &ALLEYCAT_AGENT_INVENTORY_REFRESH_DELAYS_MS
+    } else {
+        &[]
+    }
+}
+
 fn alleycat_dial_retry_delays(use_all_controller_agents: bool) -> &'static [u64] {
     if use_all_controller_agents {
         &ALLEYCAT_CONTROLLER_AGENT_DIAL_RETRY_DELAYS_MS
@@ -1749,14 +1757,25 @@ impl MobileClient {
     pub async fn list_alleycat_agents(
         &self,
         params: ParsedAlleycatPairPayload,
+        wait_for_registration: bool,
     ) -> Result<Vec<AlleycatAgentInfo>, TransportError> {
         let endpoint = self
             .alleycat_endpoint()
             .await
             .map_err(|error| TransportError::ConnectionFailed(error.to_string()))?;
-        let agents = crate::alleycat::list_agents(&endpoint, params)
+        let mut agents = crate::alleycat::list_agents(&endpoint, params.clone())
             .await
             .map_err(|error| TransportError::ConnectionFailed(error.to_string()))?;
+        for delay_ms in alleycat_inventory_refresh_delays(wait_for_registration) {
+            tokio::time::sleep(std::time::Duration::from_millis(*delay_ms)).await;
+            match crate::alleycat::list_agents(&endpoint, params.clone()).await {
+                Ok(refreshed) => merge_alleycat_agent_inventory(&mut agents, refreshed),
+                Err(error) => warn!(
+                    "MobileClient: Alleycat inventory refresh failed node_id={} delay_ms={} error={}",
+                    params.node_id, delay_ms, error
+                ),
+            }
+        }
         // Cache metadata so platforms can render labels/icons/capability
         // flags from anywhere in the app, not just at probe time.
         self.agent_metadata
@@ -1811,26 +1830,12 @@ impl MobileClient {
         let selected_agent_names = selected_agent_names
             .into_iter()
             .collect::<std::collections::HashSet<_>>();
-        let mut agent_inventory = self.list_alleycat_agents(params.clone()).await?;
-        if use_all_controller_agents {
-            // The controller can answer inventory requests before every enabled
-            // runtime bridge has finished its cold-start registration. Sample a
-            // short startup window and merge by stable agent name so a fast
-            // Local Studio bridge cannot make a slightly slower Codex bridge
-            // disappear for the entire app session.
-            for delay_ms in ALLEYCAT_AGENT_INVENTORY_REFRESH_DELAYS_MS {
-                tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
-                match self.list_alleycat_agents(params.clone()).await {
-                    Ok(refreshed) => {
-                        merge_alleycat_agent_inventory(&mut agent_inventory, refreshed)
-                    }
-                    Err(error) => warn!(
-                        "MobileClient: Alleycat controller inventory refresh failed server_id={} delay_ms={} error={}",
-                        server_id, delay_ms, error
-                    ),
-                }
-            }
-        }
+        // Local Studio can answer before its Pi/Codex bridges have registered.
+        // Stabilize the same inventory used by the pairing scanner and connect
+        // path so an empty first probe cannot permanently hide those agents.
+        let agent_inventory = self
+            .list_alleycat_agents(params.clone(), use_all_controller_agents)
+            .await?;
         let mut seen_runtime_kinds = std::collections::HashSet::new();
         let requested_agents = agent_inventory
             .into_iter()

--- a/shared/rust-bridge/codex-mobile-client/src/mobile_client/tests.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/mobile_client/tests.rs
@@ -482,6 +482,11 @@ mod mobile_client_tests {
             "alleycat:controller-node"
         ));
         assert_eq!(
+            alleycat_inventory_refresh_delays(true),
+            ALLEYCAT_AGENT_INVENTORY_REFRESH_DELAYS_MS
+        );
+        assert!(alleycat_inventory_refresh_delays(false).is_empty());
+        assert_eq!(
             alleycat_dial_retry_delays(true),
             ALLEYCAT_CONTROLLER_AGENT_DIAL_RETRY_DELAYS_MS
         );
@@ -492,15 +497,8 @@ mod mobile_client_tests {
     }
 
     #[test]
-    fn alleycat_inventory_refresh_updates_existing_agents_and_keeps_new_agents() {
-        let mut inventory = vec![AlleycatAgentInfo {
-            name: "local-studio".to_string(),
-            display_name: "Local Studio".to_string(),
-            wire: AlleycatAgentWire::Jsonl,
-            available: true,
-            presentation: None,
-            capabilities: None,
-        }];
+    fn alleycat_inventory_refresh_recovers_from_empty_initial_probe() {
+        let mut inventory = Vec::new();
         merge_alleycat_agent_inventory(
             &mut inventory,
             vec![
@@ -526,6 +524,20 @@ mod mobile_client_tests {
         assert_eq!(inventory.len(), 2);
         assert_eq!(inventory[0].display_name, "Local Studio (ready)");
         assert_eq!(inventory[1].name, "codex");
+
+        merge_alleycat_agent_inventory(
+            &mut inventory,
+            vec![AlleycatAgentInfo {
+                name: "codex".to_string(),
+                display_name: "Codex (ready)".to_string(),
+                wire: AlleycatAgentWire::Websocket,
+                available: true,
+                presentation: None,
+                capabilities: None,
+            }],
+        );
+        assert_eq!(inventory.len(), 2);
+        assert_eq!(inventory[1].display_name, "Codex (ready)");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- stabilize Local Studio agent discovery across the controller's cold-registration window
- keep generic KittyLitter scans immediate
- reuse one shared Rust inventory path for scanner and connection, removing the duplicate connection retry loop
- project the mode choice through thin iOS and Android calls

## Root cause

The Local Studio controller can answer an inventory request before Pi, Codex, and other enabled agent bridges have registered. Litter scanned once and disabled Connect when that first inventory was empty, while the later connection path contained retries the user could never reach.

## Verification

- focused Rust recovery and Local Studio connection-expansion tests passed
- full `codex-mobile-client` library suite: 774 passed, 0 failed, 5 ignored live-only tests
- generated Swift and Kotlin bindings successfully
- Android unit tests, debug AndroidTest compilation, and debug APK assembly passed
- iOS fast simulator build passed
- live iPhone 17 Pro simulator flow passed against the Pop!_OS controller: paste Local Studio connection JSON, discover Pi and Codex, select agents, connect, and observe the pairing sheet close
- live controller inventory found Codex, Pi, OpenCode, Claude, Droid, Hermes, and Shell; multiplexed connection attached every available agent
- Pop!_OS mobile website exercised progressive streaming, rendered reasoning, and completed a shell tool call
- installed Local Studio desktop app completed a fresh shell tool call and rendered the completion; an existing task confirmed desktop reasoning rendering
- the identical pre-rebase patch passed GitHub Mobile CI `shared-prep`, `android`, and `ios`; final head `517f2d69` passed release planning and the Windows npm test, while its Mobile CI rerun is queued for shared runner capacity

## Review notes

- Local Studio waits through the same bounded 500/1000/1500 ms registration window previously hidden in the connection path
- refreshes merge by agent name, update later metadata, and retain earlier inventory if a later refresh fails
- KittyLitter behavior remains immediate
- no generated bindings or temporary live-test credentials are committed
- physical-device and Android-emulator runtime validation were not performed in this pass
