### PR TITLE
bridge: persist per-thread collaboration mode

### DIFF
--- a/apps/android/app/src/main/java/com/litter/android/state/AppModel.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/AppModel.kt
@@ -134,6 +134,7 @@ class AppModel private constructor(context: android.content.Context) {
         // directory. Without setting it at launch the hook is a silent no-op.
         client.setSavedAppsDirectory(SavedAppsDirectory.path(context))
         client.setSlingshotCredentialsDirectory(MobilePreferencesDirectory.path(context))
+        store.setThreadModePersistenceDirectory(MobilePreferencesDirectory.path(context))
         discovery = DiscoveryBridge()
         serverBridge = ServerBridge()
         ssh = SshBridge()

--- a/apps/ios/Sources/Litter/Models/AppModel.swift
+++ b/apps/ios/Sources/Litter/Models/AppModel.swift
@@ -152,6 +152,7 @@ final class AppModel {
         // Without this, auto-save silently no-ops.
         self.client.setSavedAppsDirectory(directory: SavedAppsDirectory.path)
         self.client.setSlingshotCredentialsDirectory(directory: MobilePreferencesDirectory.path)
+        self.store.setThreadModePersistenceDirectory(directory: MobilePreferencesDirectory.path)
 
         // Route Swift presentation lookups through the Rust-owned
         // `AgentMetadataStore`. Any view rendering an agent label /

--- a/shared/rust-bridge/codex-mobile-client/src/ffi/app_store.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/ffi/app_store.rs
@@ -363,6 +363,14 @@ impl AppStore {
         }
     }
 
+    /// Register the private directory used for bounded, Rust-owned thread
+    /// mode persistence. Call once at process startup before hydrating threads.
+    pub fn set_thread_mode_persistence_directory(&self, directory: String) {
+        self.inner
+            .app_store
+            .configure_thread_mode_persistence(&directory);
+    }
+
     pub async fn snapshot(&self) -> Result<AppSnapshotRecord, ClientError> {
         AppSnapshotRecord::try_from(self.inner.app_snapshot()).map_err(ClientError::Serialization)
     }

--- a/shared/rust-bridge/codex-mobile-client/src/store/mod.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/store/mod.rs
@@ -4,6 +4,7 @@ pub mod boundary;
 pub mod reconcile;
 pub mod reducer;
 pub mod snapshot;
+mod thread_modes;
 pub mod updates;
 mod voice;
 

--- a/shared/rust-bridge/codex-mobile-client/src/store/reducer.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/store/reducer.rs
@@ -44,6 +44,7 @@ use super::snapshot::{
     QueuedFollowUpDraft, ServerHealthSnapshot, ServerMutatingCommandKind, ServerSnapshot,
     ServerTransportDiagnostics, TerminalSessionSnapshot, ThreadSnapshot,
 };
+use super::thread_modes::ThreadModeStore;
 use super::updates::{AppStoreUpdateRecord, ThreadStreamingDeltaKind};
 use super::voice::{VoiceDerivedUpdate, VoiceRealtimeState};
 use crate::terminal::TerminalBackendKind;
@@ -97,6 +98,7 @@ fn dedupe_agent_runtimes(runtimes: Vec<AgentRuntimeInfo>) -> Vec<AgentRuntimeInf
 
 pub struct AppStoreReducer {
     snapshot: RwLock<AppSnapshot>,
+    thread_modes: ThreadModeStore,
     last_thread_state_updates: RwLock<
         HashMap<
             ThreadKey,
@@ -145,6 +147,7 @@ impl AppStoreReducer {
         let (updates_tx, _) = broadcast::channel(1024);
         Self {
             snapshot: RwLock::new(AppSnapshot::default()),
+            thread_modes: ThreadModeStore::default(),
             last_thread_state_updates: RwLock::new(HashMap::new()),
             last_thread_item_upserts: RwLock::new(HashMap::new()),
             dynamic_tool_arg_buffers: RwLock::new(HashMap::new()),
@@ -171,6 +174,12 @@ impl AppStoreReducer {
 
     pub fn subscribe(&self) -> broadcast::Receiver<AppStoreUpdateRecord> {
         self.updates_tx.subscribe()
+    }
+
+    /// Configure bounded local persistence before the first thread hydrate.
+    /// Platforms pass their private mobile-preferences directory at startup.
+    pub fn configure_thread_mode_persistence(&self, directory: &str) {
+        self.thread_modes.configure(directory);
     }
 
     pub fn upsert_server(&self, config: &ServerConfig, health: ServerHealthSnapshot) {
@@ -374,6 +383,9 @@ impl AppStoreReducer {
                 } else {
                     let mut thread = ThreadSnapshot::from_info(server_id, info.clone());
                     thread.agent_runtime_kind = runtime_kind.clone();
+                    if let Some(mode) = self.thread_modes.mode_for(&key) {
+                        thread.collaboration_mode = mode;
+                    }
                     snapshot.threads.insert(key.clone(), thread);
                     upserted_thread_keys.push(key);
                 }
@@ -584,6 +596,7 @@ impl AppStoreReducer {
 
     pub fn upsert_thread_snapshot(&self, mut thread: ThreadSnapshot) {
         let key = thread.key.clone();
+        let persisted_mode = self.thread_modes.mode_for(&key);
         {
             let mut snapshot = self.snapshot.write().expect("app store lock poisoned");
             let existing = snapshot.threads.get(&key).cloned();
@@ -644,6 +657,10 @@ impl AppStoreReducer {
                     thread.items = existing.items.clone();
                 }
             }
+            if let Some(mode) = persisted_mode {
+                thread.collaboration_mode = mode;
+            }
+            restore_plan_implementation_prompt_from_history(&mut thread, existing.as_ref());
             if !thread.queued_follow_up_drafts.is_empty() || thread.queued_follow_ups.is_empty() {
                 sync_thread_follow_up_projection(&mut thread);
             }
@@ -876,6 +893,7 @@ impl AppStoreReducer {
     }
 
     pub fn set_thread_collaboration_mode(&self, key: &ThreadKey, mode: AppModeKind) {
+        self.thread_modes.set_mode(key, mode);
         if self
             .mutate_thread_with_result(key, |thread| {
                 if thread.collaboration_mode == mode {
@@ -1677,17 +1695,20 @@ impl AppStoreReducer {
                 if matches!(
                     notification.item,
                     codex_app_server_protocol::ThreadItem::Plan { .. }
-                ) && self
-                    .mutate_thread_with_result(key, |thread| {
-                        if thread.collaboration_mode != AppModeKind::Plan {
-                            thread.collaboration_mode = AppModeKind::Plan;
-                            return true;
-                        }
-                        false
-                    })
-                    .unwrap_or(false)
-                {
-                    self.emit_thread_metadata_changed(key);
+                ) {
+                    self.thread_modes.set_mode(key, AppModeKind::Plan);
+                    if self
+                        .mutate_thread_with_result(key, |thread| {
+                            if thread.collaboration_mode != AppModeKind::Plan {
+                                thread.collaboration_mode = AppModeKind::Plan;
+                                return true;
+                            }
+                            false
+                        })
+                        .unwrap_or(false)
+                    {
+                        self.emit_thread_metadata_changed(key);
+                    }
                 }
             }
             UiEvent::MessageDelta {
@@ -2227,13 +2248,17 @@ impl AppStoreReducer {
     where
         F: FnOnce(&mut ThreadSnapshot),
     {
+        let persisted_mode = self.thread_modes.mode_for(&key);
         let inserted = {
             let mut snapshot = self.snapshot.write().expect("app store lock poisoned");
             let inserted = !snapshot.threads.contains_key(&key);
-            let thread = snapshot
-                .threads
-                .entry(key.clone())
-                .or_insert_with(|| ThreadSnapshot::from_info(&key.server_id, info.clone()));
+            let thread = snapshot.threads.entry(key.clone()).or_insert_with(|| {
+                let mut thread = ThreadSnapshot::from_info(&key.server_id, info.clone());
+                if let Some(mode) = persisted_mode {
+                    thread.collaboration_mode = mode;
+                }
+                thread
+            });
             thread.info.id = info.id;
             if info.title.is_some() {
                 thread.info.title = info.title;
@@ -3431,6 +3456,55 @@ fn preserve_thread_runtime_state(source: &ThreadSnapshot, target: &mut ThreadSna
     }
 }
 
+fn restore_plan_implementation_prompt_from_history(
+    target: &mut ThreadSnapshot,
+    existing: Option<&ThreadSnapshot>,
+) {
+    if target.collaboration_mode != AppModeKind::Plan
+        || target.active_turn_id.is_some()
+        || target.pending_plan_implementation_turn_id.is_some()
+    {
+        return;
+    }
+
+    let Some((plan_index, plan_turn_id)) = latest_proposed_plan_turn(&target.items) else {
+        return;
+    };
+    // A refresh must not resurrect a prompt the user dismissed during this
+    // process lifetime. A cold restart has no existing snapshot, so the
+    // durable Plan mode plus hydrated history can reconstruct it once.
+    if existing.is_some_and(|thread| {
+        latest_proposed_plan_turn(&thread.items).is_some_and(|(_, existing_turn_id)| {
+            existing_turn_id == plan_turn_id && thread.pending_plan_implementation_turn_id.is_none()
+        })
+    }) {
+        return;
+    }
+    if target.items.iter().skip(plan_index + 1).any(|item| {
+        item.is_from_user_turn_boundary
+            || matches!(&item.content, HydratedConversationItemContent::User(_))
+    }) {
+        return;
+    }
+
+    target.pending_plan_implementation_turn_id = Some(plan_turn_id);
+}
+
+fn latest_proposed_plan_turn(items: &[HydratedConversationItem]) -> Option<(usize, String)> {
+    items.iter().enumerate().rev().find_map(|(index, item)| {
+        if matches!(
+            &item.content,
+            HydratedConversationItemContent::ProposedPlan(_)
+        ) {
+            item.source_turn_id
+                .as_ref()
+                .map(|turn_id| (index, turn_id.clone()))
+        } else {
+            None
+        }
+    })
+}
+
 fn preserve_thread_title(existing: &ThreadInfo, incoming: &mut ThreadInfo) {
     let incoming_blank = incoming
         .title
@@ -3640,6 +3714,7 @@ mod tests {
         McpToolCallProgressNotification, ModelRerouteReason, ModelReroutedNotification,
         TurnDiffUpdatedNotification, TurnPlanStep, TurnPlanStepStatus, TurnPlanUpdatedNotification,
     };
+    use tempfile::tempdir;
     use tokio::sync::broadcast::error::TryRecvError;
 
     fn make_thread_info(id: &str) -> ThreadInfo {
@@ -3659,6 +3734,33 @@ mod tests {
             agent_status: None,
             created_at: None,
             updated_at: None,
+        }
+    }
+
+    fn proposed_plan_item(item_id: &str, turn_id: &str) -> HydratedConversationItem {
+        HydratedConversationItem {
+            id: item_id.to_string(),
+            content: HydratedConversationItemContent::ProposedPlan(HydratedProposedPlanData {
+                content: "Implementation plan".to_string(),
+            }),
+            source_turn_id: Some(turn_id.to_string()),
+            source_turn_index: None,
+            timestamp: None,
+            is_from_user_turn_boundary: false,
+        }
+    }
+
+    fn hydrated_user_item(item_id: &str, turn_id: &str) -> HydratedConversationItem {
+        HydratedConversationItem {
+            id: item_id.to_string(),
+            content: HydratedConversationItemContent::User(HydratedUserMessageData {
+                text: "Continue".to_string(),
+                image_data_uris: Vec::new(),
+            }),
+            source_turn_id: Some(turn_id.to_string()),
+            source_turn_index: None,
+            timestamp: None,
+            is_from_user_turn_boundary: true,
         }
     }
 
@@ -3686,6 +3788,172 @@ mod tests {
             is_local: false,
             tls: false,
         }
+    }
+
+    #[test]
+    fn persisted_plan_mode_restores_after_reducer_restart() {
+        let directory = tempdir().expect("tempdir");
+        let directory = directory.path().to_string_lossy();
+        let key = ThreadKey {
+            server_id: "srv".to_string(),
+            thread_id: "thread".to_string(),
+        };
+
+        let first = AppStoreReducer::new();
+        first.configure_thread_mode_persistence(&directory);
+        first.upsert_thread_snapshot(ThreadSnapshot::from_info(
+            &key.server_id,
+            make_thread_info(&key.thread_id),
+        ));
+        first.set_thread_collaboration_mode(&key, AppModeKind::Plan);
+        drop(first);
+
+        let restarted = AppStoreReducer::new();
+        restarted.configure_thread_mode_persistence(&directory);
+        restarted.upsert_thread_snapshot(ThreadSnapshot::from_info(
+            &key.server_id,
+            make_thread_info(&key.thread_id),
+        ));
+
+        assert_eq!(
+            restarted
+                .thread_snapshot(&key)
+                .expect("thread")
+                .collaboration_mode,
+            AppModeKind::Plan
+        );
+    }
+
+    #[test]
+    fn cold_hydration_restores_implement_prompt_for_persisted_plan() {
+        let directory = tempdir().expect("tempdir");
+        let directory = directory.path().to_string_lossy();
+        let key = ThreadKey {
+            server_id: "srv".to_string(),
+            thread_id: "thread".to_string(),
+        };
+
+        let first = AppStoreReducer::new();
+        first.configure_thread_mode_persistence(&directory);
+        first.set_thread_collaboration_mode(&key, AppModeKind::Plan);
+        drop(first);
+
+        let restarted = AppStoreReducer::new();
+        restarted.configure_thread_mode_persistence(&directory);
+        let mut hydrated =
+            ThreadSnapshot::from_info(&key.server_id, make_thread_info(&key.thread_id));
+        hydrated.items.push(proposed_plan_item("plan", "turn-plan"));
+        restarted.upsert_thread_snapshot(hydrated);
+
+        let thread = restarted.thread_snapshot(&key).expect("thread");
+        assert_eq!(thread.collaboration_mode, AppModeKind::Plan);
+        assert_eq!(
+            thread.pending_plan_implementation_turn_id.as_deref(),
+            Some("turn-plan")
+        );
+    }
+
+    #[test]
+    fn refreshed_hydration_does_not_restore_dismissed_plan_prompt() {
+        let directory = tempdir().expect("tempdir");
+        let directory = directory.path().to_string_lossy();
+        let key = ThreadKey {
+            server_id: "srv".to_string(),
+            thread_id: "thread".to_string(),
+        };
+        let reducer = AppStoreReducer::new();
+        reducer.configure_thread_mode_persistence(&directory);
+        reducer.set_thread_collaboration_mode(&key, AppModeKind::Plan);
+        let mut hydrated =
+            ThreadSnapshot::from_info(&key.server_id, make_thread_info(&key.thread_id));
+        hydrated.items.push(proposed_plan_item("plan", "turn-plan"));
+        reducer.upsert_thread_snapshot(hydrated.clone());
+        reducer.dismiss_plan_implementation_prompt(&key);
+
+        reducer.upsert_thread_snapshot(hydrated);
+
+        assert_eq!(
+            reducer
+                .thread_snapshot(&key)
+                .expect("thread")
+                .pending_plan_implementation_turn_id,
+            None
+        );
+    }
+
+    #[test]
+    fn cold_hydration_does_not_restore_prompt_after_later_user_turn() {
+        let directory = tempdir().expect("tempdir");
+        let directory = directory.path().to_string_lossy();
+        let key = ThreadKey {
+            server_id: "srv".to_string(),
+            thread_id: "thread".to_string(),
+        };
+        let first = AppStoreReducer::new();
+        first.configure_thread_mode_persistence(&directory);
+        first.set_thread_collaboration_mode(&key, AppModeKind::Plan);
+        drop(first);
+
+        let restarted = AppStoreReducer::new();
+        restarted.configure_thread_mode_persistence(&directory);
+        let mut hydrated =
+            ThreadSnapshot::from_info(&key.server_id, make_thread_info(&key.thread_id));
+        hydrated.items.push(proposed_plan_item("plan", "turn-plan"));
+        hydrated.items.push(hydrated_user_item("user", "turn-user"));
+        restarted.upsert_thread_snapshot(hydrated);
+
+        assert_eq!(
+            restarted
+                .thread_snapshot(&key)
+                .expect("thread")
+                .pending_plan_implementation_turn_id,
+            None
+        );
+    }
+
+    #[test]
+    fn completed_plan_item_persists_auto_detected_mode() {
+        let directory = tempdir().expect("tempdir");
+        let directory = directory.path().to_string_lossy();
+        let key = ThreadKey {
+            server_id: "srv".to_string(),
+            thread_id: "thread".to_string(),
+        };
+        let reducer = AppStoreReducer::new();
+        reducer.configure_thread_mode_persistence(&directory);
+        reducer.upsert_thread_snapshot(ThreadSnapshot::from_info(
+            &key.server_id,
+            make_thread_info(&key.thread_id),
+        ));
+
+        reducer.apply_ui_event(&UiEvent::ItemCompleted {
+            key: key.clone(),
+            notification: upstream::ItemCompletedNotification {
+                item: upstream::ThreadItem::Plan {
+                    id: "plan".to_string(),
+                    text: "Implementation plan".to_string(),
+                },
+                thread_id: key.thread_id.clone(),
+                turn_id: "turn-plan".to_string(),
+                completed_at_ms: 0,
+            },
+        });
+        drop(reducer);
+
+        let restarted = AppStoreReducer::new();
+        restarted.configure_thread_mode_persistence(&directory);
+        restarted.upsert_thread_snapshot(ThreadSnapshot::from_info(
+            &key.server_id,
+            make_thread_info(&key.thread_id),
+        ));
+
+        assert_eq!(
+            restarted
+                .thread_snapshot(&key)
+                .expect("thread")
+                .collaboration_mode,
+            AppModeKind::Plan
+        );
     }
 
     #[test]

--- a/shared/rust-bridge/codex-mobile-client/src/store/thread_modes.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/store/thread_modes.rs
@@ -1,0 +1,251 @@
+//! Bounded, mobile-owned persistence for per-thread collaboration modes.
+//!
+//! The pinned app-server protocol does not expose collaboration mode on
+//! `thread/list`, `thread/read`, `thread/resume`, or lifecycle notifications.
+//! Until it does, mobile cannot authoritatively recover that state after a
+//! process restart. This store persists only non-default modes, keyed by the
+//! existing mobile [`ThreadKey`], and caps stale entries so it cannot grow
+//! without bound.
+//!
+//! This fallback cannot observe mode changes made by another client and will
+//! miss if a server is later registered under a different `server_id`. An
+//! upstream thread metadata field should supersede this local value once one
+//! is available.
+
+use std::collections::HashSet;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::{AppModeKind, ThreadKey};
+
+const THREAD_MODES_FILE: &str = "thread_modes.json";
+const CURRENT_VERSION: u32 = 1;
+const MAX_PERSISTED_THREAD_MODES: usize = 512;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PersistedThreadMode {
+    server_id: String,
+    thread_id: String,
+    mode: AppModeKind,
+}
+
+impl PersistedThreadMode {
+    fn key(&self) -> ThreadKey {
+        ThreadKey {
+            server_id: self.server_id.clone(),
+            thread_id: self.thread_id.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PersistedThreadModes {
+    #[serde(default)]
+    version: u32,
+    #[serde(default)]
+    modes: Vec<PersistedThreadMode>,
+}
+
+#[derive(Default)]
+struct ThreadModeState {
+    path: Option<PathBuf>,
+    modes: Vec<PersistedThreadMode>,
+}
+
+#[derive(Default)]
+pub(super) struct ThreadModeStore {
+    state: Mutex<ThreadModeState>,
+}
+
+impl ThreadModeStore {
+    pub(super) fn configure(&self, directory: &str) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let trimmed = directory.trim();
+        if trimmed.is_empty() {
+            *state = ThreadModeState::default();
+            return;
+        }
+
+        let path = PathBuf::from(trimmed).join(THREAD_MODES_FILE);
+        let mut modes = read_thread_modes(&path).modes;
+        normalize_modes(&mut modes);
+        *state = ThreadModeState {
+            path: Some(path),
+            modes,
+        };
+    }
+
+    pub(super) fn mode_for(&self, key: &ThreadKey) -> Option<AppModeKind> {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state
+            .modes
+            .iter()
+            .rev()
+            .find(|entry| entry.server_id == key.server_id && entry.thread_id == key.thread_id)
+            .map(|entry| entry.mode)
+    }
+
+    pub(super) fn set_mode(&self, key: &ThreadKey, mode: AppModeKind) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let Some(path) = state.path.clone() else {
+            return;
+        };
+
+        state
+            .modes
+            .retain(|entry| entry.server_id != key.server_id || entry.thread_id != key.thread_id);
+        if mode != AppModeKind::Default {
+            state.modes.push(PersistedThreadMode {
+                server_id: key.server_id.clone(),
+                thread_id: key.thread_id.clone(),
+                mode,
+            });
+        }
+        trim_to_capacity(&mut state.modes);
+
+        write_thread_modes(&path, &PersistedThreadModes {
+            version: CURRENT_VERSION,
+            modes: state.modes.clone(),
+        });
+    }
+}
+
+fn normalize_modes(modes: &mut Vec<PersistedThreadMode>) {
+    modes.retain(|entry| entry.mode != AppModeKind::Default);
+    let mut seen = HashSet::new();
+    modes.reverse();
+    modes.retain(|entry| seen.insert(entry.key()));
+    modes.reverse();
+    trim_to_capacity(modes);
+}
+
+fn trim_to_capacity(modes: &mut Vec<PersistedThreadMode>) {
+    if modes.len() > MAX_PERSISTED_THREAD_MODES {
+        modes.drain(..modes.len() - MAX_PERSISTED_THREAD_MODES);
+    }
+}
+
+fn read_thread_modes(path: &Path) -> PersistedThreadModes {
+    let bytes = match fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(_) => return PersistedThreadModes::default(),
+    };
+    serde_json::from_slice(&bytes).unwrap_or_default()
+}
+
+fn write_thread_modes(path: &Path, value: &PersistedThreadModes) {
+    let Some(parent) = path.parent() else { return };
+    if let Err(error) = fs::create_dir_all(parent) {
+        tracing::warn!(error = %error, "thread_modes: create dir failed");
+        return;
+    }
+
+    let json = match serde_json::to_vec_pretty(value) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            tracing::warn!(error = %error, "thread_modes: serialize failed");
+            return;
+        }
+    };
+    let temporary_path = path.with_extension("json.tmp");
+    match fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&temporary_path)
+    {
+        Ok(mut file) => {
+            if let Err(error) = file.write_all(&json) {
+                tracing::warn!(error = %error, "thread_modes: write failed");
+                let _ = fs::remove_file(&temporary_path);
+                return;
+            }
+            let _ = file.sync_all();
+        }
+        Err(error) => {
+            tracing::warn!(error = %error, "thread_modes: open temp file failed");
+            return;
+        }
+    }
+    if let Err(error) = fs::rename(&temporary_path, path) {
+        tracing::warn!(error = %error, "thread_modes: rename failed");
+        let _ = fs::remove_file(&temporary_path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn key(index: usize) -> ThreadKey {
+        ThreadKey {
+            server_id: "server".to_string(),
+            thread_id: format!("thread-{index}"),
+        }
+    }
+
+    #[test]
+    fn plan_mode_round_trips_across_store_instances() {
+        let directory = tempdir().expect("tempdir");
+        let directory = directory.path().to_string_lossy();
+        let first = ThreadModeStore::default();
+        first.configure(&directory);
+        first.set_mode(&key(1), AppModeKind::Plan);
+
+        let restarted = ThreadModeStore::default();
+        restarted.configure(&directory);
+
+        assert_eq!(restarted.mode_for(&key(1)), Some(AppModeKind::Plan));
+    }
+
+    #[test]
+    fn default_mode_removes_persisted_entry() {
+        let directory = tempdir().expect("tempdir");
+        let directory = directory.path().to_string_lossy();
+        let first = ThreadModeStore::default();
+        first.configure(&directory);
+        first.set_mode(&key(1), AppModeKind::Plan);
+        first.set_mode(&key(1), AppModeKind::Default);
+
+        let restarted = ThreadModeStore::default();
+        restarted.configure(&directory);
+
+        assert_eq!(restarted.mode_for(&key(1)), None);
+    }
+
+    #[test]
+    fn persisted_modes_are_bounded_to_recent_entries() {
+        let directory = tempdir().expect("tempdir");
+        let directory = directory.path().to_string_lossy();
+        let store = ThreadModeStore::default();
+        store.configure(&directory);
+        for index in 0..=MAX_PERSISTED_THREAD_MODES {
+            store.set_mode(&key(index), AppModeKind::Plan);
+        }
+
+        let restarted = ThreadModeStore::default();
+        restarted.configure(&directory);
+
+        assert_eq!(restarted.mode_for(&key(0)), None);
+        assert_eq!(
+            restarted.mode_for(&key(MAX_PERSISTED_THREAD_MODES)),
+            Some(AppModeKind::Plan)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- persist non-default per-thread collaboration mode in a bounded, Rust-owned `thread_modes.json`
- restore persisted mode through the canonical reducer on list, lifecycle, and hydrated snapshots
- reconstruct the Implement Plan affordance on cold hydration only when the latest proposed plan has no later user turn
- register each platform's existing private mobile-preferences directory through one generated `AppStore` method
- retain explicit Default cleanup and avoid resurrecting a prompt dismissed during the current process

## Root cause

The pinned app-server protocol's authoritative `Thread` data returned by list/read/resume does not expose collaboration mode. `ThreadSnapshot::from_info` therefore rebuilt every process-cold thread in Default mode, while live Plan-item handling only changed reducer memory. Process death lost both that mode and the transient implement-plan prompt.

## Validation

- `cargo test --manifest-path shared/rust-bridge/Cargo.toml -p codex-mobile-client --lib` — 790 passed, 5 ignored
- generated Swift and Kotlin UniFFI bindings; confirmed `setThreadModePersistenceDirectory` on both surfaces
- Android `:app:compileDebugKotlin :app:testDebugUnitTest` — BUILD SUCCESSFUL
- iOS `make ios-sim-fast` — BUILD SUCCEEDED
- post-rebase incremental iOS simulator `xcodebuild ... build` — BUILD SUCCEEDED
- `git diff --check origin/main...HEAD` — passed

Focused tests cover Default removing the durable entry, restart restoration, Plan-item auto-detection persistence, cold implement-prompt reconstruction, dismissed-prompt preservation on ordinary refresh, later-user-turn suppression, and the 512-entry storage bound.

## Known acceptance gap

This remains a bounded mobile fallback because upstream cannot round-trip collaboration mode today. It cannot observe a mode change made by another client, and a thread will not match its local entry if the same server is later registered under a different `server_id`. An authoritative upstream thread field should supersede the local fallback when available.

This PR stays draft until an installed iOS/Android app is killed and relaunched against a live Plan-mode thread to confirm the full cold-relaunch UX.

Closes #100
