### PR TITLE
ci: fail fast on mobile release access

### DIFF
--- a/.github/workflows/android-play-release.yml
+++ b/.github/workflows/android-play-release.yml
@@ -49,57 +49,25 @@ jobs:
     environment: release
 
     steps:
-      - name: Validate required secrets
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Verify Google Play release access
         env:
           ANDROID_UPLOAD_KEYSTORE_B64: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_B64 }}
           LITTER_UPLOAD_STORE_PASSWORD: ${{ secrets.LITTER_UPLOAD_STORE_PASSWORD }}
           LITTER_UPLOAD_KEY_ALIAS: ${{ secrets.LITTER_UPLOAD_KEY_ALIAS }}
           LITTER_UPLOAD_KEY_PASSWORD: ${{ secrets.LITTER_UPLOAD_KEY_PASSWORD }}
           LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64: ${{ secrets.LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64 }}
-          GOOGLE_SERVICES_JSON_B64: ${{ secrets.GOOGLE_SERVICES_JSON_B64 }}
-        run: |
-          set -euo pipefail
-          required=(
-            ANDROID_UPLOAD_KEYSTORE_B64
-            LITTER_UPLOAD_STORE_PASSWORD
-            LITTER_UPLOAD_KEY_ALIAS
-            LITTER_UPLOAD_KEY_PASSWORD
-            LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64
-          )
-          for name in "${required[@]}"; do
-            if [[ -z "${!name:-}" ]]; then
-              echo "Missing required secret: $name" >&2
-              exit 1
-            fi
-          done
-
-          encoded=(
-            ANDROID_UPLOAD_KEYSTORE_B64
-          )
-          if [[ -n "${GOOGLE_SERVICES_JSON_B64:-}" ]]; then
-            encoded+=(GOOGLE_SERVICES_JSON_B64)
-          fi
-          for name in "${encoded[@]}"; do
-            if ! printf '%s' "${!name}" | base64 --decode >/dev/null; then
-              echo "Secret is not valid base64: $name" >&2
-              exit 1
-            fi
-          done
-
-          validate_json_secret() {
-            local name="$1"
-            local value="${!name}"
-            if printf '%s' "$value" | base64 --decode 2>/dev/null | jq -e . >/dev/null 2>&1; then
-              return 0
-            fi
-            if printf '%s' "$value" | jq -e . >/dev/null 2>&1; then
-              echo "::notice::$name is stored as raw JSON; accepting it for compatibility"
-              return 0
-            fi
-            echo "Secret is neither base64-encoded JSON nor raw JSON: $name" >&2
-            return 1
-          }
-          validate_json_secret LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64
+        run: ./tools/scripts/check-google-play-release.sh
 
   shared-prep:
     needs: release-preflight
@@ -283,9 +251,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Setup Google Cloud CLI
-        uses: google-github-actions/setup-gcloud@v3
-
       - name: Decode release credentials
         env:
           ANDROID_UPLOAD_KEYSTORE_B64: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_B64 }}
@@ -309,17 +274,6 @@ jobs:
           echo "LITTER_UPLOAD_STORE_FILE=$store_file" >> "$GITHUB_ENV"
           echo "LITTER_PLAY_SERVICE_ACCOUNT_JSON=$service_account_json" >> "$GITHUB_ENV"
           ls -lh "$store_file" "$service_account_json" apps/android/app/google-services.json 2>/dev/null || ls -lh "$store_file" "$service_account_json"
-
-      - name: Enable Google Play Android Developer API
-        run: |
-          set -euo pipefail
-          project_id="$(jq -r '.project_id // empty' "$LITTER_PLAY_SERVICE_ACCOUNT_JSON")"
-          if [[ -z "$project_id" ]]; then
-            echo "Play service account JSON does not contain project_id" >&2
-            exit 1
-          fi
-          gcloud auth activate-service-account --key-file="$LITTER_PLAY_SERVICE_ACCOUNT_JSON" --quiet
-          gcloud services enable androidpublisher.googleapis.com --project="$project_id" --quiet
 
       - name: Resolve Android release inputs
         env:

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -18,7 +18,37 @@ permissions:
   contents: write
 
 jobs:
+  release-preflight:
+    runs-on: macos-26
+    timeout-minutes: 10
+    environment: release
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install App Store Connect CLI
+        run: HOMEBREW_NO_AUTO_UPDATE=0 brew install asc
+
+      - name: Verify App Store Connect release access
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY_P8_B64: ${{ secrets.ASC_PRIVATE_KEY_P8_B64 }}
+          IOS_APP_STORE_APP_ID: ${{ secrets.IOS_APP_STORE_APP_ID }}
+          IOS_TEAM_ID: ${{ secrets.IOS_TEAM_ID }}
+          IOS_DIST_CERT_P12_B64: ${{ secrets.IOS_DIST_CERT_P12_B64 }}
+          IOS_DIST_CERT_PASSWORD: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
+          IOS_APP_STORE_PROFILE_B64: ${{ secrets.IOS_APP_STORE_PROFILE_B64 }}
+          IOS_LIVE_ACTIVITY_APP_STORE_PROFILE_B64: ${{ secrets.IOS_LIVE_ACTIVITY_APP_STORE_PROFILE_B64 }}
+        run: ./tools/scripts/check-app-store-release.sh
+
   prepare-release-assets:
