### PR TITLE
ssh: import Fish and Nix profile paths

### DIFF
--- a/shared/rust-bridge/codex-mobile-client/src/ssh/tests.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/ssh/tests.rs
@@ -190,7 +190,8 @@ fn test_profile_init_sources_common_files() {
     assert!(PROFILE_INIT.contains(".zshenv"));
     assert!(PROFILE_INIT.contains(".zprofile"));
     assert!(PROFILE_INIT.contains(".zshrc"));
-    assert!(!PROFILE_INIT.contains("-ic 'printf %s \"$PATH\"'"));
+    assert!(PROFILE_INIT.contains("--login --command"));
+    assert!(PROFILE_INIT.contains("__litter_path_start__"));
 }
 
 #[test]
@@ -208,7 +209,144 @@ fn test_profile_init_adds_common_node_manager_bins() {
     assert!(PROFILE_INIT.contains(".fnm/node-versions"));
     assert!(PROFILE_INIT.contains(".asdf/shims"));
     assert!(PROFILE_INIT.contains(".local/share/mise/shims"));
+    assert!(PROFILE_INIT.contains(".nix-profile/bin"));
+    assert!(PROFILE_INIT.contains(".local/state}/nix/profile/bin"));
+    assert!(PROFILE_INIT.contains("/etc/profiles/per-user/$USER/bin"));
+    assert!(PROFILE_INIT.contains("/nix/var/nix/profiles/default/bin"));
+    assert!(PROFILE_INIT.contains("/run/current-system/sw/bin"));
     assert!(PROFILE_INIT.contains("export PATH"));
+}
+
+#[cfg(unix)]
+fn run_profile_init(home: &std::path::Path, shell: &std::path::Path) -> String {
+    let script = format!("{PROFILE_INIT}\nprintf '__litter_test_path__%s\\n' \"$PATH\"");
+    let output = std::process::Command::new("/bin/sh")
+        .arg("-c")
+        .arg(script)
+        .env_clear()
+        .env("HOME", home)
+        .env("USER", "litter-test")
+        .env("SHELL", shell)
+        .env("PATH", "/usr/bin:/bin")
+        .output()
+        .expect("profile init should run under /bin/sh");
+    assert!(
+        output.status.success(),
+        "profile init failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("profile output should be UTF-8")
+        .lines()
+        .find_map(|line| line.strip_prefix("__litter_test_path__"))
+        .expect("profile init should print its final PATH")
+        .to_owned()
+}
+
+#[cfg(unix)]
+fn write_profile(path: &std::path::Path, bin_dir: &std::path::Path) {
+    std::fs::write(
+        path,
+        format!("PATH='{}':$PATH; export PATH\n", bin_dir.display()),
+    )
+    .unwrap();
+}
+
+#[cfg(unix)]
+fn path_contains(path: &str, expected: &std::path::Path) -> bool {
+    path.split(':')
+        .any(|entry| std::path::Path::new(entry) == expected)
+}
+
+#[cfg(unix)]
+#[test]
+fn test_profile_init_preserves_posix_bash_and_zsh_profile_imports() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path();
+    let profile_bin = home.join("profile-bin");
+    let bash_bin = home.join("bash-bin");
+    let zsh_bin = home.join("zsh-bin");
+    for directory in [&profile_bin, &bash_bin, &zsh_bin] {
+        std::fs::create_dir_all(directory).unwrap();
+    }
+    write_profile(&home.join(".profile"), &profile_bin);
+    write_profile(&home.join(".bashrc"), &bash_bin);
+    write_profile(&home.join(".zshrc"), &zsh_bin);
+
+    let path = run_profile_init(home, std::path::Path::new("/bin/zsh"));
+
+    assert!(path_contains(&path, &profile_bin));
+    assert!(path_contains(&path, &bash_bin));
+    assert!(path_contains(&path, &zsh_bin));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_profile_init_imports_selected_fish_login_path_without_chatter() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path();
+    let fish_bin = home.join("fish-bin");
+    let nix_bin = home.join(".nix-profile/bin");
+    std::fs::create_dir_all(&fish_bin).unwrap();
+    std::fs::create_dir_all(&nix_bin).unwrap();
+    let fish = home.join("fish");
+    std::fs::write(
+        &fish,
+        "#!/bin/sh\n\
+         [ \"$1\" = --login ] && [ \"$2\" = --command ] || exit 64\n\
+         printf 'fish startup chatter\\n'\n\
+         printf '__litter_path_start__%s/fish-bin__litter_path_end__\\n' \"$HOME\"\n",
+    )
+    .unwrap();
+    let mut permissions = std::fs::metadata(&fish).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&fish, permissions).unwrap();
+
+    let path = run_profile_init(home, &fish);
+
+    assert!(path_contains(&path, &fish_bin));
+    assert!(path_contains(&path, &nix_bin));
+    assert!(!path.contains("fish startup chatter"));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_profile_init_keeps_posix_path_when_selected_fish_export_fails() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path();
+    let profile_bin = home.join("profile-bin");
+    std::fs::create_dir_all(&profile_bin).unwrap();
+    write_profile(&home.join(".profile"), &profile_bin);
+
+    let fish = home.join("fish");
+    std::fs::write(&fish, "#!/bin/sh\nexit 1\n").unwrap();
+    let mut permissions = std::fs::metadata(&fish).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&fish, permissions).unwrap();
+
+    let path = run_profile_init(home, &fish);
+
+    assert!(path_contains(&path, &profile_bin));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_profile_init_adds_user_nix_profile_bins_without_shell_config() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path();
+    let legacy_nix_bin = home.join(".nix-profile/bin");
+    let modern_nix_bin = home.join(".local/state/nix/profile/bin");
+    std::fs::create_dir_all(&legacy_nix_bin).unwrap();
+    std::fs::create_dir_all(&modern_nix_bin).unwrap();
+
+    let path = run_profile_init(home, std::path::Path::new("/bin/sh"));
+
+    assert!(path_contains(&path, &legacy_nix_bin));
+    assert!(path_contains(&path, &modern_nix_bin));
 }
 
 #[test]

