### PR TITLE
ci: normalize Apple signing identity imports

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -45,6 +45,9 @@ jobs:
           IOS_DIST_CERT_PASSWORD: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
           IOS_APP_STORE_PROFILE_B64: ${{ secrets.IOS_APP_STORE_PROFILE_B64 }}
           IOS_LIVE_ACTIVITY_APP_STORE_PROFILE_B64: ${{ secrets.IOS_LIVE_ACTIVITY_APP_STORE_PROFILE_B64 }}
+          IOS_WATCH_APP_STORE_PROFILE_B64: ${{ secrets.IOS_WATCH_APP_STORE_PROFILE_B64 }}
+          IOS_WATCH_COMPLICATIONS_APP_STORE_PROFILE_B64: ${{ secrets.IOS_WATCH_COMPLICATIONS_APP_STORE_PROFILE_B64 }}
+          REQUIRE_WATCH_PROFILES: "1"
         run: ./tools/scripts/check-app-store-release.sh
 
   prepare-release-assets:
@@ -212,26 +215,33 @@ jobs:
           IOS_DIST_CERT_PASSWORD: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
           IOS_APP_STORE_PROFILE_B64: ${{ secrets.IOS_APP_STORE_PROFILE_B64 }}
           IOS_LIVE_ACTIVITY_APP_STORE_PROFILE_B64: ${{ secrets.IOS_LIVE_ACTIVITY_APP_STORE_PROFILE_B64 }}
+          IOS_WATCH_APP_STORE_PROFILE_B64: ${{ secrets.IOS_WATCH_APP_STORE_PROFILE_B64 }}
+          IOS_WATCH_COMPLICATIONS_APP_STORE_PROFILE_B64: ${{ secrets.IOS_WATCH_COMPLICATIONS_APP_STORE_PROFILE_B64 }}
         run: |
           set -euo pipefail
 
           CERT_PATH="$RUNNER_TEMP/dist-cert.p12"
           APP_PROFILE_PATH="$RUNNER_TEMP/app-store.mobileprovision"
           LIVE_ACTIVITY_PROFILE_PATH="$RUNNER_TEMP/live-activity-app-store.mobileprovision"
+          WATCH_PROFILE_PATH="$RUNNER_TEMP/watch-app-store.mobileprovision"
+          WATCH_COMP_PROFILE_PATH="$RUNNER_TEMP/watch-complications-app-store.mobileprovision"
           KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain-db"
           KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
 
           echo "$IOS_DIST_CERT_P12_B64" | base64 --decode > "$CERT_PATH"
           echo "$IOS_APP_STORE_PROFILE_B64" | base64 --decode > "$APP_PROFILE_PATH"
           echo "$IOS_LIVE_ACTIVITY_APP_STORE_PROFILE_B64" | base64 --decode > "$LIVE_ACTIVITY_PROFILE_PATH"
+          echo "$IOS_WATCH_APP_STORE_PROFILE_B64" | base64 --decode > "$WATCH_PROFILE_PATH"
+          echo "$IOS_WATCH_COMPLICATIONS_APP_STORE_PROFILE_B64" | base64 --decode > "$WATCH_COMP_PROFILE_PATH"
 
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security list-keychains -d user -s "$KEYCHAIN_PATH"
           security default-keychain -d user -s "$KEYCHAIN_PATH"
-          security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$IOS_DIST_CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
-          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          export APPLE_SIGNING_P12_PASSWORD="$IOS_DIST_CERT_PASSWORD"
+          export APPLE_SIGNING_KEYCHAIN_PASSWORD="$KEYCHAIN_PASSWORD"
+          ./tools/scripts/import-apple-signing-identity.sh "$CERT_PATH" "$KEYCHAIN_PATH"
 
           mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
 
@@ -248,6 +258,8 @@ jobs:
 
           install_profile "$APP_PROFILE_PATH" "APP_PROVISIONING_PROFILE_SPECIFIER"
           install_profile "$LIVE_ACTIVITY_PROFILE_PATH" "LIVE_ACTIVITY_PROVISIONING_PROFILE_SPECIFIER"
+          install_profile "$WATCH_PROFILE_PATH" "WATCH_PROVISIONING_PROFILE_SPECIFIER"
+          install_profile "$WATCH_COMP_PROFILE_PATH" "WATCH_COMP_PROVISIONING_PROFILE_SPECIFIER"
 
       - name: Resolve release inputs
         run: |

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -794,8 +794,9 @@ jobs:
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security list-keychains -d user -s "$KEYCHAIN_PATH"
           security default-keychain -d user -s "$KEYCHAIN_PATH"
-          security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$IOS_DIST_CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
-          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          export APPLE_SIGNING_P12_PASSWORD="$IOS_DIST_CERT_PASSWORD"
+          export APPLE_SIGNING_KEYCHAIN_PASSWORD="$KEYCHAIN_PASSWORD"
+          ./tools/scripts/import-apple-signing-identity.sh "$CERT_PATH" "$KEYCHAIN_PATH"
 
           mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
 