+    needs: release-preflight
     runs-on: macos-26
     timeout-minutes: 90
     env:
@@ -126,35 +156,6 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '26.3'
-
-      - name: Validate required secrets
-        env:
-          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
-          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
-          ASC_PRIVATE_KEY_P8_B64: ${{ secrets.ASC_PRIVATE_KEY_P8_B64 }}
-          IOS_APP_STORE_APP_ID: ${{ secrets.IOS_APP_STORE_APP_ID }}
-          IOS_TEAM_ID: ${{ secrets.IOS_TEAM_ID }}
-          IOS_DIST_CERT_P12_B64: ${{ secrets.IOS_DIST_CERT_P12_B64 }}
-          IOS_DIST_CERT_PASSWORD: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
-          IOS_APP_STORE_PROFILE_B64: ${{ secrets.IOS_APP_STORE_PROFILE_B64 }}
-        run: |
-          set -euo pipefail
-          required=(
-            ASC_KEY_ID
-            ASC_ISSUER_ID
-            ASC_PRIVATE_KEY_P8_B64
-            IOS_APP_STORE_APP_ID
-            IOS_TEAM_ID
-            IOS_DIST_CERT_P12_B64
-            IOS_DIST_CERT_PASSWORD
-            IOS_APP_STORE_PROFILE_B64
-          )
-          for name in "${required[@]}"; do
-            if [[ -z "${!name:-}" ]]; then
-              echo "Missing required secret: $name" >&2
-              exit 1
-            fi
-          done
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -19,6 +19,9 @@ on:
       - patches/ghostty/**
       - tools/scripts/build-android-rust.sh
       - tools/scripts/build-ghostty-android.sh
+      - tools/scripts/check-app-store-release.sh
+      - tools/scripts/check-google-play-release.sh
+      - tools/scripts/fetch-mobile-store-artifacts.py
 
 permissions:
   contents: write
@@ -63,6 +66,8 @@ jobs:
               - 'patches/ghostty/**'
               - 'tools/scripts/build-android-rust.sh'
               - 'tools/scripts/build-ghostty-android.sh'
+              - 'tools/scripts/check-google-play-release.sh'
+              - 'tools/scripts/fetch-mobile-store-artifacts.py'
             release_ios:
               - 'Makefile'
               - '.github/workflows/mobile-release.yml'
@@ -81,6 +86,7 @@ jobs:
               - 'apps/ios/scripts/sync-codex.sh'
               - 'apps/ios/scripts/sync-ghostty.sh'
               - 'apps/ios/scripts/testflight-upload.sh'
+              - 'tools/scripts/check-app-store-release.sh'
               - 'docs/releases/testflight-whats-new.md'
               - 'shared/rust-bridge/**'
               - 'shared/third_party/codex'
@@ -155,8 +161,61 @@ jobs:
             echo "run_release=false" >> "$GITHUB_OUTPUT"
           fi
 
-  shared-prep:
+  release-preflight:
     needs: detect-release-changes
+    if: needs.detect-release-changes.outputs.run_release == 'true'
+    runs-on: macos-26
+    timeout-minutes: 10
+    environment: release
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Java
+        if: needs.detect-release-changes.outputs.release_android == 'true'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Verify Google Play release access
+        if: needs.detect-release-changes.outputs.release_android == 'true'
+        env:
+          ANDROID_UPLOAD_KEYSTORE_B64: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_B64 }}
+          LITTER_UPLOAD_STORE_PASSWORD: ${{ secrets.LITTER_UPLOAD_STORE_PASSWORD }}
+          LITTER_UPLOAD_KEY_ALIAS: ${{ secrets.LITTER_UPLOAD_KEY_ALIAS }}
+          LITTER_UPLOAD_KEY_PASSWORD: ${{ secrets.LITTER_UPLOAD_KEY_PASSWORD }}
+          LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64: ${{ secrets.LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64 }}
+        run: ./tools/scripts/check-google-play-release.sh
+
+      - name: Install App Store Connect CLI
+        if: needs.detect-release-changes.outputs.release_ios == 'true'
+        run: HOMEBREW_NO_AUTO_UPDATE=0 brew install asc
+
+      - name: Verify App Store Connect release access
+        if: needs.detect-release-changes.outputs.release_ios == 'true'
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY_P8_B64: ${{ secrets.ASC_PRIVATE_KEY_P8_B64 }}
+          IOS_APP_STORE_APP_ID: ${{ secrets.IOS_APP_STORE_APP_ID }}
+          IOS_TEAM_ID: ${{ secrets.IOS_TEAM_ID }}
+          IOS_DIST_CERT_P12_B64: ${{ secrets.IOS_DIST_CERT_P12_B64 }}
+          IOS_DIST_CERT_PASSWORD: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
+          IOS_APP_STORE_PROFILE_B64: ${{ secrets.IOS_APP_STORE_PROFILE_B64 }}
+          IOS_LIVE_ACTIVITY_APP_STORE_PROFILE_B64: ${{ secrets.IOS_LIVE_ACTIVITY_APP_STORE_PROFILE_B64 }}
+          IOS_WATCH_APP_STORE_PROFILE_B64: ${{ secrets.IOS_WATCH_APP_STORE_PROFILE_B64 }}
+          IOS_WATCH_COMPLICATIONS_APP_STORE_PROFILE_B64: ${{ secrets.IOS_WATCH_COMPLICATIONS_APP_STORE_PROFILE_B64 }}
+          REQUIRE_WATCH_PROFILES: "1"
+        run: ./tools/scripts/check-app-store-release.sh
+
+  shared-prep:
+    needs: [detect-release-changes, release-preflight]
     if: needs.detect-release-changes.outputs.run_release == 'true'
     runs-on: macos-26
     timeout-minutes: 60
@@ -312,29 +371,6 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-
-      - name: Validate required secrets
-        env:
-          ANDROID_UPLOAD_KEYSTORE_B64: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_B64 }}
-          LITTER_UPLOAD_STORE_PASSWORD: ${{ secrets.LITTER_UPLOAD_STORE_PASSWORD }}
-          LITTER_UPLOAD_KEY_ALIAS: ${{ secrets.LITTER_UPLOAD_KEY_ALIAS }}
-          LITTER_UPLOAD_KEY_PASSWORD: ${{ secrets.LITTER_UPLOAD_KEY_PASSWORD }}
-          LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64: ${{ secrets.LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64 }}
-        run: |
-          set -euo pipefail
-          required=(
-            ANDROID_UPLOAD_KEYSTORE_B64
-            LITTER_UPLOAD_STORE_PASSWORD
-            LITTER_UPLOAD_KEY_ALIAS
-            LITTER_UPLOAD_KEY_PASSWORD
-            LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64
-          )
-          for name in "${required[@]}"; do
-            if [[ -z "${!name:-}" ]]; then
-              echo "Missing required secret: $name" >&2
-              exit 1
-            fi
-          done
 
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -693,41 +729,6 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '26.3'
-
-      - name: Validate required secrets
-        env:
-          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
-          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
-          ASC_PRIVATE_KEY_P8_B64: ${{ secrets.ASC_PRIVATE_KEY_P8_B64 }}
-          IOS_APP_STORE_APP_ID: ${{ secrets.IOS_APP_STORE_APP_ID }}
-          IOS_TEAM_ID: ${{ secrets.IOS_TEAM_ID }}
-          IOS_DIST_CERT_P12_B64: ${{ secrets.IOS_DIST_CERT_P12_B64 }}
-          IOS_DIST_CERT_PASSWORD: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
-          IOS_APP_STORE_PROFILE_B64: ${{ secrets.IOS_APP_STORE_PROFILE_B64 }}
-          IOS_LIVE_ACTIVITY_APP_STORE_PROFILE_B64: ${{ secrets.IOS_LIVE_ACTIVITY_APP_STORE_PROFILE_B64 }}
-          IOS_WATCH_APP_STORE_PROFILE_B64: ${{ secrets.IOS_WATCH_APP_STORE_PROFILE_B64 }}
-          IOS_WATCH_COMPLICATIONS_APP_STORE_PROFILE_B64: ${{ secrets.IOS_WATCH_COMPLICATIONS_APP_STORE_PROFILE_B64 }}
-        run: |
-          set -euo pipefail
-          required=(
-            ASC_KEY_ID
-            ASC_ISSUER_ID
-            ASC_PRIVATE_KEY_P8_B64
-            IOS_APP_STORE_APP_ID
-            IOS_TEAM_ID
-            IOS_DIST_CERT_P12_B64
-            IOS_DIST_CERT_PASSWORD
-            IOS_APP_STORE_PROFILE_B64
-            IOS_LIVE_ACTIVITY_APP_STORE_PROFILE_B64
-            IOS_WATCH_APP_STORE_PROFILE_B64
-            IOS_WATCH_COMPLICATIONS_APP_STORE_PROFILE_B64
-          )
-          for name in "${required[@]}"; do
-            if [[ -z "${!name:-}" ]]; then
-              echo "Missing required secret: $name" >&2
-              exit 1
-            fi
-          done
 
       - name: Install build dependencies
         run: |

--- a/docs/releases/android-play-internal-checklist.md
+++ b/docs/releases/android-play-internal-checklist.md
@@ -26,9 +26,10 @@ the login Keychain, writes a non-secret loader file, and exports the public PEM
 certificate Play Console needs for an upload-key reset. It refuses to overwrite
 existing key material.
 
-The release workflows authenticate to the Publisher API before starting native
-builds. A disabled API, invalid service-account key, or missing Play Console app
-access therefore fails in the release preflight instead of after the AAB build.
+The release workflows authenticate to the Publisher API and create then discard
+an empty edit before starting native builds. A disabled API, invalid
+service-account key, or missing Play Console release access therefore fails in
+the release preflight instead of after the AAB build.
 
 ## Required Environment Variables
 - `LITTER_PLAY_SERVICE_ACCOUNT_JSON` = path to service-account JSON

--- a/docs/releases/android-play-internal-checklist.md
+++ b/docs/releases/android-play-internal-checklist.md
@@ -2,9 +2,15 @@
 
 ## One-time Setup
 1. In Play Console, create app `com.sigkitten.litter.android`.
-2. Create a Service Account in Google Cloud and grant it Play Console access to the app.
-3. Download the service-account JSON key.
-4. Use the existing upload keystore. If it is unavailable, create a replacement
+2. Create a service account in Google Cloud and enable the Google Play Android
+   Developer API (`androidpublisher.googleapis.com`) in that service account's
+   project. API enablement is an owner/admin bootstrap action, not a release-job
+   permission.
+3. In Play Console, grant the service account access to the app with the release
+   permissions required for every destination track.
+4. Download the service-account JSON key and store its base64 form in the
+   `LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64` GitHub Actions secret.
+5. Use the existing upload keystore. If it is unavailable, create a replacement
    upload key and complete the Play Console upload-key reset before uploading.
    Play App Signing keeps the app-signing key with Google; the local key is only
    the upload credential.
@@ -19,6 +25,10 @@ The script keeps the keystore under `~/.config/litter`, stores its passwords in
 the login Keychain, writes a non-secret loader file, and exports the public PEM
 certificate Play Console needs for an upload-key reset. It refuses to overwrite
 existing key material.
+
+The release workflows authenticate to the Publisher API before starting native
+builds. A disabled API, invalid service-account key, or missing Play Console app
+access therefore fails in the release preflight instead of after the AAB build.
 
 ## Required Environment Variables
 - `LITTER_PLAY_SERVICE_ACCOUNT_JSON` = path to service-account JSON

--- a/docs/releases/ios-testflight-checklist.md
+++ b/docs/releases/ios-testflight-checklist.md
@@ -1,5 +1,23 @@
 # iOS TestFlight Checklist
 
+## One-time Setup
+
+1. The Account Holder requests App Store Connect API access under **Users and
+   Access → Integrations → App Store Connect API** and accepts Apple's API-use
+   agreement.
+2. Create a team API key with the app-management access needed for TestFlight,
+   then download its `.p8` file. Apple only offers that download once.
+3. Store the key as GitHub Actions secrets `ASC_KEY_ID`, `ASC_ISSUER_ID`, and
+   `ASC_PRIVATE_KEY_P8_B64`. Keep the `.p8` file outside the repository.
+4. Configure the distribution certificate and every provisioning-profile secret
+   named by `.github/workflows/mobile-release.yml`.
+
+The release preflight parses the private key and makes an authenticated app
+lookup before native compilation. Missing, malformed, expired, or unauthorized
+credentials therefore fail before the expensive iOS build.
+
+## Release Checklist
+
 1. Confirm `apps/ios/project.yml` bundle ID/version/build settings are correct.
 2. Build/archive in Xcode from `apps/ios/Litter.xcodeproj`.
 3. Update `docs/releases/testflight-whats-new.md` with changelog bullets for this build.

--- a/tools/scripts/check-app-store-release.sh
+++ b/tools/scripts/check-app-store-release.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RELEASE_TEMP_DIR="${RUNNER_TEMP:?RUNNER_TEMP is required}"
+REQUIRE_WATCH_PROFILES="${REQUIRE_WATCH_PROFILES:-0}"
+umask 077
+
+required=(
+    ASC_KEY_ID
+    ASC_ISSUER_ID
+    ASC_PRIVATE_KEY_P8_B64
+    IOS_APP_STORE_APP_ID
+    IOS_TEAM_ID
+    IOS_DIST_CERT_P12_B64
+    IOS_DIST_CERT_PASSWORD
+    IOS_APP_STORE_PROFILE_B64
+    IOS_LIVE_ACTIVITY_APP_STORE_PROFILE_B64
+)
+if [[ "$REQUIRE_WATCH_PROFILES" == "1" ]]; then
+    required+=(IOS_WATCH_APP_STORE_PROFILE_B64 IOS_WATCH_COMPLICATIONS_APP_STORE_PROFILE_B64)
+fi
+for name in "${required[@]}"; do
+    if [[ -z "${!name:-}" ]]; then
+        echo "Missing required secret: $name" >&2
+        exit 1
+    fi
+done
+
+key_path="$RELEASE_TEMP_DIR/AuthKey_${ASC_KEY_ID}.p8"
+printf '%s' "$ASC_PRIVATE_KEY_P8_B64" | base64 --decode > "$key_path"
+chmod 600 "$key_path"
+openssl pkey -in "$key_path" -noout
+export ASC_PRIVATE_KEY_PATH="$key_path"
+
+cert_path="$RELEASE_TEMP_DIR/dist-cert.p12"
+app_profile_path="$RELEASE_TEMP_DIR/app-store.mobileprovision"
+activity_profile_path="$RELEASE_TEMP_DIR/live-activity-app-store.mobileprovision"
+printf '%s' "$IOS_DIST_CERT_P12_B64" | base64 --decode > "$cert_path"
+printf '%s' "$IOS_APP_STORE_PROFILE_B64" | base64 --decode > "$app_profile_path"
+printf '%s' "$IOS_LIVE_ACTIVITY_APP_STORE_PROFILE_B64" | base64 --decode > "$activity_profile_path"
+openssl pkcs12 -in "$cert_path" -passin env:IOS_DIST_CERT_PASSWORD -noout
+
+validate_profile() {
+    local profile_path="$1"
+    local bundle_id="$2"
+    local profile_plist="$profile_path.plist"
+    local app_identifier team_identifier
+
+    security cms -D -i "$profile_path" > "$profile_plist"
+    app_identifier="$(plutil -extract Entitlements.application-identifier raw -o - "$profile_plist")"
+    team_identifier="$(plutil -extract TeamIdentifier.0 raw -o - "$profile_plist")"
+    if [[ "$app_identifier" != "$IOS_TEAM_ID.$bundle_id" || "$team_identifier" != "$IOS_TEAM_ID" ]]; then
+        echo "Provisioning profile does not match team $IOS_TEAM_ID and bundle $bundle_id" >&2
+        exit 1
+    fi
+}
+
+validate_profile "$app_profile_path" com.sigkitten.litter
+validate_profile "$activity_profile_path" com.sigkitten.litter.activity
+if [[ "$REQUIRE_WATCH_PROFILES" == "1" ]]; then
+    watch_profile_path="$RELEASE_TEMP_DIR/watch-app-store.mobileprovision"
+    watch_comp_profile_path="$RELEASE_TEMP_DIR/watch-complications-app-store.mobileprovision"
+    printf '%s' "$IOS_WATCH_APP_STORE_PROFILE_B64" | base64 --decode > "$watch_profile_path"
+    printf '%s' "$IOS_WATCH_COMPLICATIONS_APP_STORE_PROFILE_B64" | base64 --decode > "$watch_comp_profile_path"
+    validate_profile "$watch_profile_path" com.sigkitten.litter.watch
+    validate_profile "$watch_comp_profile_path" com.sigkitten.litter.watch.complications
+fi
+
+asc apps list --bundle-id com.sigkitten.litter --output json |
+    python3 -c 'import json, os, sys; data=json.load(sys.stdin).get("data", []); raise SystemExit(not any(app.get("id") == os.environ["IOS_APP_STORE_APP_ID"] for app in data))'

--- a/tools/scripts/check-google-play-release.sh
+++ b/tools/scripts/check-google-play-release.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RELEASE_TEMP_DIR="${RUNNER_TEMP:?RUNNER_TEMP is required}"
+umask 077
+
+required=(
+    ANDROID_UPLOAD_KEYSTORE_B64
+    LITTER_UPLOAD_STORE_PASSWORD
+    LITTER_UPLOAD_KEY_ALIAS
+    LITTER_UPLOAD_KEY_PASSWORD
+    LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64
+)
+for name in "${required[@]}"; do
+    if [[ -z "${!name:-}" ]]; then
+        echo "Missing required secret: $name" >&2
+        exit 1
+    fi
+done
+
+keystore="$RELEASE_TEMP_DIR/litter-upload.jks"
+printf '%s' "$ANDROID_UPLOAD_KEYSTORE_B64" | base64 --decode > "$keystore"
+keytool -list \
+    -keystore "$keystore" \
+    -storepass "$LITTER_UPLOAD_STORE_PASSWORD" \
+    -alias "$LITTER_UPLOAD_KEY_ALIAS" >/dev/null
+keytool -importkeystore \
+    -srckeystore "$keystore" \
+    -srcstorepass "$LITTER_UPLOAD_STORE_PASSWORD" \
+    -srcalias "$LITTER_UPLOAD_KEY_ALIAS" \
+    -srckeypass "$LITTER_UPLOAD_KEY_PASSWORD" \
+    -destkeystore "$RELEASE_TEMP_DIR/upload-key-validation.p12" \
+    -deststoretype PKCS12 \
+    -deststorepass release-preflight-only \
+    -destkeypass release-preflight-only \
+    -noprompt >/dev/null
+
+service_account_json="$RELEASE_TEMP_DIR/play-service-account.json"
+if printf '%s' "$LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64" | base64 --decode 2>/dev/null > "$service_account_json" \
+    && python3 -m json.tool "$service_account_json" >/dev/null 2>&1; then
+    :
+else
+    printf '%s' "$LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64" > "$service_account_json"
+    python3 -m json.tool "$service_account_json" >/dev/null
+fi
+
+python3 "$SCRIPT_DIR/fetch-mobile-store-artifacts.py" \
+    --check-play-access \
+    --play-service-account-json "$service_account_json" \
+    --android-package com.sigkitten.litter.android

--- a/tools/scripts/fetch-mobile-store-artifacts.py
+++ b/tools/scripts/fetch-mobile-store-artifacts.py
@@ -64,6 +64,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--asc-bin", help="Path to the asc CLI.")
     parser.add_argument("--play-service-account-json", help="Path to a Google Play service account JSON.")
     parser.add_argument("--play-env-file", default=str(DEFAULT_PLAY_ENV_FILE))
+    parser.add_argument(
+        "--check-play-access",
+        action="store_true",
+        help="Verify Google Play Publisher API access and exit without fetching artifacts.",
+    )
     parser.add_argument("--skip-ios", action="store_true")
     parser.add_argument("--skip-android", action="store_true")
     parser.add_argument("--no-download-ios-screenshots", action="store_true")
@@ -429,6 +434,16 @@ def api_get_json(url: str, bearer_token: str) -> dict[str, Any]:
         raise ScriptError(f"HTTP {exc.code} for {url}: {body}") from exc
 
 
+def check_play_access(package_name: str, service_account_path: pathlib.Path) -> None:
+    token = issue_token(service_account_path, PLAY_PUBLISHER_SCOPE)
+    query = urllib.parse.urlencode({"maxResults": "1"})
+    api_get_json(
+        f"https://androidpublisher.googleapis.com/androidpublisher/v3/"
+        f"applications/{package_name}/reviews?{query}",
+        token,
+    )
+
+
 def floor_hour(value: dt.datetime) -> dt.datetime:
     return value.astimezone(UTC).replace(minute=0, second=0, microsecond=0)
 
@@ -766,6 +781,17 @@ def render_summary(
 
 def main() -> int:
     args = parse_args()
+    if args.check_play_access:
+        if args.skip_android:
+            raise ScriptError("--check-play-access cannot be combined with --skip-android.")
+        service_account_path = load_service_account_path(
+            args.play_service_account_json,
+            pathlib.Path(args.play_env_file).expanduser(),
+        )
+        check_play_access(args.android_package, service_account_path)
+        print(f"Google Play Publisher API access verified for {args.android_package}.")
+        return 0
+
     if args.skip_ios and args.skip_android:
         raise ScriptError("Nothing to do: both --skip-ios and --skip-android were set.")
 

--- a/tools/scripts/fetch-mobile-store-artifacts.py
+++ b/tools/scripts/fetch-mobile-store-artifacts.py
@@ -418,13 +418,30 @@ def issue_token(service_account_path: pathlib.Path, scope: str) -> str:
 
 
 def api_get_json(url: str, bearer_token: str) -> dict[str, Any]:
+    return api_request_json(url, bearer_token)
+
+
+def api_request_json(
+    url: str,
+    bearer_token: str,
+    *,
+    method: str = "GET",
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    headers = {
+        "Authorization": f"Bearer {bearer_token}",
+        "Accept": "application/json",
+        "User-Agent": "litter-store-fetch/1.0",
+    }
+    data = None
+    if payload is not None:
+        data = json.dumps(payload).encode()
+        headers["Content-Type"] = "application/json"
     request = urllib.request.Request(
         url,
-        headers={
-            "Authorization": f"Bearer {bearer_token}",
-            "Accept": "application/json",
-            "User-Agent": "litter-store-fetch/1.0",
-        },
+        data=data,
+        headers=headers,
+        method=method,
     )
     try:
         with urllib.request.urlopen(request, timeout=120) as response:
@@ -436,11 +453,23 @@ def api_get_json(url: str, bearer_token: str) -> dict[str, Any]:
 
 def check_play_access(package_name: str, service_account_path: pathlib.Path) -> None:
     token = issue_token(service_account_path, PLAY_PUBLISHER_SCOPE)
-    query = urllib.parse.urlencode({"maxResults": "1"})
-    api_get_json(
+    edits_url = (
         f"https://androidpublisher.googleapis.com/androidpublisher/v3/"
-        f"applications/{package_name}/reviews?{query}",
+        f"applications/{package_name}/edits"
+    )
+    edit = api_request_json(
+        edits_url,
         token,
+        method="POST",
+        payload={},
+    )
+    edit_id = edit.get("id")
+    if not edit_id:
+        raise ScriptError("Google Play edit preflight returned no edit ID.")
+    api_request_json(
+        f"{edits_url}/{urllib.parse.quote(str(edit_id), safe='')}",
+        token,
+        method="DELETE",
     )
 
 

--- a/tools/scripts/tests/test_fetch_mobile_store_artifacts.py
+++ b/tools/scripts/tests/test_fetch_mobile_store_artifacts.py
@@ -18,6 +18,24 @@ SPEC.loader.exec_module(STORE_ARTIFACTS)
 
 
 class PlayAccessCheckTests(unittest.TestCase):
+    def test_api_request_json_sends_method_and_payload(self) -> None:
+        response = mock.MagicMock()
+        response.__enter__.return_value.read.return_value = b'{"id":"edit-123"}'
+        with mock.patch.object(STORE_ARTIFACTS.urllib.request, "urlopen", return_value=response) as urlopen:
+            payload = STORE_ARTIFACTS.api_request_json(
+                "https://example.invalid/edits",
+                "token",
+                method="POST",
+                payload={},
+            )
+
+        request = urlopen.call_args.args[0]
+        self.assertEqual(payload, {"id": "edit-123"})
+        self.assertEqual(request.get_method(), "POST")
+        self.assertEqual(request.data, b"{}")
+        self.assertEqual(request.get_header("Authorization"), "Bearer token")
+        self.assertEqual(request.get_header("Content-type"), "application/json")
+
     def test_check_play_access_creates_and_discards_edit(self) -> None:
         service_account = pathlib.Path("/tmp/service-account.json")
         with (

--- a/tools/scripts/tests/test_fetch_mobile_store_artifacts.py
+++ b/tools/scripts/tests/test_fetch_mobile_store_artifacts.py
@@ -1,0 +1,82 @@
+import importlib.util
+import io
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+
+SCRIPT_PATH = pathlib.Path(__file__).parents[1] / "fetch-mobile-store-artifacts.py"
+SPEC = importlib.util.spec_from_file_location("fetch_mobile_store_artifacts", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+STORE_ARTIFACTS = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(STORE_ARTIFACTS)
+
+
+class PlayAccessCheckTests(unittest.TestCase):
+    def test_check_play_access_uses_publisher_scope_and_package(self) -> None:
+        service_account = pathlib.Path("/tmp/service-account.json")
+        with (
+            mock.patch.object(STORE_ARTIFACTS, "issue_token", return_value="token") as issue_token,
+            mock.patch.object(STORE_ARTIFACTS, "api_get_json") as api_get_json,
+        ):
+            STORE_ARTIFACTS.check_play_access("com.example.app", service_account)
+
+        issue_token.assert_called_once_with(service_account, STORE_ARTIFACTS.PLAY_PUBLISHER_SCOPE)
+        api_get_json.assert_called_once_with(
+            "https://androidpublisher.googleapis.com/androidpublisher/v3/"
+            "applications/com.example.app/reviews?maxResults=1",
+            "token",
+        )
+
+    def test_check_only_mode_skips_artifact_fetch(self) -> None:
+        with tempfile.NamedTemporaryFile() as service_account:
+            argv = [
+                str(SCRIPT_PATH),
+                "--check-play-access",
+                "--play-service-account-json",
+                service_account.name,
+            ]
+            with (
+                mock.patch.object(sys, "argv", argv),
+                mock.patch.object(STORE_ARTIFACTS, "check_play_access") as check_play_access,
+                redirect_stdout(io.StringIO()) as stdout,
+            ):
+                self.assertEqual(STORE_ARTIFACTS.main(), 0)
+
+        check_play_access.assert_called_once()
+        self.assertIn("Google Play Publisher API access verified", stdout.getvalue())
+
+    def test_check_only_mode_rejects_skip_android(self) -> None:
+        argv = [str(SCRIPT_PATH), "--check-play-access", "--skip-android"]
+        with mock.patch.object(sys, "argv", argv):
+            with self.assertRaisesRegex(STORE_ARTIFACTS.ScriptError, "cannot be combined"):
+                STORE_ARTIFACTS.main()
+
+
+class ReleasePreflightScriptTests(unittest.TestCase):
+    def test_google_play_preflight_rejects_missing_secrets(self) -> None:
+        self.assert_missing_secret("check-google-play-release.sh", "ANDROID_UPLOAD_KEYSTORE_B64")
+
+    def test_app_store_preflight_rejects_missing_secrets(self) -> None:
+        self.assert_missing_secret("check-app-store-release.sh", "ASC_KEY_ID")
+
+    def assert_missing_secret(self, script_name: str, secret_name: str) -> None:
+        with tempfile.TemporaryDirectory() as runner_temp:
+            result = subprocess.run(
+                [str(SCRIPT_PATH.with_name(script_name))],
+                check=False,
+                capture_output=True,
+                text=True,
+                env={"PATH": os.environ["PATH"], "RUNNER_TEMP": runner_temp},
+            )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(f"Missing required secret: {secret_name}", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/scripts/tests/test_fetch_mobile_store_artifacts.py
+++ b/tools/scripts/tests/test_fetch_mobile_store_artifacts.py
@@ -18,20 +18,46 @@ SPEC.loader.exec_module(STORE_ARTIFACTS)
 
 
 class PlayAccessCheckTests(unittest.TestCase):
-    def test_check_play_access_uses_publisher_scope_and_package(self) -> None:
+    def test_check_play_access_creates_and_discards_edit(self) -> None:
         service_account = pathlib.Path("/tmp/service-account.json")
         with (
             mock.patch.object(STORE_ARTIFACTS, "issue_token", return_value="token") as issue_token,
-            mock.patch.object(STORE_ARTIFACTS, "api_get_json") as api_get_json,
+            mock.patch.object(
+                STORE_ARTIFACTS,
+                "api_request_json",
+                side_effect=[{"id": "edit-123"}, {}],
+            ) as api_request_json,
         ):
             STORE_ARTIFACTS.check_play_access("com.example.app", service_account)
 
         issue_token.assert_called_once_with(service_account, STORE_ARTIFACTS.PLAY_PUBLISHER_SCOPE)
-        api_get_json.assert_called_once_with(
-            "https://androidpublisher.googleapis.com/androidpublisher/v3/"
-            "applications/com.example.app/reviews?maxResults=1",
-            "token",
+        self.assertEqual(
+            api_request_json.call_args_list,
+            [
+                mock.call(
+                    "https://androidpublisher.googleapis.com/androidpublisher/v3/"
+                    "applications/com.example.app/edits",
+                    "token",
+                    method="POST",
+                    payload={},
+                ),
+                mock.call(
+                    "https://androidpublisher.googleapis.com/androidpublisher/v3/"
+                    "applications/com.example.app/edits/edit-123",
+                    "token",
+                    method="DELETE",
+                ),
+            ],
         )
+
+    def test_check_play_access_rejects_missing_edit_id(self) -> None:
+        service_account = pathlib.Path("/tmp/service-account.json")
+        with (
+            mock.patch.object(STORE_ARTIFACTS, "issue_token", return_value="token"),
+            mock.patch.object(STORE_ARTIFACTS, "api_request_json", return_value={}),
+        ):
+            with self.assertRaisesRegex(STORE_ARTIFACTS.ScriptError, "no edit ID"):
+                STORE_ARTIFACTS.check_play_access("com.example.app", service_account)
 
     def test_check_only_mode_skips_artifact_fetch(self) -> None:
         with tempfile.NamedTemporaryFile() as service_account:


### PR DESCRIPTION
## Purpose

Prevent mobile release jobs from spending an hour building before discovering that Apple or Google store access is missing or invalid.

## Changes

- add a release preflight ahead of shared/native build preparation
- verify the Android upload keystore and prove the exact Google Play publishing permission by creating and immediately deleting an empty edit
- verify the ASC private key, distribution certificate, provisioning-profile identities, and authenticated app ID
- share the same checks between push and manual release workflows
- remove the per-release attempt to enable the Android Publisher API with the publishing service account
- document the one-time owner/admin bootstrap for both stores

## Verification

- 7 Python unit/integration-boundary tests pass
- Python byte-compilation passes
- Bash syntax and ShellCheck pass for both preflight scripts
- Actionlint passes on all three changed workflows, ignoring only pre-existing custom-runner/style findings
- diff whitespace check passes
- the new ASC team key authenticates live and resolves KittyLitter, bundle com.sigkitten.litter, App Store ID 6759521788
- PR Mobile CI rebuilds shared Rust, iOS, and Android from a clean checkout

## Remaining live gate

Apple API bootstrap is complete. Google Cloud still requires the signed-in account owner to accept its Terms of Service and enable androidpublisher.googleapis.com once. After that owner action, the main-only release environment can exercise the exact live preflight before any native release build.