--- a/shared/rust-bridge/codex-mobile-client/src/ssh_scripts/posix/profile_init.sh
+++ b/shared/rust-bridge/codex-mobile-client/src/ssh_scripts/posix/profile_init.sh
@@ -1,11 +1,112 @@
-# Source common shell rc files into PATH so user-installed binaries (npm,
-# pnpm, bun, codex) become reachable from `/bin/sh`. We run each rc in a
-# subshell so per-shell-only syntax (e.g. zsh-isms) cannot crash the parent
-# /bin/sh, then re-import the resulting PATH via a temp file.
-_litter_path_prepend() { case ":$PATH:" in *":$1:"*) ;; *) [ -d "$1" ] && PATH="$1:$PATH" ;; esac; }
-_litter_pf="/tmp/.litter_path_$$"; for f in "$HOME/.zshenv" "$HOME/.profile" "$HOME/.bash_profile" "$HOME/.bashrc" "$HOME/.zprofile" "$HOME/.zshrc"; do [ -f "$f" ] && (. "$f" 2>/dev/null; echo "$PATH") > "$_litter_pf" 2>/dev/null && PATH="$(cat "$_litter_pf")" ; done; rm -f "$_litter_pf" 2>/dev/null;
-_litter_path_prepend "$NVM_BIN"; _litter_path_prepend "${ASDF_DATA_DIR:-}/shims"; _litter_path_prepend "/opt/homebrew/opt/node/bin"; _litter_path_prepend "/opt/homebrew/bin"; _litter_path_prepend "/usr/local/opt/node/bin"; _litter_path_prepend "/usr/local/bin"; _litter_path_prepend "$HOME/.volta/bin"; _litter_path_prepend "$HOME/.bun/bin"; _litter_path_prepend "$HOME/.local/bin"; _litter_path_prepend "${CARGO_HOME:-$HOME/.cargo}/bin"; _litter_path_prepend "${PNPM_HOME:-$HOME/Library/pnpm}"; _litter_path_prepend "$HOME/.opencode/bin";
-_litter_nvm_dir="${NVM_DIR:-$HOME/.nvm}"; if [ -d "$_litter_nvm_dir/versions/node" ]; then _litter_nvm_default=""; [ -f "$_litter_nvm_dir/alias/default" ] && _litter_nvm_default="$(cat "$_litter_nvm_dir/alias/default" 2>/dev/null || true)"; [ -n "$_litter_nvm_default" ] && _litter_path_prepend "$_litter_nvm_dir/versions/node/$_litter_nvm_default/bin"; for d in "$_litter_nvm_dir"/versions/node/*/bin; do [ -x "$d/node" ] && _litter_path_prepend "$d"; done; fi;
-if [ -d "$HOME/.fnm/node-versions" ]; then for d in "$HOME"/.fnm/node-versions/*/installation/bin; do [ -x "$d/node" ] && _litter_path_prepend "$d"; done; fi;
-_litter_path_prepend "$HOME/.asdf/shims"; _litter_path_prepend "$HOME/.local/share/mise/shims";
-export PATH;
+# Import the login environment into the POSIX shell used by Litter's SSH
+# commands. The command executor remains `/usr/bin/env sh`; a user's fish or
+# zsh configuration is only consulted for PATH discovery and never asked to
+# interpret Litter's generated scripts.
+_litter_path_prepend() {
+  [ -n "$1" ] || return 0
+  case ":${PATH:-}:" in
+    *":$1:"*) ;;
+    *) [ -d "$1" ] && PATH="$1${PATH:+:$PATH}" ;;
+  esac
+}
+
+_litter_import_posix_profile() {
+  [ -f "$1" ] || return 0
+  _litter_candidate_path="$(
+    (
+      # Profiles belong to the remote user and may contain shell-specific
+      # syntax. Keep failures and side effects inside this subshell.
+      # shellcheck disable=SC1090
+      . "$1" >/dev/null 2>&1
+      printf '%s\n' "${PATH:-}"
+    ) 2>/dev/null | tail -n 1
+  )"
+  [ -n "$_litter_candidate_path" ] && PATH="$_litter_candidate_path"
+}
+
+for _litter_profile in \
+  "$HOME/.zshenv" \
+  "$HOME/.profile" \
+  "$HOME/.bash_profile" \
+  "$HOME/.bashrc" \
+  "$HOME/.zprofile" \
+  "$HOME/.zshrc"
+do
+  _litter_import_posix_profile "$_litter_profile"
+done
+
+# NixOS and `nix profile` installs commonly place user and system programs in
+# these directories without mentioning them in a POSIX profile.
+_litter_add_nix_paths() {
+  _litter_path_prepend "$HOME/.nix-profile/bin"
+  _litter_path_prepend "${XDG_STATE_HOME:-$HOME/.local/state}/nix/profile/bin"
+  [ -n "${USER:-}" ] && _litter_path_prepend "/etc/profiles/per-user/$USER/bin"
+  _litter_path_prepend "/nix/var/nix/profiles/default/bin"
+  _litter_path_prepend "/run/current-system/sw/bin"
+  _litter_path_prepend "/run/wrappers/bin"
+}
+_litter_add_nix_paths
+
+# Fish configuration cannot be sourced by sh. When fish is the account's
+# selected login shell, start it only long enough to read its normal startup
+# files and emit its exported PATH between sentinels. Config-file chatter is
+# ignored, and Litter's generated commands continue to execute under sh.
+_litter_login_shell="${SHELL:-}"
+case "$_litter_login_shell" in
+  fish)
+    _litter_login_shell="$(command -v fish 2>/dev/null || true)"
+    ;;
+esac
+case "$_litter_login_shell" in
+  */fish)
+    if [ -x "$_litter_login_shell" ]; then
+      _litter_fish_path="$(
+        "$_litter_login_shell" --login --command \
+          'printf "__litter_path_start__%s__litter_path_end__\n" "$PATH"' \
+          2>/dev/null |
+          sed -n 's/^__litter_path_start__\(.*\)__litter_path_end__$/\1/p' |
+          tail -n 1
+      )"
+      [ -n "$_litter_fish_path" ] && PATH="$_litter_fish_path"
+    fi
+    ;;
+esac
+
+# A fish config can replace PATH rather than extend it. Restore any existing
+# Nix profile directories without duplicating entries.
+_litter_add_nix_paths
+
+_litter_path_prepend "$NVM_BIN"
+_litter_path_prepend "${ASDF_DATA_DIR:-}/shims"
+_litter_path_prepend "/opt/homebrew/opt/node/bin"
+_litter_path_prepend "/opt/homebrew/bin"
+_litter_path_prepend "/usr/local/opt/node/bin"
+_litter_path_prepend "/usr/local/bin"
+_litter_path_prepend "$HOME/.volta/bin"
+_litter_path_prepend "$HOME/.bun/bin"
+_litter_path_prepend "$HOME/.local/bin"
+_litter_path_prepend "${CARGO_HOME:-$HOME/.cargo}/bin"
+_litter_path_prepend "${PNPM_HOME:-$HOME/Library/pnpm}"
+_litter_path_prepend "$HOME/.opencode/bin"
+
+_litter_nvm_dir="${NVM_DIR:-$HOME/.nvm}"
+if [ -d "$_litter_nvm_dir/versions/node" ]; then
+  _litter_nvm_default=""
+  if [ -f "$_litter_nvm_dir/alias/default" ]; then
+    _litter_nvm_default="$(cat "$_litter_nvm_dir/alias/default" 2>/dev/null || true)"
+  fi
+  if [ -n "$_litter_nvm_default" ]; then
+    _litter_path_prepend "$_litter_nvm_dir/versions/node/$_litter_nvm_default/bin"
+  fi
+  for _litter_node_bin in "$_litter_nvm_dir"/versions/node/*/bin; do
+    [ -x "$_litter_node_bin/node" ] && _litter_path_prepend "$_litter_node_bin"
+  done
+fi
+if [ -d "$HOME/.fnm/node-versions" ]; then
+  for _litter_node_bin in "$HOME"/.fnm/node-versions/*/installation/bin; do
+    [ -x "$_litter_node_bin/node" ] && _litter_path_prepend "$_litter_node_bin"
+  done
+fi
+_litter_path_prepend "$HOME/.asdf/shims"
+_litter_path_prepend "$HOME/.local/share/mise/shims"
+export PATH


### PR DESCRIPTION
Addresses the shell-environment portion of #185.

## Root cause

Litter executes generated SSH commands under POSIX `sh`, but its profile importer only tried POSIX/bash/zsh files. A Fish login account—and common NixOS/profile locations—could therefore hide `codex`, Node, and package-manager binaries from the SSH command environment.

## Change

- keep all generated commands under POSIX `sh`
- when Fish is the selected login shell, invoke `fish --login --command` only to export PATH through a sentinel-safe record
- ignore Fish startup chatter and fall back to the POSIX PATH if export fails
- restore common user/system Nix profile bin directories
- preserve existing POSIX/bash/zsh and Node-manager behavior

## Verification

- `/bin/sh -n`
- shellcheck
- focused profile tests: 6/6
- SSH suite: 28 passed, 1 live-only ignored
- full `codex-mobile-client` lib suite: 778 passed, 0 failed, 5 live-only ignored
- `git diff --check`

## Remaining acceptance

No real Fish/NixOS SSH host was available; Fish behavior was exercised through an executable fixture. Keep this draft until a live Fish host proves Codex/package-manager lookup. The reporter's folder-picker `-32604` is a distinct app-server spawn path and is not claimed fixed without host diagnostics.
