### PR TITLE
mobile: preserve runtime-only thread selection

### DIFF
--- a/apps/android/app/src/main/java/com/litter/android/state/AppLaunchState.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/AppLaunchState.kt
@@ -33,6 +33,39 @@ data class AppLaunchStateSnapshot(
     val threadPermissionOverrides: Map<String, ThreadPermissionOverride> = emptyMap(),
 )
 
+internal data class AppLaunchModelSelection(
+    val agentRuntimeKind: AgentRuntimeKind?,
+    val model: String?,
+)
+
+internal fun appLaunchModelSelection(
+    modelOverride: String?,
+    selectedModel: String?,
+    selectedAgentRuntimeKind: AgentRuntimeKind?,
+): AppLaunchModelSelection =
+    AppLaunchModelSelection(
+        agentRuntimeKind = selectedAgentRuntimeKind,
+        model = modelOverride.normalizedOrNull() ?: selectedModel.normalizedOrNull(),
+    )
+
+internal fun AppLaunchStateSnapshot.updatingSelectedModel(
+    model: String?,
+    agentRuntimeKind: AgentRuntimeKind?,
+): AppLaunchStateSnapshot {
+    val normalizedModel = model.normalizedOrEmpty()
+    return if (
+        selectedModel == normalizedModel &&
+        selectedAgentRuntimeKind == agentRuntimeKind
+    ) {
+        this
+    } else {
+        copy(
+            selectedModel = normalizedModel,
+            selectedAgentRuntimeKind = agentRuntimeKind,
+        )
+    }
+}
+
 private const val PREFS_NAME = "litter.launchState"
 private const val APPROVAL_POLICY_KEY = "litter.approvalPolicy"
 private const val SANDBOX_MODE_KEY = "litter.sandboxMode"
@@ -69,21 +102,7 @@ class AppLaunchState(context: Context) {
         model: String?,
         agentRuntimeKind: AgentRuntimeKind? = null,
     ) {
-        val normalized = model.normalizedOrEmpty()
-        val normalizedRuntime = if (normalized.isEmpty()) null else agentRuntimeKind
-        _snapshot.update { state ->
-            if (
-                state.selectedModel == normalized &&
-                state.selectedAgentRuntimeKind == normalizedRuntime
-            ) {
-                state
-            } else {
-                state.copy(
-                    selectedModel = normalized,
-                    selectedAgentRuntimeKind = normalizedRuntime,
-                )
-            }
-        }
+        _snapshot.update { state -> state.updatingSelectedModel(model, agentRuntimeKind) }
     }
 
     fun updateReasoningEffort(effort: String?) {
@@ -146,10 +165,14 @@ class AppLaunchState(context: Context) {
 
     fun launchConfig(modelOverride: String? = null, threadKey: ThreadKey? = null): AppThreadLaunchConfig {
         val state = snapshot.value
-        val selectedModel = modelOverride.normalizedOrNull() ?: state.selectedModel.normalizedOrNull()
+        val selection = appLaunchModelSelection(
+            modelOverride = modelOverride,
+            selectedModel = state.selectedModel,
+            selectedAgentRuntimeKind = state.selectedAgentRuntimeKind,
+        )
         return AppThreadLaunchConfig(
-            agentRuntimeKind = if (selectedModel == null) null else state.selectedAgentRuntimeKind,
-            model = selectedModel,
+            agentRuntimeKind = selection.agentRuntimeKind,
+            model = selection.model,
             approvalPolicy = approvalPolicyValue(threadKey),
             sandboxMode = sandboxModeValue(threadKey),
             developerInstructions = null,

--- a/apps/android/app/src/test/java/com/litter/android/state/AppLaunchModelSelectionTest.kt
+++ b/apps/android/app/src/test/java/com/litter/android/state/AppLaunchModelSelectionTest.kt
@@ -1,0 +1,54 @@
+package com.litter.android.state
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AppLaunchModelSelectionTest {
+    @Test
+    fun updatingModelStateRetainsRuntimeWhenModelIsEmpty() {
+        val state = AppLaunchStateSnapshot().updatingSelectedModel(
+            model = null,
+            agentRuntimeKind = "opencode",
+        )
+
+        assertEquals("opencode", state.selectedAgentRuntimeKind)
+        assertEquals("", state.selectedModel)
+    }
+
+    @Test
+    fun runtimeOnlySelectionPreservesExplicitRuntime() {
+        val selection = appLaunchModelSelection(
+            modelOverride = null,
+            selectedModel = null,
+            selectedAgentRuntimeKind = "opencode",
+        )
+
+        assertEquals("opencode", selection.agentRuntimeKind)
+        assertNull(selection.model)
+    }
+
+    @Test
+    fun selectionNormalizesModelWithoutChangingRuntime() {
+        val selection = appLaunchModelSelection(
+            modelOverride = "  local/model  ",
+            selectedModel = null,
+            selectedAgentRuntimeKind = "local-studio",
+        )
+
+        assertEquals("local-studio", selection.agentRuntimeKind)
+        assertEquals("local/model", selection.model)
+    }
+
+    @Test
+    fun whitespaceOnlyModelDoesNotDiscardRuntime() {
+        val selection = appLaunchModelSelection(
+            modelOverride = "  \n ",
+            selectedModel = null,
+            selectedAgentRuntimeKind = "opencode",
+        )
+
+        assertEquals("opencode", selection.agentRuntimeKind)
+        assertNull(selection.model)
+    }
+}

--- a/apps/ios/Litter.xcodeproj/project.pbxproj
+++ b/apps/ios/Litter.xcodeproj/project.pbxproj
@@ -299,6 +299,7 @@
 		6DC558677229D4C88CF3B5ED /* TerminalSessionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FF500954C7BD43BD398E761 /* TerminalSessionController.swift */; };
 		6DE00D539BF6F92533A4D8C4 /* RustAlleycatBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CDBDD02E344E7C903D5DEC /* RustAlleycatBridge.swift */; };
 		6E5AE2344005411B8D8A0BF8 /* poimandres.json in Resources */ = {isa = PBXBuildFile; fileRef = 6F877B8FA83A8228C4515FB4 /* poimandres.json */; };
+		6E823C2FF74B3CEFE95BCB46 /* AppThreadLaunchSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 309A45553C06BE791FBF24D5 /* AppThreadLaunchSelectionTests.swift */; };
 		6EF7AFD103A68CDEA1A94612 /* HomeDashboardSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018779F7529B6CAAC3A2B896 /* HomeDashboardSupportTests.swift */; };
 		6F9DC3769AABC5641DFD46DA /* material-theme.json in Resources */ = {isa = PBXBuildFile; fileRef = ACA6050F3A6D566E963B09A7 /* material-theme.json */; };
 		6FBA78C9A03BA409D4B04827 /* PendingUserInputRequest+ThreadMatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A1EEEAE225FB324930D3AA /* PendingUserInputRequest+ThreadMatching.swift */; };
