### PR TITLE
android: keep session timestamps on one line

### DIFF
--- a/apps/android/app/src/androidTest/java/com/litter/android/ui/sessions/SessionMetadataRowTest.kt
+++ b/apps/android/app/src/androidTest/java/com/litter/android/ui/sessions/SessionMetadataRowTest.kt
@@ -1,0 +1,61 @@
+package com.litter.android.ui.sessions
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.assertWidthIsAtLeast
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SessionMetadataRowTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun timestampRemainsWholeAtNarrowWidthAndIncreasedFontScale() {
+        composeTestRule.setContent {
+            val density = LocalDensity.current
+            CompositionLocalProvider(
+                LocalDensity provides Density(density = density.density, fontScale = 2f),
+            ) {
+                Box(modifier = Modifier.width(180.dp)) {
+                    SessionMetadataRow(
+                        modelLabel = "a-very-long-provider-and-model-name-that-must-yield",
+                        agentLabel = "a-very-long-runtime-label-that-must-yield",
+                        relativeTime = "just now",
+                    )
+                }
+            }
+        }
+
+        val timestamp = composeTestRule.onNodeWithText("just now")
+        timestamp.assertWidthIsAtLeast(48.dp)
+
+        val textLayouts = mutableListOf<TextLayoutResult>()
+        timestamp.performSemanticsAction(SemanticsActions.GetTextLayoutResult) { action ->
+            assertTrue(action(textLayouts))
+        }
+
+        val layout = textLayouts.single()
+        assertEquals(1, layout.lineCount)
+        assertFalse(layout.didOverflowWidth)
+        assertFalse(layout.didOverflowHeight)
+        assertFalse(layout.isLineEllipsized(0))
+    }
+}

--- a/apps/android/app/src/main/java/com/litter/android/ui/sessions/SessionsScreen.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/sessions/SessionsScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -56,6 +57,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -611,29 +613,12 @@ private fun SessionNodeRow(
                     fontSize = 13.sp,
                     maxLines = 1,
                 )
-                Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                    summary.model?.let { model ->
-                        Text(
-                            text = model.substringAfterLast('/'),
-                            color = LitterTheme.textMuted,
-                            fontSize = 10.sp,
-                        )
-                    }
-                    summary.agentDisplayLabel?.let { label ->
-                        Text(
-                            text = label,
-                            color = LitterTheme.accent,
-                            fontSize = 10.sp,
-                        )
-                    }
-                }
+                SessionMetadataRow(
+                    modelLabel = summary.model?.substringAfterLast('/'),
+                    agentLabel = summary.agentDisplayLabel,
+                    relativeTime = HomeDashboardSupport.relativeTime(summary.updatedAt),
+                )
             }
-
-            Text(
-                text = HomeDashboardSupport.relativeTime(summary.updatedAt),
-                color = LitterTheme.textMuted,
-                fontSize = 10.sp,
-            )
         }
 
         DropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }) {
@@ -724,6 +709,67 @@ private fun SessionNodeRow(
     }
 
     Spacer(Modifier.height(4.dp))
+}
+
+private val SessionTimestampMinWidth = 48.dp
+
+/**
+ * Keeps relative time on the metadata line and reserves its intrinsic width
+ * before long model or runtime labels are measured.
+ */
+@Composable
+internal fun SessionMetadataRow(
+    modelLabel: String?,
+    agentLabel: String?,
+    relativeTime: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Row(
+            modifier = Modifier.weight(1f),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            modelLabel?.let { model ->
+                Text(
+                    text = model,
+                    color = LitterTheme.textMuted,
+                    fontSize = 10.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+            }
+            agentLabel?.let { label ->
+                Text(
+                    text = label,
+                    color = LitterTheme.accent,
+                    fontSize = 10.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+            }
+        }
+
+        if (relativeTime.isNotEmpty()) {
+            Spacer(Modifier.width(6.dp))
+            Text(
+                text = relativeTime,
+                color = LitterTheme.textMuted,
+                fontSize = 10.sp,
+                maxLines = 1,
+                softWrap = false,
+                overflow = TextOverflow.Clip,
+                textAlign = TextAlign.End,
+                modifier = Modifier
+                    .widthIn(min = SessionTimestampMinWidth),
+            )
+        }
+    }
 }
 
 private fun visibleSessionRows(


### PR DESCRIPTION
Closes #162.

## Root cause

The session row rendered relative time as an unconstrained multiline trailing `Text`. Long model/runtime metadata or increased font scale could reduce the remaining width enough for Compose to wrap the timestamp one character at a time.

## Change

- move time into the second metadata row
- make model/runtime labels yield space and ellipsize
- reserve a minimum timestamp width
- enforce one line, no wrapping, and end alignment
- add a Compose regression at 180dp, 2× font scale, and long metadata

The corresponding iOS metadata row already uses a single line, so this is intentionally Android-only.

## Verification

- `git diff --check`
- static layout review confirms `maxLines = 1`, `softWrap = false`, and a reserved minimum width

## Remaining acceptance

This machine has no configured Android emulator. The instrumented test and exact rendered row must run under PR CI/emulator, followed by a screenshot or physical-device check with long host/CWD metadata at increased font size. This remains draft until then.
