### PR TITLE
mobile: prefer renamed session titles

### DIFF
--- a/apps/android/app/src/main/java/com/litter/android/state/SnapshotExtensions.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/SnapshotExtensions.kt
@@ -207,8 +207,8 @@ val AppThreadSnapshot.resolvedPreview: String
     get() = displayTitle
 
 val AppSessionSummary.displayTitle: String
-    get() = preview?.takeIf { it.isNotBlank() }
-        ?: title?.takeIf { it.isNotBlank() }
+    get() = title?.takeIf { it.isNotBlank() }
+        ?: preview?.takeIf { it.isNotBlank() }
         ?: "Untitled session"
 
 val AppThreadSnapshot.contextPercent: Int

--- a/apps/android/app/src/test/java/com/litter/android/state/SnapshotExtensionsTest.kt
+++ b/apps/android/app/src/test/java/com/litter/android/state/SnapshotExtensionsTest.kt
@@ -2,6 +2,9 @@ package com.litter.android.state
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import uniffi.codex_mobile_client.AppSessionSummary
+import uniffi.codex_mobile_client.AppSubagentStatus
+import uniffi.codex_mobile_client.ThreadKey
 
 class SnapshotExtensionsTest {
 
@@ -38,5 +41,43 @@ class SnapshotExtensionsTest {
                 agentRuntimeKind = "opencode",
             ),
         )
+    }
+
+    @Test
+    fun `session display title prefers explicit title over preview`() {
+        val summary = AppSessionSummary(
+            key = ThreadKey(serverId = "studio", threadId = "renamed"),
+            agentRuntimeKind = "codex",
+            serverDisplayName = "Studio",
+            serverHost = "studio.local",
+            title = "litter-deepseek",
+            preview = "<command-message>review</command-message>",
+            cwd = "/tmp",
+            model = "",
+            modelProvider = "",
+            parentThreadId = null,
+            forkedFromId = null,
+            agentNickname = null,
+            agentRole = null,
+            agentDisplayLabel = null,
+            agentStatus = AppSubagentStatus.UNKNOWN,
+            updatedAt = null,
+            hasActiveTurn = false,
+            isResumed = false,
+            isSubagent = false,
+            isFork = false,
+            lastResponsePreview = null,
+            lastResponseTurnId = null,
+            lastUserMessage = null,
+            lastToolLabel = null,
+            recentToolLog = emptyList(),
+            lastTurnStartMs = null,
+            lastTurnEndMs = null,
+            stats = null,
+            tokenUsage = null,
+            goal = null,
+        )
+
+        assertEquals("litter-deepseek", summary.displayTitle)
     }
 }

--- a/apps/ios/Sources/Litter/Views/SessionsTypes.swift
+++ b/apps/ios/Sources/Litter/Views/SessionsTypes.swift
@@ -5,14 +5,14 @@ extension AppSessionSummary: Identifiable {
     var serverId: String { key.serverId }
     var threadId: String { key.threadId }
     var displayTitle: String {
-        let trimmedPreview = preview.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmedPreview.isEmpty {
-            return trimmedPreview
-        }
-
         let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmedTitle.isEmpty {
             return trimmedTitle
+        }
+
+        let trimmedPreview = preview.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedPreview.isEmpty {
+            return trimmedPreview
         }
 
         return "Untitled session"

--- a/apps/ios/Tests/LitterTests/RunningTurnSnapshotTests.swift
+++ b/apps/ios/Tests/LitterTests/RunningTurnSnapshotTests.swift
@@ -88,6 +88,18 @@ final class RunningTurnSnapshotTests: XCTestCase {
         XCTAssertEqual(payload.lastTool, "edit_file src/auth.go")
     }
 
+    func testSessionSummaryDisplayTitlePrefersExplicitTitleOverPreview() {
+        let summary = makeSummary(
+            key: ThreadKey(serverId: "studio", threadId: "renamed"),
+            serverDisplayName: "Studio",
+            title: "litter-deepseek",
+            preview: "<command-message>review</command-message>",
+            lastToolLabel: nil
+        )
+
+        XCTAssertEqual(summary.displayTitle, "litter-deepseek")
+    }
+
     func testMakeRunningTurnSnapshotFallsBackWhenServerOrSummaryMissing() {
         let key = ThreadKey(serverId: "studio", threadId: "t2")
         let thread = makeThread(key: key, model: "")
@@ -141,6 +153,7 @@ final class RunningTurnSnapshotTests: XCTestCase {
         key: ThreadKey,
         serverDisplayName: String,
         title: String,
+        preview: String = "",
         lastToolLabel: String?
     ) -> AppSessionSummary {
         AppSessionSummary(
@@ -149,7 +162,7 @@ final class RunningTurnSnapshotTests: XCTestCase {
             serverDisplayName: serverDisplayName,
             serverHost: "\(key.serverId).local",
             title: title,
-            preview: "",
+            preview: preview,
             cwd: "/tmp",
             model: "",
             modelProvider: "",


### PR DESCRIPTION
Closes #166.

## Root cause

The shared Rust summary already projects an explicit title separately from preview text, but both mobile session-list projections re-selected preview first. A renamed Claude session could therefore keep rendering its first raw command/XML message.

## Change

- prefer trimmed explicit `title` over `preview` in iOS `AppSessionSummary.displayTitle`
- apply the same ordering on Android
- retain preview and `Untitled session` fallbacks
- add explicit title-vs-preview regressions on both platforms

## Verification

- generated current UniFFI bindings from the synced patch stack
- focused Android `SnapshotExtensionsTest`: passed
- Android debug Kotlin compilation: passed
- `git diff --check`: passed

The iOS fast-simulator build/test is still running locally; PR CI is also the final cross-platform gate. This stays draft until those pass.
