### PR TITLE
release: fix Windows npm install with verified provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,6 +224,15 @@ jobs:
           dist build ${{ needs.plan.outputs.tag-flag }} --output-format=json "--artifacts=global" > dist-manifest.json
           echo "dist ran successfully"
 
+          # cargo-dist 0.31.0's Windows npm installer can report success when
+          # Expand-Archive did not create the expected executable. Finalize the
+          # package before it enters scratch storage, then replace both checksum
+          # records so every downstream publisher consumes these exact bytes.
+          node tools/scripts/finalize-kittylitter-npm-package.js \
+            --directory target/distrib \
+            --manifest dist-manifest.json \
+            --checksum-list target/distrib/sha256.sum
+
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
           jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
@@ -237,14 +246,74 @@ jobs:
           path: |
             ${{ steps.cargo-dist.outputs.paths }}
             ${{ env.BUILD_MANIFEST_NAME }}
+
+  test-final-npm-windows:
+    needs:
+      - plan
+      - build-local-artifacts
+      - build-global-artifacts
+    if: ${{ always() && needs.plan.result == 'success' && (needs.build-global-artifacts.result == 'success' || needs.build-global-artifacts.result == 'skipped') }}
+    runs-on: windows-2025
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          package-manager-cache: false
+      - name: Test npm package finalizer
+        run: node --test tools/scripts/tests/finalize-kittylitter-npm-package.test.js
+      - name: Fetch finalized release artifacts
+        if: ${{ needs.build-global-artifacts.result == 'success' }}
+        uses: actions/download-artifact@v7
+        with:
+          pattern: artifacts-*
+          path: target/distrib/
+          merge-multiple: true
+      - name: Verify finalized release artifact provenance
+        if: ${{ needs.build-global-artifacts.result == 'success' }}
+        run: |
+          node tools/scripts/finalize-kittylitter-npm-package.js `
+            --verify-only `
+            --directory target/distrib `
+            --manifest target/distrib/global-dist-manifest.json `
+            --checksum-list target/distrib/sha256.sum
+      - name: Fetch pinned cargo-dist 0.31.0 fixture artifacts
+        if: ${{ needs.build-global-artifacts.result == 'skipped' }}
+        run: |
+          New-Item -ItemType Directory -Force target/distrib | Out-Null
+          gh release download v0.3.4 `
+            --repo 0xSero/litter `
+            --dir target/distrib `
+            --pattern kittylitter-npm-package.tar.gz `
+            --pattern kittylitter-x86_64-pc-windows-msvc.zip `
+            --pattern dist-manifest.json `
+            --pattern sha256.sum
+      - name: Finalize pinned cargo-dist fixture
+        if: ${{ needs.build-global-artifacts.result == 'skipped' }}
+        run: |
+          node tools/scripts/finalize-kittylitter-npm-package.js `
+            --directory target/distrib `
+            --manifest target/distrib/dist-manifest.json `
+            --checksum-list target/distrib/sha256.sum
+      - name: Smoke-test finalized npm installer
+        run: |
+          node tools/scripts/test-kittylitter-npm-windows.js `
+            target/distrib/kittylitter-npm-package.tar.gz `
+            target/distrib/kittylitter-x86_64-pc-windows-msvc.zip
+
   # Determines if we should publish/announce
   host:
     needs:
       - plan
       - build-local-artifacts
       - build-global-artifacts
+      - test-final-npm-windows
     # Only run if we're "publishing", and only if plan, local and global didn't fail (skipped is fine)
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') && (needs.test-final-npm-windows.result == 'skipped' || needs.test-final-npm-windows.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: "ubuntu-22.04"
@@ -268,6 +337,14 @@ jobs:
           pattern: artifacts-*
           path: target/distrib/
           merge-multiple: true
+      - name: Verify finalized artifacts before hosting
+        if: ${{ needs.build-global-artifacts.result == 'success' }}
+        run: |
+          node tools/scripts/finalize-kittylitter-npm-package.js \
+            --verify-only \
+            --directory target/distrib \
+            --manifest target/distrib/global-dist-manifest.json \
+            --checksum-list target/distrib/sha256.sum
       - id: host
         shell: bash
         run: |
@@ -275,6 +352,14 @@ jobs:
           echo "artifacts uploaded and released successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
+      - name: Verify hosted manifest provenance
+        if: ${{ needs.build-global-artifacts.result == 'success' }}
+        run: |
+          node tools/scripts/finalize-kittylitter-npm-package.js \
+            --verify-only \
+            --directory target/distrib \
+            --manifest dist-manifest.json \
+            --checksum-list target/distrib/sha256.sum
       - name: "Upload dist-manifest.json"
         uses: actions/upload-artifact@v6
         with:
@@ -317,6 +402,9 @@ jobs:
       PLAN: ${{ needs.plan.outputs.val }}
     if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
     steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Fetch npm packages
         uses: actions/download-artifact@v7
         with:
@@ -325,13 +413,20 @@ jobs:
           merge-multiple: true
       - uses: actions/setup-node@v6
         with:
-          node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
           package-manager-cache: false
+      - name: Verify final package provenance
+        run: |
+          node tools/scripts/finalize-kittylitter-npm-package.js \
+            --verify-only \
+            --directory npm \
+            --manifest npm/dist-manifest.json \
+            --checksum-list npm/sha256.sum
       - run: |
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do
             pkg=$(echo "$release" | jq '.artifacts[] | select(endswith("-npm-package.tar.gz"))' --raw-output)
-            npm publish --access public "./npm/${pkg}"
+            npm publish --access public --provenance "./npm/${pkg}"
           done
 
   announce:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,6 +254,9 @@ jobs:
       - build-global-artifacts
     if: ${{ always() && needs.plan.result == 'success' && (needs.build-global-artifacts.result == 'success' || needs.build-global-artifacts.result == 'skipped') }}
     runs-on: windows-2025
+    timeout-minutes: 15
+    permissions:
+      contents: read
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/tools/scripts/finalize-kittylitter-npm-package.js
+++ b/tools/scripts/finalize-kittylitter-npm-package.js
@@ -1,0 +1,322 @@
+#!/usr/bin/env node
+
+const crypto = require("crypto");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const PATCH_MARKER = "LITTER_CARGO_DIST_WINDOWS_EXTRACTION_FIX";
+const NPM_PACKAGE_SUFFIX = "-npm-package.tar.gz";
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    stdio: "pipe",
+    ...options,
+  });
+  if (result.error || result.status !== 0) {
+    throw new Error(
+      [
+        `command failed: ${command} ${args.join(" ")}`,
+        result.error ? `error: ${result.error.message}` : "",
+        result.stdout ? `stdout:\n${result.stdout}` : "",
+        result.stderr ? `stderr:\n${result.stderr}` : "",
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    );
+  }
+  return result;
+}
+
+function patchBinaryInstaller(source) {
+  if (source.includes(PATCH_MARKER)) {
+    throw new Error("cargo-dist binary installer is already finalized");
+  }
+
+  const originalWindowsExtractor = `if (this.platform.artifactName.includes("windows")) {
+                  // Windows does not have "unzip" by default on many installations, instead
+                  // we use Expand-Archive from powershell
+                  result = spawnSync("powershell.exe", [
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-Command",
+                    \`& {
+                        param([string]$LiteralPath, [string]$DestinationPath)
+                        Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
+                    }\`,
+                    tempFile,
+                    this.installDirectory,
+                  ]);
+                }`;
+
+  const windowsExtractor = `if (this.platform.artifactName.includes("windows")) {
+                  // ${PATCH_MARKER}
+                  // Modern Windows includes bsdtar. Prefer it because some
+                  // PowerShell installations cannot autoload Expand-Archive.
+                  result = spawnSync("tar", [
+                    "-xf",
+                    tempFile,
+                    "-C",
+                    this.installDirectory,
+                  ]);
+
+                  if (result.error || result.status !== 0) {
+                    result = spawnSync("powershell.exe", [
+                      "-NoProfile",
+                      "-NonInteractive",
+                      "-ExecutionPolicy",
+                      "Bypass",
+                      "-Command",
+                      \`& {
+                        param([string]$LiteralPath, [string]$DestinationPath)
+                        $ErrorActionPreference = "Stop"
+                        Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
+                    }\`,
+                      tempFile,
+                      this.installDirectory,
+                    ]);
+                  }
+                }`;
+
+  if (!source.includes(originalWindowsExtractor)) {
+    throw new Error(
+      "cargo-dist 0.31.0 Windows extractor block was not found; update the pinned fixture before changing the patch",
+    );
+  }
+  source = source.replace(originalWindowsExtractor, windowsExtractor);
+
+  const installSuccessBlock = `.then(() => {
+        if (!suppressLogs) {
+          console.error(\`${"${this.name}"} has been installed!\`);
+        }
+      })`;
+
+  const verifiedInstallSuccessBlock = `.then(() => {
+        if (!this.exists()) {
+          const missing = Object.values(this.binaries)
+            .map((binRelPath) => join(this.installDirectory, binRelPath))
+            .filter((binPath) => !existsSync(binPath));
+          throw new Error(
+            \`${"${this.name}"} install failed: missing expected binaries: ${'${missing.join(", ")}'}\`,
+          );
+        }
+        if (!suppressLogs) {
+          console.error(\`${"${this.name}"} has been installed!\`);
+        }
+      })`;
+
+  if (!source.includes(installSuccessBlock)) {
+    throw new Error(
+      "cargo-dist 0.31.0 install-success block was not found; update the pinned fixture before changing the patch",
+    );
+  }
+  return source.replace(installSuccessBlock, verifiedInstallSuccessBlock);
+}
+
+function sha256File(filePath) {
+  const hash = crypto.createHash("sha256");
+  hash.update(fs.readFileSync(filePath));
+  return hash.digest("hex");
+}
+
+function findArtifact(manifest, packageName) {
+  if (!manifest || typeof manifest.artifacts !== "object") {
+    throw new Error("cargo-dist manifest does not contain an artifacts object");
+  }
+  const matches = Object.entries(manifest.artifacts).filter(
+    ([key, artifact]) => key === packageName || artifact?.name === packageName,
+  );
+  if (matches.length !== 1) {
+    throw new Error(
+      `expected exactly one cargo-dist manifest entry for ${packageName}, found ${matches.length}`,
+    );
+  }
+  const artifact = matches[0][1];
+  if (!artifact.checksums || typeof artifact.checksums.sha256 !== "string") {
+    throw new Error(
+      `cargo-dist manifest entry for ${packageName} lacks sha256`,
+    );
+  }
+  return artifact;
+}
+
+function updateManifest(manifestPath, packageName, digest) {
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  findArtifact(manifest, packageName).checksums.sha256 = digest;
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+function updateChecksumList(checksumPath, packageName, digest) {
+  const lines = fs.readFileSync(checksumPath, "utf8").split(/\r?\n/);
+  let matches = 0;
+  const updated = lines.map((line) => {
+    const match = line.match(/^([a-fA-F0-9]{64})(\s+)(\*?)(.+)$/);
+    if (!match || path.basename(match[4]) !== packageName) {
+      return line;
+    }
+    matches += 1;
+    return `${digest}${match[2]}${match[3]}${match[4]}`;
+  });
+  if (matches !== 1) {
+    throw new Error(
+      `expected exactly one checksum-list entry for ${packageName}, found ${matches}`,
+    );
+  }
+  fs.writeFileSync(checksumPath, updated.join("\n"));
+}
+
+function readInstallerSource(packagePath) {
+  return run("tar", ["-xOzf", packagePath, "package/binary-install.js"]).stdout;
+}
+
+function verifyFinalizedPackage(packagePath, manifestPath, checksumPath) {
+  const packageName = path.basename(packagePath);
+  const digest = sha256File(packagePath);
+  const source = readInstallerSource(packagePath);
+  if (!source.includes(PATCH_MARKER)) {
+    throw new Error(
+      `${packageName} does not contain the Windows extraction fix`,
+    );
+  }
+  if (!source.includes("missing expected binaries")) {
+    throw new Error(`${packageName} does not verify its installed binaries`);
+  }
+
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  const manifestDigest = findArtifact(manifest, packageName).checksums.sha256;
+  if (manifestDigest !== digest) {
+    throw new Error(
+      `${packageName} manifest sha256 mismatch: expected ${digest}, found ${manifestDigest}`,
+    );
+  }
+
+  const checksumLines = fs.readFileSync(checksumPath, "utf8").split(/\r?\n/);
+  const matchingLines = checksumLines.filter((line) => {
+    const match = line.match(/^([a-fA-F0-9]{64})\s+\*?(.+)$/);
+    return match && path.basename(match[2]) === packageName;
+  });
+  if (matchingLines.length !== 1 || !matchingLines[0].startsWith(digest)) {
+    throw new Error(
+      `${packageName} unified checksum does not match final bytes`,
+    );
+  }
+  return digest;
+}
+
+function finalizePackage(packagePath, manifestPath, checksumPath) {
+  if (!fs.existsSync(packagePath)) {
+    throw new Error(`npm package not found: ${packagePath}`);
+  }
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "kittylitter-npm-"));
+  const repackedPath = path.join(
+    path.dirname(packagePath),
+    `.${path.basename(packagePath)}.final-${process.pid}`,
+  );
+  try {
+    run("tar", ["-xzf", packagePath, "-C", tempDir]);
+    const installerPath = path.join(tempDir, "package", "binary-install.js");
+    if (!fs.existsSync(installerPath)) {
+      throw new Error(`binary-install.js not found in ${packagePath}`);
+    }
+    const patched = patchBinaryInstaller(
+      fs.readFileSync(installerPath, "utf8"),
+    );
+    fs.writeFileSync(installerPath, patched);
+    run("tar", ["-czf", repackedPath, "-C", tempDir, "package"]);
+    // copyFileSync replaces the destination on Windows, where renameSync does
+    // not reliably replace an existing artifact.
+    fs.copyFileSync(repackedPath, packagePath);
+
+    const packageName = path.basename(packagePath);
+    const digest = sha256File(packagePath);
+    updateManifest(manifestPath, packageName, digest);
+    updateChecksumList(checksumPath, packageName, digest);
+    verifyFinalizedPackage(packagePath, manifestPath, checksumPath);
+    return digest;
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    fs.rmSync(repackedPath, { force: true });
+  }
+}
+
+function findPackages(directory) {
+  if (!fs.existsSync(directory)) {
+    throw new Error(`artifact directory not found: ${directory}`);
+  }
+  const packages = fs
+    .readdirSync(directory)
+    .filter((name) => name.endsWith(NPM_PACKAGE_SUFFIX))
+    .sort()
+    .map((name) => path.join(directory, name));
+  if (packages.length === 0) {
+    throw new Error(`no ${NPM_PACKAGE_SUFFIX} artifacts found in ${directory}`);
+  }
+  return packages;
+}
+
+function parseArgs(argv) {
+  const options = { verifyOnly: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--verify-only") {
+      options.verifyOnly = true;
+      continue;
+    }
+    const key = {
+      "--directory": "directory",
+      "--manifest": "manifestPath",
+      "--checksum-list": "checksumPath",
+    }[arg];
+    if (!key || index + 1 >= argv.length) {
+      throw new Error(`unknown or incomplete argument: ${arg}`);
+    }
+    options[key] = path.resolve(argv[index + 1]);
+    index += 1;
+  }
+  for (const key of ["directory", "manifestPath", "checksumPath"]) {
+    if (!options[key]) {
+      throw new Error(`missing required option: ${key}`);
+    }
+  }
+  return options;
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  for (const packagePath of findPackages(options.directory)) {
+    const digest = options.verifyOnly
+      ? verifyFinalizedPackage(
+          packagePath,
+          options.manifestPath,
+          options.checksumPath,
+        )
+      : finalizePackage(
+          packagePath,
+          options.manifestPath,
+          options.checksumPath,
+        );
+    const action = options.verifyOnly ? "verified" : "finalized";
+    console.error(`${action} ${path.basename(packagePath)} sha256=${digest}`);
+  }
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  PATCH_MARKER,
+  finalizePackage,
+  patchBinaryInstaller,
+  sha256File,
+  updateChecksumList,
+  updateManifest,
+  verifyFinalizedPackage,
+};

