### PR TITLE
bridge: restore fork lineage on cold thread lists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,8 @@ PATCH_FILES := \
 	$(PATCHES_DIR)/ios-exec-hook.patch \
 	$(PATCHES_DIR)/client-controlled-handoff.patch \
 	$(PATCHES_DIR)/mobile-code-mode-stub.patch \
-	$(PATCHES_DIR)/thread-read-permissions.patch
+	$(PATCHES_DIR)/thread-read-permissions.patch \
+	$(PATCHES_DIR)/thread-list-fork-lineage.patch
 
 BOUNDARY_SOURCES := \
 	$(RUST_DIR)/codex-mobile-client/Cargo.toml \

--- a/apps/ios/scripts/sync-codex.sh
+++ b/apps/ios/scripts/sync-codex.sh
@@ -9,6 +9,7 @@ PATCH_FILES=(
     "$REPO_DIR/patches/codex/ios-exec-hook.patch"
     "$REPO_DIR/patches/codex/mobile-code-mode-stub.patch"
     "$REPO_DIR/patches/codex/thread-read-permissions.patch"
+    "$REPO_DIR/patches/codex/thread-list-fork-lineage.patch"
     "$REPO_DIR/patches/codex/mobile-shell-snapshot-timeout.patch"
     "$REPO_DIR/patches/codex/remote-app-server-websocket-cap.patch"
     "$REPO_DIR/patches/codex/absolute-path-cross-platform.patch"

--- a/patches/codex/thread-list-fork-lineage.patch
+++ b/patches/codex/thread-list-fork-lineage.patch
@@ -1,0 +1,88 @@
+diff --git a/codex-rs/thread-store/src/local/list_threads.rs b/codex-rs/thread-store/src/local/list_threads.rs
+index ede9e9e..ead8b7f 100644
+--- a/codex-rs/thread-store/src/local/list_threads.rs
++++ b/codex-rs/thread-store/src/local/list_threads.rs
+@@ -75,6 +75,25 @@ pub(super) async fn list_threads(
+         })
+         .collect::<Vec<_>>();
+
++    // The lightweight rollout-list projection does not carry fork lineage,
++    // while `read_thread` does. Restore the immutable parent id from the
++    // canonical session metadata so a cold `thread/list` can rediscover
++    // persistent forks without loading their histories. Keep state-DB-only
++    // requests free of filesystem reads as their contract requires.
++    if !params.use_state_db_only {
++        for thread in &mut items {
++            let Some(rollout_path) = thread.rollout_path.as_ref() else {
++                continue;
++            };
++            let Ok(meta_line) = codex_rollout::read_session_meta_line(rollout_path).await else {
++                continue;
++            };
++            if meta_line.meta.id == thread.thread_id {
++                thread.forked_from_id = meta_line.meta.forked_from_id;
++            }
++        }
++    }
++
+     let thread_ids = items
+         .iter()
+         .map(|thread| thread.thread_id)
+@@ -199,6 +218,7 @@ mod tests {
+     use crate::local::test_support::write_archived_session_file;
+     use crate::local::test_support::write_session_file;
+     use crate::local::test_support::write_session_file_with;
++    use crate::local::test_support::write_session_file_with_fork;
+
+     #[tokio::test]
+     async fn list_threads_uses_default_provider_when_rollout_omits_provider() {
+@@ -234,6 +254,49 @@ mod tests {
+         assert_eq!(page.items[0].model_provider, "test-provider");
+     }
+
++    #[tokio::test]
++    async fn cold_list_threads_preserves_fork_lineage_from_rollout() {
++        let home = TempDir::new().expect("temp dir");
++        let parent_id = Uuid::from_u128(103);
++        let fork_id = Uuid::from_u128(104);
++        write_session_file_with_fork(
++            home.path(),
++            home.path().join("sessions/2025/01/03"),
++            "2025-01-03T12-00-00",
++            fork_id,
++            "Forked user message",
++            Some("test-provider"),
++            Some(parent_id),
++        )
++        .expect("fork rollout");
++
++        // A fresh store has no warm in-memory fork response to preserve. The
++        // list response must recover lineage from the persisted rollout.
++        let store = LocalThreadStore::new(test_config(home.path()), /*state_db*/ None);
++        let page = store
++            .list_threads(ListThreadsParams {
++                page_size: 10,
++                cursor: None,
++                sort_key: ThreadSortKey::CreatedAt,
++                sort_direction: SortDirection::Desc,
++                allowed_sources: Vec::new(),
++                model_providers: None,
++                cwd_filters: None,
++                archived: false,
++                search_term: None,
++                use_state_db_only: false,
++            })
++            .await
++            .expect("cold thread listing");
++
++        assert_eq!(page.items.len(), 1);
++        assert_eq!(page.items[0].thread_id.to_string(), fork_id.to_string());
++        assert_eq!(
++            page.items[0].forked_from_id.map(|id| id.to_string()),
++            Some(parent_id.to_string())
++        );
++    }
++
+     #[tokio::test]
+     async fn list_threads_preserves_sqlite_title_search_results() {
+         let home = TempDir::new().expect("temp dir");


### PR DESCRIPTION
## Purpose

Fix persistent fork rediscovery after leaving a session or restarting Litter. Fixes #150 when merged.

## Root cause

The fork rollout is durable and thread/read returns its forkedFromId, but the upstream local thread-store list projection discarded that immutable field. After a cold restart, thread/list therefore returned the fork without lineage, so the Forks projection could not identify it.

## Changes

- add a narrow Codex patch that restores forked_from_id from the canonical first session metadata record for non-state-DB-only lists
- preserve the state-DB-only contract by performing no filesystem read for those requests
- add a cold-store regression proving a persistent fork is rediscovered with its parent id
- wire the patch into the normal Codex sync and unpatch lanes

## Verification

- cargo test -p codex-thread-store cold_list_threads_preserves_fork_lineage_from_rollout -- --nocapture
- cargo test -p codex-thread-store (73 passed)
- built the patched codex-app-server binary
- end-to-end synthetic acceptance: fork persistent rollout, terminate app-server, start a fresh process, verify thread/list finds the fork with the same forkedFromId, and verify thread/read agrees
- bash -n apps/ios/scripts/sync-codex.sh
- clean apply and reverse-apply checks against pinned Codex 13595c36e218fcbd13df118eeadf00d4eb0e6d31

## Remaining acceptance

A physical iPhone This Device flow and a remote VM flow still need UI-level validation before merge: fork, send a follow-up, leave the conversation, force restart, reopen from Sessions and the Forks filter, and continue the thread. The PR stays draft until those two acceptance surfaces are proven.