@@ -815,6 +816,7 @@
 		2ECDF838BCE5FEBFE5B80DCC /* StreamingRendererCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingRendererCoordinator.swift; sourceTree = "<group>"; };
 		2FB04F90D08EE57F92DD7F58 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = AppIcon.icon; sourceTree = "<group>"; };
 		2FB206863136DF3B8FA50457 /* HomeDashboardSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeDashboardSupport.swift; sourceTree = "<group>"; };
+		309A45553C06BE791FBF24D5 /* AppThreadLaunchSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppThreadLaunchSelectionTests.swift; sourceTree = "<group>"; };
 		318F2F8563E91AB97950F5DA /* DirectoryPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectoryPickerView.swift; sourceTree = "<group>"; };
 		32488157EAB1D3ADBA2D3CF7 /* TaskDetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetailScreen.swift; sourceTree = "<group>"; };
 		3299D7A71DE1AC05363FDE27 /* MessageContentBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageContentBridgeTests.swift; sourceTree = "<group>"; };
@@ -1232,6 +1234,7 @@
 			children = (
 				49496FAE8491262D2C8CC657 /* AppSnapshotRuntimeTests.swift */,
 				F3474B8EA8D3148C94A7583F /* AppStatePermissionTests.swift */,
+				309A45553C06BE791FBF24D5 /* AppThreadLaunchSelectionTests.swift */,
 				33402D8F29D5CAA2DD07ED9F /* ChatGPTOAuthTests.swift */,
 				347FEEBE4E54174740D93E9D /* ConversationAttachmentSupportTests.swift */,
 				77969543FA36FEA8B621A3B9 /* ConversationDisplayPreferenceTests.swift */,