--- a/tools/scripts/finalize-kittylitter-npm-package.js
+++ b/tools/scripts/finalize-kittylitter-npm-package.js
@@ -224,7 +224,11 @@ function finalizePackage(packagePath, manifestPath, checksumPath) {
       fs.readFileSync(installerPath, "utf8"),
     );
     fs.writeFileSync(installerPath, patched);
-    run("tar", ["-czf", repackedPath, "-C", tempDir, "package"]);
+    run("tar", ["-czf", repackedPath, "-C", tempDir, "package"], {
+      // macOS bsdtar otherwise serializes extended attributes as AppleDouble
+      // `._*` files, changing the npm payload depending on the finalizer host.
+      env: { ...process.env, COPYFILE_DISABLE: "1" },
+    });
     // copyFileSync replaces the destination on Windows, where renameSync does
     // not reliably replace an existing artifact.
     fs.copyFileSync(repackedPath, packagePath);

--- a/tools/scripts/finalize-kittylitter-npm-package.js
+++ b/tools/scripts/finalize-kittylitter-npm-package.js
@@ -31,6 +31,7 @@ function run(command, args, options = {}) {
 }
 
 function patchBinaryInstaller(source) {
+  source = source.replace(/\r\n/g, "\n");
   if (source.includes(PATCH_MARKER)) {
     throw new Error("cargo-dist binary installer is already finalized");
   }

--- a/tools/scripts/fixtures/cargo-dist-0.31.0/binary-install.js
+++ b/tools/scripts/fixtures/cargo-dist-0.31.0/binary-install.js
@@ -1,0 +1,214 @@
+// Pinned from cargo-dist 0.31.0 output in the published kittylitter v0.3.4 npm artifact.
+// Upstream generated file: package/binary-install.js
+const { createWriteStream, existsSync, mkdirSync, mkdtemp } = require("fs");
+const { join, sep } = require("path");
+const { spawnSync } = require("child_process");
+const { tmpdir } = require("os");
+
+const axios = require("axios");
+const rimraf = require("rimraf");
+const tmpDir = tmpdir();
+
+const error = (msg) => {
+  console.error(msg);
+  process.exit(1);
+};
+
+class Package {
+  constructor(platform, name, url, filename, zipExt, binaries) {
+    let errors = [];
+    if (typeof url !== "string") {
+      errors.push("url must be a string");
+    } else {
+      try {
+        new URL(url);
+      } catch (e) {
+        errors.push(e);
+      }
+    }
+    if (name && typeof name !== "string") {
+      errors.push("package name must be a string");
+    }
+    if (!name) {
+      errors.push("You must specify the name of your package");
+    }
+    if (binaries && typeof binaries !== "object") {
+      errors.push("binaries must be a string => string map");
+    }
+    if (!binaries) {
+      errors.push("You must specify the binaries in the package");
+    }
+
+    if (errors.length > 0) {
+      let errorMsg =
+        "One or more of the parameters you passed to the Binary constructor are invalid:\n";
+      errors.forEach((error) => {
+        errorMsg += error;
+      });
+      errorMsg +=
+        '\n\nCorrect usage: new Package("my-binary", "https://example.com/binary/download.tar.gz", {"my-binary": "my-binary"})';
+      error(errorMsg);
+    }
+
+    this.platform = platform;
+    this.url = url;
+    this.name = name;
+    this.filename = filename;
+    this.zipExt = zipExt;
+    this.installDirectory = join(__dirname, "node_modules", ".bin_real");
+    this.binaries = binaries;
+
+    if (!existsSync(this.installDirectory)) {
+      mkdirSync(this.installDirectory, { recursive: true });
+    }
+  }
+
+  exists() {
+    for (const binaryName in this.binaries) {
+      const binRelPath = this.binaries[binaryName];
+      const binPath = join(this.installDirectory, binRelPath);
+      if (!existsSync(binPath)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  install(fetchOptions, suppressLogs = false) {
+    if (this.exists()) {
+      if (!suppressLogs) {
+        console.error(
+          `${this.name} is already installed, skipping installation.`,
+        );
+      }
+      return Promise.resolve();
+    }
+
+    if (existsSync(this.installDirectory)) {
+      rimraf.sync(this.installDirectory);
+    }
+
+    mkdirSync(this.installDirectory, { recursive: true });
+
+    if (!suppressLogs) {
+      console.error(`Downloading release from ${this.url}`);
+    }
+
+    return axios({ ...fetchOptions, url: this.url, responseType: "stream" })
+      .then((res) => {
+        return new Promise((resolve, reject) => {
+          mkdtemp(`${tmpDir}${sep}`, (err, directory) => {
+            let tempFile = join(directory, this.filename);
+            const sink = res.data.pipe(createWriteStream(tempFile));
+            sink.on("error", (err) => reject(err));
+            sink.on("close", () => {
+              if (/\.tar\.*/.test(this.zipExt)) {
+                const result = spawnSync("tar", [
+                  "xf",
+                  tempFile,
+                  // The tarballs are stored with a leading directory
+                  // component; we strip one component in the
+                  // shell installers too.
+                  "--strip-components",
+                  "1",
+                  "-C",
+                  this.installDirectory,
+                ]);
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred untarring the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else if (this.zipExt == ".zip") {
+                let result;
+                if (this.platform.artifactName.includes("windows")) {
+                  // Windows does not have "unzip" by default on many installations, instead
+                  // we use Expand-Archive from powershell
+                  result = spawnSync("powershell.exe", [
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-Command",
+                    `& {
+                        param([string]$LiteralPath, [string]$DestinationPath)
+                        Expand-Archive -LiteralPath $LiteralPath -DestinationPath $DestinationPath -Force
+                    }`,
+                    tempFile,
+                    this.installDirectory,
+                  ]);
+                } else {
+                  result = spawnSync("unzip", [
+                    "-q",
+                    tempFile,
+                    "-d",
+                    this.installDirectory,
+                  ]);
+                }
+
+                if (result.status == 0) {
+                  resolve();
+                } else if (result.error) {
+                  reject(result.error);
+                } else {
+                  reject(
+                    new Error(
+                      `An error occurred unzipping the artifact: stdout: ${result.stdout}; stderr: ${result.stderr}`,
+                    ),
+                  );
+                }
+              } else {
+                reject(
+                  new Error(`Unrecognized file extension: ${this.zipExt}`),
+                );
+              }
+            });
+          });
+        });
+      })
+      .then(() => {
+        if (!suppressLogs) {
+          console.error(`${this.name} has been installed!`);
+        }
+      })
+      .catch((e) => {
+        error(`Error fetching release: ${e.message}`);
+      });
+  }
+
+  run(binaryName, fetchOptions) {
+    const promise = !this.exists()
+      ? this.install(fetchOptions, true)
+      : Promise.resolve();
+
+    promise
+      .then(() => {
+        const [, , ...args] = process.argv;
+
+        const options = { cwd: process.cwd(), stdio: "inherit" };
+
+        const binRelPath = this.binaries[binaryName];
+        if (!binRelPath) {
+          error(`${binaryName} is not a known binary in ${this.name}`);
+        }
+        const binPath = join(this.installDirectory, binRelPath);
+        const result = spawnSync(binPath, args, options);
+
+        if (result.error) {
+          error(result.error);
+        }
+
+        process.exit(result.status);
+      })
+      .catch((e) => {
+        error(e.message);
+        process.exit(1);
+      });
+  }
+}
+
+module.exports.Package = Package;

--- a/tools/scripts/test-kittylitter-npm-windows.js
+++ b/tools/scripts/test-kittylitter-npm-windows.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const http = require("http");
+const os = require("os");
+const path = require("path");
+const { spawn } = require("child_process");
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function run(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env ?? process.env,
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (status, signal) => {
+      resolve({ signal, status, stderr, stdout });
+    });
+  });
+}
+
+function requireSuccess(result, description) {
+  if (result.status !== 0) {
+    fail(
+      `${description} failed with status ${result.status}:\n${result.stdout}\n${result.stderr}`,
+    );
+  }
+}
+
+function startArchiveServer(archivePath) {
+  const archiveName = path.basename(archivePath);
+  const server = http.createServer((request, response) => {
+    if (request.url !== `/${archiveName}`) {
+      response.writeHead(404);
+      response.end("not found");
+      return;
+    }
+    response.writeHead(200, {
+      "Content-Length": fs.statSync(archivePath).size,
+      "Content-Type": "application/zip",
+    });
+    fs.createReadStream(archivePath).pipe(response);
+  });
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      resolve({
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        close: () => new Promise((done) => server.close(done)),
+      });
+    });
+  });
+}
+
+async function main() {
+  if (process.platform !== "win32") {
+    fail("the kittylitter npm installer smoke test must run on Windows");
+  }
+  const [packageArgument, archiveArgument] = process.argv.slice(2);
+  if (!packageArgument || !archiveArgument) {
+    fail(
+      "usage: test-kittylitter-npm-windows.js <npm-package.tar.gz> <windows.zip>",
+    );
+  }
+  const packagePath = path.resolve(packageArgument);
+  const archivePath = path.resolve(archiveArgument);
+  for (const artifactPath of [packagePath, archivePath]) {
+    if (!fs.existsSync(artifactPath)) {
+      fail(`artifact not found: ${artifactPath}`);
+    }
+  }
+
+  const tempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "kittylitter-win-smoke-"),
+  );
+  const server = await startArchiveServer(archivePath);
+  try {
+    fs.writeFileSync(
+      path.join(tempDir, "package.json"),
+      `${JSON.stringify({ name: "kittylitter-windows-smoke", private: true })}\n`,
+    );
+    const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+    const npmInstall = await run(
+      npm,
+      ["install", "--ignore-scripts", "--no-audit", "--no-fund", packagePath],
+      { cwd: tempDir },
+    );
+    requireSuccess(npmInstall, "installing the finalized npm tarball");
+
+    const packageRoot = path.join(tempDir, "node_modules", "kittylitter");
+    const metadataPath = path.join(packageRoot, "package.json");
+    const metadata = JSON.parse(fs.readFileSync(metadataPath, "utf8"));
+    const windowsTarget = metadata.supportedPlatforms["x86_64-pc-windows-msvc"];
+    if (!windowsTarget) {
+      fail("final npm package lacks x86_64-pc-windows-msvc metadata");
+    }
+    metadata.artifactDownloadUrls = [server.baseUrl];
+    windowsTarget.artifactName = path.basename(archivePath);
+    fs.writeFileSync(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`);
+
+    const install = await run(process.execPath, ["install.js"], {
+      cwd: packageRoot,
+    });
+    requireSuccess(install, "extracting the real Windows archive");
+    const installOutput = `${install.stdout}\n${install.stderr}`;
+    if (!installOutput.includes("kittylitter has been installed!")) {
+      fail(`successful install omitted confirmation:\n${installOutput}`);
+    }
+
+    const installDirectory = path.join(
+      packageRoot,
+      "node_modules",
+      ".bin_real",
+    );
+    const executablePath = path.join(installDirectory, "kittylitter.exe");
+    if (!fs.existsSync(executablePath)) {
+      fail(`successful install did not create ${executablePath}`);
+    }
+    const version = await run(executablePath, ["--version"], { cwd: tempDir });
+    requireSuccess(version, "executing the installed kittylitter.exe");
+    if (
+      !`${version.stdout}\n${version.stderr}`
+        .toLowerCase()
+        .includes("kittylitter")
+    ) {
+      fail("kittylitter.exe --version did not identify kittylitter");
+    }
+
+    fs.rmSync(installDirectory, { recursive: true, force: true });
+    metadata.supportedPlatforms["x86_64-pc-windows-msvc"].bins.kittylitter =
+      "missing-kittylitter.exe";
+    fs.writeFileSync(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`);
+
+    const missingBinary = await run(process.execPath, ["install.js"], {
+      cwd: packageRoot,
+    });
+    const missingOutput = `${missingBinary.stdout}\n${missingBinary.stderr}`;
+    if (missingBinary.status === 0) {
+      fail(`missing-binary install unexpectedly succeeded:\n${missingOutput}`);
+    }
+    if (missingOutput.includes("kittylitter has been installed!")) {
+      fail(`missing-binary install printed false success:\n${missingOutput}`);
+    }
+    if (!missingOutput.includes("missing expected binaries")) {
+      fail(
+        `missing-binary install lacked actionable failure:\n${missingOutput}`,
+      );
+    }
+
+    console.log("finalized npm tarball installed and executed kittylitter.exe");
+    console.log("missing-binary extraction failed without false success");
+  } finally {
+    await server.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/tools/scripts/test-kittylitter-npm-windows.js
+++ b/tools/scripts/test-kittylitter-npm-windows.js
@@ -25,7 +25,9 @@ function run(command, args, options = {}) {
     child.stderr.on("data", (chunk) => {
       stderr += chunk;
     });
-    child.on("error", reject);
+    child.on("error", (error) => {
+      reject(new Error(`could not spawn ${command}: ${error.message}`));
+    });
     child.on("close", (status, signal) => {
       resolve({ signal, status, stderr, stdout });
     });
@@ -93,10 +95,26 @@ async function main() {
       path.join(tempDir, "package.json"),
       `${JSON.stringify({ name: "kittylitter-windows-smoke", private: true })}\n`,
     );
-    const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+    const npmCli = path.join(
+      path.dirname(process.execPath),
+      "node_modules",
+      "npm",
+      "bin",
+      "npm-cli.js",
+    );
+    if (!fs.existsSync(npmCli)) {
+      fail(`npm CLI not found beside Node: ${npmCli}`);
+    }
     const npmInstall = await run(
-      npm,
-      ["install", "--ignore-scripts", "--no-audit", "--no-fund", packagePath],
+      process.execPath,
+      [
+        npmCli,
+        "install",
+        "--ignore-scripts",
+        "--no-audit",
+        "--no-fund",
+        packagePath,
+      ],
       { cwd: tempDir },
     );
     requireSuccess(npmInstall, "installing the finalized npm tarball");

--- a/tools/scripts/tests/finalize-kittylitter-npm-package.test.js
+++ b/tools/scripts/tests/finalize-kittylitter-npm-package.test.js
@@ -1,0 +1,158 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const test = require("node:test");
+
+const {
+  PATCH_MARKER,
+  finalizePackage,
+  patchBinaryInstaller,
+  sha256File,
+  verifyFinalizedPackage,
+} = require("../finalize-kittylitter-npm-package.js");
+
+const fixturePath = path.resolve(
+  __dirname,
+  "../fixtures/cargo-dist-0.31.0/binary-install.js",
+);
+
+function run(command, args) {
+  const result = spawnSync(command, args, { encoding: "utf8" });
+  assert.equal(
+    result.status,
+    0,
+    `${command} ${args.join(" ")} failed:\n${result.stderr}`,
+  );
+  return result;
+}
+
+function makeArtifactFixture(tempDir) {
+  const packageRoot = path.join(tempDir, "source", "package");
+  const artifactDir = path.join(tempDir, "artifacts");
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.mkdirSync(artifactDir, { recursive: true });
+  fs.copyFileSync(fixturePath, path.join(packageRoot, "binary-install.js"));
+  fs.writeFileSync(
+    path.join(packageRoot, "package.json"),
+    `${JSON.stringify({ name: "kittylitter", version: "0.0.0-test" })}\n`,
+  );
+
+  const packageName = "kittylitter-npm-package.tar.gz";
+  const packagePath = path.join(artifactDir, packageName);
+  run("tar", ["-czf", packagePath, "-C", path.dirname(packageRoot), "package"]);
+  const originalDigest = sha256File(packagePath);
+
+  const manifestPath = path.join(tempDir, "dist-manifest.json");
+  fs.writeFileSync(
+    manifestPath,
+    `${JSON.stringify(
+      {
+        artifacts: {
+          [packageName]: {
+            name: packageName,
+            kind: "installer",
+            checksums: { sha256: originalDigest },
+          },
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const checksumPath = path.join(artifactDir, "sha256.sum");
+  fs.writeFileSync(checksumPath, `${originalDigest} *${packageName}\n`);
+  return { checksumPath, manifestPath, originalDigest, packagePath };
+}
+
+test("patches the pinned cargo-dist 0.31.0 Windows installer", () => {
+  const source = fs.readFileSync(fixturePath, "utf8");
+  const patched = patchBinaryInstaller(source);
+
+  assert.match(patched, new RegExp(PATCH_MARKER));
+  assert.match(patched, /spawnSync\("tar", \[/);
+  assert.match(patched, /"-ExecutionPolicy",\s+"Bypass"/);
+  assert.match(patched, /\$ErrorActionPreference = "Stop"/);
+  assert.match(patched, /missing expected binaries/);
+  assert.doesNotMatch(
+    patched,
+    /Windows does not have "unzip" by default on many installations/,
+  );
+});
+
+test("fails closed when cargo-dist changes the pinned extractor", () => {
+  const source = fs
+    .readFileSync(fixturePath, "utf8")
+    .replace("Expand-Archive from powershell", "a different extractor");
+
+  assert.throws(
+    () => patchBinaryInstaller(source),
+    /Windows extractor block was not found/,
+  );
+});
+
+test("repacked bytes update and verify manifest and unified checksum provenance", () => {
+  const tempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "kittylitter-finalize-test-"),
+  );
+  try {
+    const fixture = makeArtifactFixture(tempDir);
+    const finalDigest = finalizePackage(
+      fixture.packagePath,
+      fixture.manifestPath,
+      fixture.checksumPath,
+    );
+
+    assert.notEqual(finalDigest, fixture.originalDigest);
+    assert.equal(finalDigest, sha256File(fixture.packagePath));
+    assert.equal(
+      verifyFinalizedPackage(
+        fixture.packagePath,
+        fixture.manifestPath,
+        fixture.checksumPath,
+      ),
+      finalDigest,
+    );
+
+    const manifest = JSON.parse(fs.readFileSync(fixture.manifestPath, "utf8"));
+    assert.equal(
+      manifest.artifacts["kittylitter-npm-package.tar.gz"].checksums.sha256,
+      finalDigest,
+    );
+    assert.equal(
+      fs.readFileSync(fixture.checksumPath, "utf8"),
+      `${finalDigest} *kittylitter-npm-package.tar.gz\n`,
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("verification rejects bytes that no longer match recorded provenance", () => {
+  const tempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "kittylitter-verify-test-"),
+  );
+  try {
+    const fixture = makeArtifactFixture(tempDir);
+    finalizePackage(
+      fixture.packagePath,
+      fixture.manifestPath,
+      fixture.checksumPath,
+    );
+    fs.appendFileSync(fixture.packagePath, "tampered");
+
+    assert.throws(
+      () =>
+        verifyFinalizedPackage(
+          fixture.packagePath,
+          fixture.manifestPath,
+          fixture.checksumPath,
+        ),
+      /manifest sha256 mismatch/,
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/tools/scripts/tests/finalize-kittylitter-npm-package.test.js
+++ b/tools/scripts/tests/finalize-kittylitter-npm-package.test.js
@@ -80,6 +80,9 @@ test("patches the pinned cargo-dist 0.31.0 Windows installer", () => {
     patched,
     /Windows does not have "unzip" by default on many installations/,
   );
+
+  const windowsCheckout = patchBinaryInstaller(source.replace(/\n/g, "\r\n"));
+  assert.match(windowsCheckout, new RegExp(PATCH_MARKER));
 });
 
 test("fails closed when cargo-dist changes the pinned extractor", () => {

--- a/tools/scripts/tests/finalize-kittylitter-npm-package.test.js
+++ b/tools/scripts/tests/finalize-kittylitter-npm-package.test.js
@@ -81,7 +81,9 @@ test("patches the pinned cargo-dist 0.31.0 Windows installer", () => {
     /Windows does not have "unzip" by default on many installations/,
   );
 
-  const windowsCheckout = patchBinaryInstaller(source.replace(/\n/g, "\r\n"));
+  const windowsCheckout = patchBinaryInstaller(
+    source.replace(/\r\n/g, "\n").replace(/\n/g, "\r\n"),
+  );
   assert.match(windowsCheckout, new RegExp(PATCH_MARKER));
 });
 

--- a/tools/scripts/tests/finalize-kittylitter-npm-package.test.js
+++ b/tools/scripts/tests/finalize-kittylitter-npm-package.test.js
@@ -125,6 +125,8 @@ test("repacked bytes update and verify manifest and unified checksum provenance"
       fs.readFileSync(fixture.checksumPath, "utf8"),
       `${finalDigest} *kittylitter-npm-package.tar.gz\n`,
     );
+    const archiveEntries = run("tar", ["-tzf", fixture.packagePath]).stdout;
+    assert.doesNotMatch(archiveEntries, /(^|\/)\._[^/]+$/m);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Purpose

Replace stale PR #148 with a current-main Windows installer fix that preserves one authoritative set of release bytes across GitHub Releases, the dist manifest/checksum list, and npm.

## Key changes

- finalize the cargo-dist 0.31.0 npm tarball before scratch upload
- prefer Windows `tar`, retain a strict PowerShell fallback, and fail when expected binaries are missing
- rewrite and independently verify the cargo-dist manifest and `sha256.sum` after repacking
- make host and npm jobs verify the same finalized bytes
- publish npm provenance attestations
- add a bounded Windows job that installs the final package, executes `kittylitter.exe`, and proves the missing-binary path fails closed
- preserve Node 24 and `package-manager-cache: false`

## Verification

- `node --test tools/scripts/tests/finalize-kittylitter-npm-package.test.js` — 4/4 pass
- finalizer + independent verification on the official v0.3.4 cargo-dist 0.31.0 tarball
- final artifact, manifest, and unified checksum matched (`f9ba0f73…b6d8bbed`)
- no AppleDouble entries after macOS repack
- local install and `npm pack --dry-run` pass
- Prettier, YAML parse, actionlint semantic validation, and `git diff --check` pass

## Remaining acceptance

The actual Windows executable smoke and npm OIDC attestation run on GitHub’s Windows/release runners. The workflow keeps hosting and publication blocked on the Windows job.

Supersedes #148.