### PR TITLE
android: bound realtime voice startup

### DIFF
--- a/apps/android/app/src/main/java/com/litter/android/voice/RealtimeWebRtcSession.kt
+++ b/apps/android/app/src/main/java/com/litter/android/voice/RealtimeWebRtcSession.kt
@@ -7,6 +7,7 @@ import android.media.AudioManager
 import android.os.Build
 import android.util.Log
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
 import org.webrtc.AudioSource
 import org.webrtc.AudioTrack
 import org.webrtc.DataChannel
@@ -28,6 +29,16 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
 class RealtimeWebRtcSessionException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
+
+internal const val REALTIME_ICE_GATHERING_TIMEOUT_MS = 5_000L
+
+internal fun realtimePeerConnectionConfiguration(): PeerConnection.RTCConfiguration =
+    PeerConnection.RTCConfiguration(emptyList()).apply {
+        sdpSemantics = PeerConnection.SdpSemantics.UNIFIED_PLAN
+        // The initial SDP is sent as a complete, non-trickle offer. Continuous
+        // gathering never transitions to COMPLETE on some Android devices.
+        continualGatheringPolicy = PeerConnection.ContinualGatheringPolicy.GATHER_ONCE
+    }
 
 class RealtimeWebRtcSession(private val context: Context) {
 
@@ -58,10 +69,7 @@ class RealtimeWebRtcSession(private val context: Context) {
 
         Log.i(TAG, "start: acquiring shared PeerConnectionFactory")
         val factory = sharedFactory(context)
-        val rtcConfig = PeerConnection.RTCConfiguration(emptyList()).apply {
-            sdpSemantics = PeerConnection.SdpSemantics.UNIFIED_PLAN
-            continualGatheringPolicy = PeerConnection.ContinualGatheringPolicy.GATHER_CONTINUALLY
-        }
+        val rtcConfig = realtimePeerConnectionConfiguration()
 
         Log.i(TAG, "start: creating PeerConnection")
         val connection = factory.createPeerConnection(rtcConfig, DelegateAdapter())
@@ -108,7 +116,15 @@ class RealtimeWebRtcSession(private val context: Context) {
         }
 
         Log.i(TAG, "start: awaiting ICE gathering complete")
-        awaitIceGatheringComplete(connection)
+        val iceGatheringCompleted = withTimeoutOrNull(REALTIME_ICE_GATHERING_TIMEOUT_MS) {
+            awaitIceGatheringComplete(connection)
+            true
+        } == true
+        if (!iceGatheringCompleted) {
+            // A host candidate is normally present by now. Prefer sending the
+            // best available offer to hanging the entire realtime start flow.
+            Log.w(TAG, "start: ICE gathering timed out; using current local description")
+        }
 
         if (isClosed.get() || peerConnection !== connection) {
             Log.w(TAG, "start: session closed while awaiting ICE gathering")

--- a/apps/android/app/src/test/java/com/litter/android/voice/RealtimeWebRtcSessionTest.kt
+++ b/apps/android/app/src/test/java/com/litter/android/voice/RealtimeWebRtcSessionTest.kt
@@ -1,0 +1,20 @@
+package com.litter.android.voice
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.webrtc.PeerConnection
+
+class RealtimeWebRtcSessionTest {
+
+    @Test
+    fun peerConnectionUsesBoundedSinglePassIceGathering() {
+        val configuration = realtimePeerConnectionConfiguration()
+
+        assertEquals(PeerConnection.SdpSemantics.UNIFIED_PLAN, configuration.sdpSemantics)
+        assertEquals(
+            PeerConnection.ContinualGatheringPolicy.GATHER_ONCE,
+            configuration.continualGatheringPolicy,
+        )
+        assertEquals(5_000L, REALTIME_ICE_GATHERING_TIMEOUT_MS)
+    }
+}

--- a/patches/codex/README.md
+++ b/patches/codex/README.md
@@ -62,9 +62,9 @@ Touches `protocol/src/protocol.rs`, `app-server-protocol/src/protocol/{common.rs
 The TUI hunks are no-op match arms required only because upstream's `ServerNotification` matches are exhaustive. Upstream moved the consolidated `handle_server_notification` match from `tui/src/chatwidget.rs` into `tui/src/chatwidget/protocol.rs`; this patch targets the new location.
 
 ## `realtime-webrtc-env-apikey.patch`
-For WebRTC realtime sessions, populate the request headers with the API key obtained from `realtime_api_key(auth, provider)`. Without this, the WebRTC peer connection fails to authenticate when the user is signed in via env-key auth.
+For WebRTC realtime sessions, populate the request headers with the API key obtained from `realtime_api_key(auth, provider)`. When ChatGPT auth falls back to that key, build a clean public OpenAI provider instead of retaining the ChatGPT backend URL. Without this, the WebRTC peer connection fails to authenticate or targets a backend call route the API key cannot access.
 
-Touches `core/src/realtime_conversation.rs`.
+Touches `core/src/{client.rs,realtime_conversation.rs,realtime_conversation_tests.rs}`.
 
 ---
 
@@ -77,7 +77,7 @@ Apply order in `sync-codex.sh` matters: `server-hint` first because it introduce
 ### `realtime-handoff-server-hint.patch`
 Adds `server: Option<String>` to `RealtimeHandoffRequested` so the model can specify which connected server (e.g. `studio`, `mac-mini`, `local`) should handle the prompt. The mobile client reads this hint to route the handoff over SSH/WS to the right backend.
 
-Touches `protocol/src/protocol.rs`, `codex-api/src/endpoint/realtime_websocket/{protocol_v1.rs,protocol_v2.rs}`, `app-server/src/bespoke_event_handling.rs`.
+Touches `protocol/src/protocol.rs`, `codex-api/src/endpoint/realtime_websocket/{protocol_v1.rs,protocol_v2.rs}`, `app-server/src/bespoke_event_handling.rs`, and `core/src/realtime_conversation_tests.rs`.
 
 Deliberately does NOT touch `methods_v2.rs` — the `server` parameter on the `background_agent` tool schema is added by `realtime-dynamic-tools.patch` as part of the `realtime_v2_session_tools` helper extraction. This keeps patch #1 orthogonal to patch #2's hunks so each patch's reverse-apply detection works independently after upstream bumps.
 

--- a/patches/codex/realtime-handoff-server-hint.patch
+++ b/patches/codex/realtime-handoff-server-hint.patch
@@ -64,3 +64,50 @@ index 30e33abe43..529e6e8248 100644
  }
  
  #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]
+diff --git a/codex-rs/core/src/realtime_conversation_tests.rs b/codex-rs/core/src/realtime_conversation_tests.rs
+--- a/codex-rs/core/src/realtime_conversation_tests.rs
++++ b/codex-rs/core/src/realtime_conversation_tests.rs
+@@ -31,7 +31,8 @@
+             RealtimeTranscriptEntry {
+                 role: "assistant".to_string(),
+                 text: "hi there".to_string(),
+             },
+         ],
++        server: None,
+     };
+     assert_eq!(
+@@ -46,8 +47,9 @@
+         item_id: "item_1".to_string(),
+         input_transcript: String::new(),
+         active_transcript: vec![RealtimeTranscriptEntry {
+             role: "user".to_string(),
+             text: "hello".to_string(),
+         }],
++        server: None,
+     };
+     assert_eq!(
+@@ -71,7 +73,8 @@
+             RealtimeTranscriptEntry {
+                 role: "assistant".to_string(),
+                 text: "hi there".to_string(),
+             },
+         ],
++        server: None,
+     };
+     assert_eq!(
+@@ -88,6 +91,7 @@
+         handoff_id: "handoff_1".to_string(),
+         item_id: "item_1".to_string(),
+         input_transcript: "ignored".to_string(),
+         active_transcript: vec![],
++        server: None,
+     };
+     assert_eq!(
+@@ -102,6 +106,7 @@
+         handoff_id: "handoff_1".to_string(),
+         item_id: "item_1".to_string(),
+         input_transcript: String::new(),
+         active_transcript: vec![],
++        server: None,
+     };
+     assert_eq!(realtime_text_from_handoff_request(&handoff), None);

--- a/patches/codex/realtime-webrtc-env-apikey.patch
+++ b/patches/codex/realtime-webrtc-env-apikey.patch
@@ -106,15 +106,7 @@ diff --git a/codex-rs/core/src/realtime_conversation.rs b/codex-rs/core/src/real
      extra_headers: Option<HeaderMap>,
      requested_realtime_session_id: Option<String>,
      version: RealtimeWsVersion,
-@@ -688,6 +694,7 @@
-         .transport
-         .unwrap_or(ConversationStartTransport::Websocket);
-     let mut api_provider = provider.to_api_provider(Some(AuthMode::ApiKey))?;
-+    let call_api_provider = api_provider.clone();
-     if let Some(realtime_ws_base_url) = &config.experimental_realtime_ws_base_url {
-         api_provider.base_url = realtime_ws_base_url.clone();
-     }
-@@ -702,23 +709,44 @@
+@@ -702,23 +708,48 @@
      )
      .await?;
      let requested_realtime_session_id = session_config.session_id.clone();
@@ -145,11 +137,15 @@ diff --git a/codex-rs/core/src/realtime_conversation.rs b/codex-rs/core/src/real
 +                Some(AuthMode::Chatgpt | AuthMode::ChatgptAuthTokens | AuthMode::AgentIdentity)
 +            );
 +            let webrtc_api_fallback = if current_auth_uses_codex_backend {
-+                realtime_api_key.as_ref().map(|api_key| {
-+                    let api_auth: SharedAuthProvider =
-+                        Arc::new(BearerAuthProvider::new(api_key.clone()));
-+                    (call_api_provider.clone(), api_auth)
-+                })
++                realtime_api_key
++                    .as_ref()
++                    .map(|api_key| {
++                        let api_auth: SharedAuthProvider =
++                            Arc::new(BearerAuthProvider::new(api_key.clone()));
++                        realtime_webrtc_api_provider()
++                            .map(|api_provider| (api_provider, api_auth))
++                    })
++                    .transpose()?
 +            } else {
 +                None
 +            };
@@ -168,7 +164,7 @@ diff --git a/codex-rs/core/src/realtime_conversation.rs b/codex-rs/core/src/real
          extra_headers,
          requested_realtime_session_id,
          version,
-@@ -843,6 +871,7 @@
+@@ -843,6 +874,7 @@
  ) -> CodexResult<()> {
      let PreparedRealtimeConversationStart {
          api_provider,
@@ -176,7 +172,7 @@ diff --git a/codex-rs/core/src/realtime_conversation.rs b/codex-rs/core/src/real
          extra_headers,
          requested_realtime_session_id,
          version,
-@@ -857,6 +886,7 @@
+@@ -857,6 +889,7 @@
      };
      let start = RealtimeStart {
          api_provider,
@@ -184,3 +180,42 @@ diff --git a/codex-rs/core/src/realtime_conversation.rs b/codex-rs/core/src/real
          extra_headers,
          session_config,
          model_client: sess.services.model_client.clone(),
+@@ -1067,6 +1100,11 @@ fn realtime_api_key(
+     ))
+ }
+-
++
++fn realtime_webrtc_api_provider() -> CodexResult<ApiProvider> {
++    ModelProviderInfo::create_openai_provider(/*base_url*/ None)
++        .to_api_provider(Some(AuthMode::ApiKey))
++}
++
+ fn realtime_request_headers(
+     realtime_session_id: Option<&str>,
+     api_key: Option<&str>,
+diff --git a/codex-rs/core/src/realtime_conversation_tests.rs b/codex-rs/core/src/realtime_conversation_tests.rs
+--- a/codex-rs/core/src/realtime_conversation_tests.rs
++++ b/codex-rs/core/src/realtime_conversation_tests.rs
+@@ -2,12 +2,21 @@
+ use super::RealtimeSessionKind;
+ use super::realtime_delegation_from_handoff;
+ use super::realtime_text_from_handoff_request;
++use super::realtime_webrtc_api_provider;
+ use super::wrap_realtime_delegation_input;
+ use async_channel::bounded;
+ use codex_protocol::protocol::RealtimeHandoffRequested;
+ use codex_protocol::protocol::RealtimeTranscriptEntry;
+ use pretty_assertions::assert_eq;
+-
++
++#[test]
++fn webrtc_api_key_fallback_uses_public_openai_endpoint() {
++    let provider = realtime_webrtc_api_provider().expect("public realtime API provider");
++
++    assert_eq!(provider.base_url, "https://api.openai.com/v1");
++    assert_eq!(provider.query_params, None);
++}
++
+ #[test]
+ fn prefers_handoff_input_transcript_over_active_transcript() {
+     let handoff = RealtimeHandoffRequested {


### PR DESCRIPTION
## Purpose

Replace stale PR #183 with a current-main fix for #182: Android realtime voice must not wait indefinitely for ICE completion, and API-key fallback must target the public OpenAI endpoint rather than a ChatGPT backend URL.

## Key changes

- use unified-plan, one-shot ICE gathering and a bounded five-second wait
- continue with the best available local description when ICE completion does not arrive
- expose the peer-connection policy through a focused test seam
- create a clean public OpenAI provider for ChatGPT API-key fallback
- repair all five `RealtimeHandoffRequested` fixtures in the owning server-hint patch

## Verification

- Codex sync/patch stack applies cleanly
- Android compile plus full debug unit suite: 46 tests, 0 failures
- focused Codex provider test: 1 passed, 0 failed
- `git diff --check` passes

## Device evidence

PR #183 documented successful Galaxy hardware verification for the same one-shot/timeout behavior. This current-main replacement has not independently repeated microphone, live ICE, SDP, and authenticated two-way audio on hardware; that remains the final acceptance surface before merge.

Closes #182. Supersedes #183.