### PR TITLE
ci: make TestFlight cache optional

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -87,10 +87,26 @@ jobs:
         with:
           targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios,i686-unknown-linux-musl
 
+      - name: Configure sccache
+        run: |
+          if [ -n "${SCCACHE_ENDPOINT:-}" ] && [ -n "${AWS_ACCESS_KEY_ID:-}" ] && [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+            echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          else
+            {
+              echo "SCCACHE_BUCKET="
+              echo "SCCACHE_ENDPOINT="
+              echo "SCCACHE_S3_KEY_PREFIX="
+              echo "AWS_ACCESS_KEY_ID="
+              echo "AWS_SECRET_ACCESS_KEY="
+            } >> "$GITHUB_ENV"
+          fi
+
       - name: Setup sccache
+        if: env.SCCACHE_ENDPOINT != '' && env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != ''
         uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Prime sccache
+        if: env.SCCACHE_ENDPOINT != '' && env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != ''
         run: |
           export SCCACHE_ERROR_LOG="$RUNNER_TEMP/sccache-ios.log"
           rm -f "$SCCACHE_ERROR_LOG"
@@ -103,7 +119,6 @@ jobs:
           CARGO_INCREMENTAL: "0"
           CARGO_BUILD_JOBS: "1"
           IOS_RUST_PROFILE: mobile-release
-          RUSTC_WRAPPER: sccache
         run: |
           set -euo pipefail
           export SCCACHE_ERROR_LOG="$RUNNER_TEMP/sccache-ios.log"


### PR DESCRIPTION
## Purpose

Keep the standalone TestFlight release runnable when the optional remote sccache credentials are not installed.

## Root cause

Run 30951375473 passed the live App Store Connect preflight, then failed before compilation because `SCCACHE_R2_ENDPOINT` and the R2 access secrets were empty while the workflow still forced `RUSTC_WRAPPER=sccache` and unconditionally started the remote cache.

## Changes

- configure sccache only when the endpoint and both credentials are present
- skip setup/priming when the cache is unavailable
- let Cargo run directly instead of forcing an unusable wrapper

This matches the existing optional-cache behavior in the merged Mobile Release lane.

## Verification

- parsed the workflow as YAML
- exercised both cache-enabled and cache-disabled configuration paths from the workflow source
- Actionlint passed, ignoring only the pre-existing SC2129 style finding elsewhere in the workflow
- `git diff --check`