@@ -2248,6 +2251,7 @@
 			files = (
 				D24451D266FD2443C0D7CBC4 /* AppSnapshotRuntimeTests.swift in Sources */,
 				620FC2343DCFADD1034E9CCB /* AppStatePermissionTests.swift in Sources */,
+				6E823C2FF74B3CEFE95BCB46 /* AppThreadLaunchSelectionTests.swift in Sources */,
 				46C5F0B53F9EF54FE8F311A4 /* ChatGPTOAuthTests.swift in Sources */,
 				46B24CBC2FD5FD3799BE207D /* ConversationAttachmentSupportTests.swift in Sources */,
 				2F28DA245F84E87318A4D7E4 /* ConversationDisplayPreferenceTests.swift in Sources */,

--- a/apps/ios/Sources/Litter/LitterApp.swift
+++ b/apps/ios/Sources/Litter/LitterApp.swift
@@ -1347,11 +1347,13 @@ private struct HomeNavigationView: View {
     }
 
     private func launchConfig(for threadKey: ThreadKey? = nil) -> AppThreadLaunchConfig {
-        let selectedModel = appState.selectedModel.trimmingCharacters(in: .whitespacesAndNewlines)
-        let hasSelectedModel = !selectedModel.isEmpty
+        let selection = AppThreadLaunchSelection(
+            agentRuntimeKind: appState.selectedAgentRuntimeKind,
+            model: appState.selectedModel
+        )
         return AppThreadLaunchConfig(
-            agentRuntimeKind: hasSelectedModel ? appState.selectedAgentRuntimeKind : nil,
-            model: hasSelectedModel ? selectedModel : nil,
+            agentRuntimeKind: selection.agentRuntimeKind,
+            model: selection.model,
             approvalPolicy: appState.launchApprovalPolicy(for: threadKey),
             sandbox: appState.launchSandboxMode(for: threadKey),
             developerInstructions: nil,

--- a/apps/ios/Sources/Litter/Models/AppRpcParams.swift
+++ b/apps/ios/Sources/Litter/Models/AppRpcParams.swift
@@ -1,5 +1,17 @@
 import Foundation
 
+struct AppThreadLaunchSelection: Equatable, Sendable {
+    let agentRuntimeKind: AgentRuntimeKind?
+    let model: String?
+
+    init(agentRuntimeKind: AgentRuntimeKind?, model: String?) {
+        self.agentRuntimeKind = agentRuntimeKind
+        self.model = model?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .nilIfEmpty
+    }
+}
+
 struct AppThreadLaunchConfig: Equatable, Sendable {
     var agentRuntimeKind: AgentRuntimeKind? = nil
     var model: String? = nil
@@ -54,6 +66,12 @@ struct AppThreadLaunchConfig: Equatable, Sendable {
             developerInstructions: developerInstructions,
             persistExtendedHistory: persistExtendedHistory
         )
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
     }
 }
 

--- a/apps/ios/Sources/Litter/Views/HomeComposerView.swift
+++ b/apps/ios/Sources/Litter/Views/HomeComposerView.swift
@@ -241,14 +241,15 @@ struct HomeComposerView: View {
                 composerSelectionRange = NSRange(location: 0, length: 0)
                 isComposerFocused = false
 
-                let pendingModel = appState.preferredModel.trimmingCharacters(in: .whitespacesAndNewlines)
-                let modelOverride = pendingModel.isEmpty ? nil : pendingModel
-                let agentRuntimeOverride = modelOverride == nil ? nil : appState.preferredAgentRuntimeKind
+                let selection = AppThreadLaunchSelection(
+                    agentRuntimeKind: appState.preferredAgentRuntimeKind,
+                    model: appState.preferredModel
+                )
                 let pendingEffort = appState.preferredReasoningEffort.trimmingCharacters(in: .whitespacesAndNewlines)
                 let effortOverride = ReasoningEffort(wireValue: pendingEffort.isEmpty ? nil : pendingEffort)
                 let launchConfig = AppThreadLaunchConfig(
-                    agentRuntimeKind: agentRuntimeOverride,
-                    model: modelOverride,
+                    agentRuntimeKind: selection.agentRuntimeKind,
+                    model: selection.model,
                     approvalPolicy: appState.launchApprovalPolicy(for: nil),
                     sandbox: appState.launchSandboxMode(for: nil),
                     developerInstructions: nil,
@@ -284,7 +285,7 @@ struct HomeComposerView: View {
                     fileAttachments: files,
                     approvalPolicy: appState.launchApprovalPolicy(for: threadKey),
                     sandboxPolicy: appState.turnSandboxPolicy(for: threadKey),
-                    model: modelOverride,
+                    model: selection.model,
                     effort: effortOverride,
                     serviceTier: nil
                 )

--- a/apps/ios/Sources/Litter/Views/SessionsScreen.swift
+++ b/apps/ios/Sources/Litter/Views/SessionsScreen.swift
@@ -1288,11 +1288,13 @@ struct SessionsScreen: View {
     }
 
     private func launchConfig(for threadKey: ThreadKey? = nil) -> AppThreadLaunchConfig {
-        let selectedModel = appState.selectedModel.trimmingCharacters(in: .whitespacesAndNewlines)
-        let hasSelectedModel = !selectedModel.isEmpty
+        let selection = AppThreadLaunchSelection(
+            agentRuntimeKind: appState.selectedAgentRuntimeKind,
+            model: appState.selectedModel
+        )
         return AppThreadLaunchConfig(
-            agentRuntimeKind: hasSelectedModel ? appState.selectedAgentRuntimeKind : nil,
-            model: hasSelectedModel ? selectedModel : nil,
+            agentRuntimeKind: selection.agentRuntimeKind,
+            model: selection.model,
             approvalPolicy: appState.launchApprovalPolicy(for: threadKey),
             sandbox: appState.launchSandboxMode(for: threadKey),
             developerInstructions: nil,

--- a/apps/ios/Tests/LitterTests/AppThreadLaunchSelectionTests.swift
+++ b/apps/ios/Tests/LitterTests/AppThreadLaunchSelectionTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import Litter
+
+final class AppThreadLaunchSelectionTests: XCTestCase {
+    func testRuntimeOnlySelectionPreservesExplicitRuntime() {
+        let selection = AppThreadLaunchSelection(
+            agentRuntimeKind: .opencode,
+            model: nil
+        )
+
+        XCTAssertEqual(selection.agentRuntimeKind, .opencode)
+        XCTAssertNil(selection.model)
+    }
+
+    func testSelectionNormalizesModelWithoutChangingRuntime() {
+        let selection = AppThreadLaunchSelection(
+            agentRuntimeKind: .localStudio,
+            model: "  local/model  "
+        )
+
+        XCTAssertEqual(selection.agentRuntimeKind, .localStudio)
+        XCTAssertEqual(selection.model, "local/model")
+    }
+
+    func testWhitespaceOnlyModelDoesNotDiscardRuntime() {
+        let selection = AppThreadLaunchSelection(
+            agentRuntimeKind: .opencode,
+            model: "  \n "
+        )
+
+        XCTAssertEqual(selection.agentRuntimeKind, .opencode)
+        XCTAssertNil(selection.model)
+    }
+}

--- a/shared/rust-bridge/codex-mobile-client/src/ffi/client.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/ffi/client.rs
@@ -436,7 +436,11 @@ impl AppClient {
             )
             .await?;
             let key = c
-                .apply_thread_start_response(&server_id, &response)
+                .apply_thread_start_response_for_runtime(
+                    &server_id,
+                    runtime_kind.clone(),
+                    &response,
+                )
                 .map_err(ClientError::Serialization)?;
             c.note_thread_runtime(key.clone(), runtime_kind);
             Ok(key)

--- a/shared/rust-bridge/codex-mobile-client/src/store/reconcile.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/store/reconcile.rs
@@ -223,6 +223,15 @@ impl MobileClient {
         server_id: &str,
         response: &upstream::ThreadStartResponse,
     ) -> Result<ThreadKey, String> {
+        self.apply_thread_start_response_for_runtime(server_id, "codex".to_string(), response)
+    }
+
+    pub fn apply_thread_start_response_for_runtime(
+        &self,
+        server_id: &str,
+        runtime_kind: AgentRuntimeKind,
+        response: &upstream::ThreadStartResponse,
+    ) -> Result<ThreadKey, String> {
         let mut snapshot = crate::thread_snapshot_from_upstream_thread_with_overrides(
             server_id,
             response.thread.clone(),
@@ -235,6 +244,7 @@ impl MobileClient {
             Some(response.sandbox.clone().into()),
         )
         .map_err(|e| e.to_string())?;
+        snapshot.agent_runtime_kind = runtime_kind;
         // A freshly-started thread has no turns to page; mark the initial
         // page as loaded so UI does not auto-fire `thread/turns/list`
         // (which the server rejects until the first user message lands).
@@ -720,6 +730,27 @@ mod tests {
             git_info: None,
             name: Some("Thread".to_string()),
             turns: Vec::new(),
+        }
+    }
+
+    fn test_thread_start_response(
+        thread_id: &str,
+        model: &str,
+        model_provider: &str,
+    ) -> upstream::ThreadStartResponse {
+        upstream::ThreadStartResponse {
+            thread: test_upstream_thread(thread_id),
+            model: model.to_string(),
+            model_provider: model_provider.to_string(),
+            service_tier: None,
+            cwd: test_abs_path("/tmp"),
+            runtime_workspace_roots: Vec::new(),
+            instruction_sources: Vec::new(),
+            approval_policy: upstream::AskForApproval::Never,
+            approvals_reviewer: upstream::ApprovalsReviewer::User,
+            sandbox: upstream::SandboxPolicy::DangerFullAccess,
+            active_permission_profile: None,
+            reasoning_effort: None,
         }
     }
 
@@ -1293,20 +1324,7 @@ mod tests {
             },
             ServerHealthSnapshot::Connected,
         );
-        let response = upstream::ThreadStartResponse {
-            thread: test_upstream_thread("thread-1"),
-            model: "gpt-5".to_string(),
-            model_provider: "openai".to_string(),
-            service_tier: None,
-            cwd: test_abs_path("/tmp"),
-            runtime_workspace_roots: Vec::new(),
-            instruction_sources: Vec::new(),
-            approval_policy: upstream::AskForApproval::Never,
-            approvals_reviewer: upstream::ApprovalsReviewer::User,
-            sandbox: upstream::SandboxPolicy::DangerFullAccess,
-            active_permission_profile: None,
-            reasoning_effort: None,
-        };
+        let response = test_thread_start_response("thread-1", "gpt-5", "openai");
         let key = client
             .apply_thread_start_response("srv", &response)
             .expect("thread/start reconciliation");
@@ -1315,7 +1333,42 @@ mod tests {
             snapshot.initial_turns_loaded,
             "new thread must be marked initial_turns_loaded"
         );
+        assert_eq!(snapshot.agent_runtime_kind, "codex");
         assert!(snapshot.older_turns_cursor.is_none());
+    }
+
+    #[test]
+    fn apply_thread_start_response_projects_explicit_runtime_immediately() {
+        let client = MobileClient::new();
+        client.app_store.upsert_server(
+            &ServerConfig {
+                server_id: "srv".to_string(),
+                display_name: "Server".to_string(),
+                host: "localhost".to_string(),
+                port: 8390,
+                websocket_url: None,
+                is_local: true,
+                tls: false,
+            },
+            ServerHealthSnapshot::Connected,
+        );
+        let response =
+            test_thread_start_response("thread-opencode", "opencode/default", "opencode");
+
+        let key = client
+            .apply_thread_start_response_for_runtime("srv", "opencode".to_string(), &response)
+            .expect("thread/start reconciliation");
+        let snapshot = client.app_store.thread_snapshot(&key).expect("snapshot");
+        assert_eq!(snapshot.agent_runtime_kind, "opencode");
+
+        let record = crate::store::AppSnapshotRecord::try_from(client.app_snapshot())
+            .expect("snapshot record");
+        let summary = record
+            .session_summaries
+            .iter()
+            .find(|summary| summary.key == key)
+            .expect("new session summary");
+        assert_eq!(summary.agent_runtime_kind, "opencode");
     }
 
     /// `thread/read` carries embedded turns and is authoritative — the


### PR DESCRIPTION
## Purpose

Replace stale PR #177 with a current-main, parity-safe fix for runtime-only thread launches. Selecting OpenCode or another non-Codex runtime must not fall back to Codex merely because no explicit model override was chosen.

## Key changes

- centralize the iOS runtime/model launch projection and use it in all three launch paths
- preserve the same runtime-only state and request projection on Android
- project the resolved runtime into the initial Rust thread snapshot before the first session-summary projection
- retain the runtime routing map needed for later resume/turn operations
- omit #177’s navigation hunk because that behavior already landed on main

## Verification

- focused Android selection tests pass
- full Android debug unit suite passes
- focused iOS tests pass on the iPhone 17 Pro simulator: 3 tests, 0 failures
- `rustfmt --check` and `git diff --check` pass

## Remaining acceptance

The pristine Codex submodule cannot compile the focused Rust test until the repository patch stack is applied (`JsonRpcWire` drift). CI must exercise the normal sync/patch lane. A physical-device OpenCode creation remains the final end-user acceptance check.

Supersedes #177.