--- a/tools/scripts/check-app-store-release.sh
+++ b/tools/scripts/check-app-store-release.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RELEASE_TEMP_DIR="${RUNNER_TEMP:?RUNNER_TEMP is required}"
 REQUIRE_WATCH_PROFILES="${REQUIRE_WATCH_PROFILES:-0}"
 umask 077
@@ -39,6 +40,24 @@ printf '%s' "$IOS_DIST_CERT_P12_B64" | base64 --decode > "$cert_path"
 printf '%s' "$IOS_APP_STORE_PROFILE_B64" | base64 --decode > "$app_profile_path"
 printf '%s' "$IOS_LIVE_ACTIVITY_APP_STORE_PROFILE_B64" | base64 --decode > "$activity_profile_path"
 openssl pkcs12 -in "$cert_path" -passin env:IOS_DIST_CERT_PASSWORD -noout
+
+validation_keychain_path="$RELEASE_TEMP_DIR/release-validation.keychain-db"
+validation_keychain_password="$(openssl rand -base64 24)"
+cleanup_validation_keychain() {
+    security delete-keychain "$validation_keychain_path" >/dev/null 2>&1 || true
+}
+trap cleanup_validation_keychain EXIT
+
+security create-keychain -p "$validation_keychain_password" "$validation_keychain_path"
+security unlock-keychain -p "$validation_keychain_password" "$validation_keychain_path"
+export APPLE_SIGNING_P12_PASSWORD="$IOS_DIST_CERT_PASSWORD"
+export APPLE_SIGNING_KEYCHAIN_PASSWORD="$validation_keychain_password"
+"$SCRIPT_DIR/import-apple-signing-identity.sh" "$cert_path" "$validation_keychain_path"
+if ! security find-identity -v -p codesigning "$validation_keychain_path" |
+    grep -Eq '^[[:space:]]*[1-9][0-9]* valid identities found$'; then
+    echo "The distribution certificate did not produce a valid macOS codesigning identity." >&2
+    exit 1
+fi
 
 validate_profile() {
     local profile_path="$1"

--- a/tools/scripts/import-apple-signing-identity.sh
+++ b/tools/scripts/import-apple-signing-identity.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -ne 2 ]]; then
+    echo "Usage: $0 <identity.p12> <keychain>" >&2
+    exit 2
+fi
+
+: "${APPLE_SIGNING_P12_PASSWORD:?APPLE_SIGNING_P12_PASSWORD is required}"
+: "${APPLE_SIGNING_KEYCHAIN_PASSWORD:?APPLE_SIGNING_KEYCHAIN_PASSWORD is required}"
+
+p12_path="$1"
+keychain_path="$2"
+temp_root="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+identity_pem="$(mktemp "$temp_root/litter-signing-identity.XXXXXX")"
+
+cleanup() {
+    rm -f "$identity_pem"
+}
+trap cleanup EXIT
+
+umask 077
+openssl pkcs12 \
+    -in "$p12_path" \
+    -passin env:APPLE_SIGNING_P12_PASSWORD \
+    -nodes \
+    -out "$identity_pem"
+
+security import "$identity_pem" \
+    -k "$keychain_path" \
+    -T /usr/bin/codesign \
+    -T /usr/bin/security
+security set-key-partition-list \
+    -S apple-tool:,apple: \
+    -s \
+    -k "$APPLE_SIGNING_KEYCHAIN_PASSWORD" \
+    "$keychain_path"


### PR DESCRIPTION
## Purpose

Make Apple release preflight exercise the same macOS Keychain surface used by archive jobs, and make the standalone TestFlight lane complete its manual signing inputs.

## Root cause

Run 30951914596 passed OpenSSL P12 validation and completed the 82-minute native release build, then macOS Keychain rejected the P12 with `SecKeychainItemImport: MAC verification failed during PKCS12 import`.

OpenSSL can verify and extract the identity, while Keychain can import the extracted PEM. The failure is therefore a PKCS#12 import-compatibility boundary, not a bad certificate or missing private key.

The same review found that the standalone lane omitted the Watch and Watch Complications provisioning profiles required by its manual signing mode.

## Changes

- add one shared Apple signing import helper that verifies/extracts the P12 with OpenSSL and imports the PEM into Keychain
- use it in standalone TestFlight and Mobile Release
- make Apple preflight create a disposable Keychain, import the identity, and require a valid codesigning identity before native builds begin
- validate and install all four iOS/watchOS App Store profiles in the standalone lane

## Verification

- generated a temporary certificate/private key/P12, imported it through the shared helper, and resolved the certificate from a disposable macOS Keychain
- verified the helper rejects missing password inputs
- `bash -n` and ShellCheck pass
- both workflows parse as YAML
- Actionlint passes with only the existing SC2129 style exclusion
- `git diff --check`
