### PR TITLE
mobile: restore Amp compatibility and Android pairing

### DIFF
--- a/apps/android/app/src/main/java/com/litter/android/state/SnapshotExtensions.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/SnapshotExtensions.kt
@@ -11,6 +11,7 @@ import uniffi.codex_mobile_client.AppConnectionStepKind
 import uniffi.codex_mobile_client.AppConnectionStepSnapshot
 import uniffi.codex_mobile_client.AppConnectionStepState
 import com.litter.android.ui.common.AgentRuntimeKind
+import com.litter.android.ui.common.locksReasoningEffortAfterActivity
 import com.litter.android.ui.common.runtimeLabel
 import uniffi.codex_mobile_client.ThreadSummaryStatus
 
@@ -140,8 +141,8 @@ val ThreadSummaryStatus.isActiveStatus: Boolean
 val AppThreadSnapshot.hasActiveTurn: Boolean
     get() = activeTurnId?.trim()?.isNotEmpty() == true || info.status.isActiveStatus
 
-val AppThreadSnapshot.ampReasoningEffortLocked: Boolean
-    get() = agentRuntimeKind == "amp" &&
+val AppThreadSnapshot.reasoningEffortLocked: Boolean
+    get() = agentRuntimeKind.locksReasoningEffortAfterActivity &&
         (hydratedConversationItems.isNotEmpty() || activeTurnId?.trim()?.isNotEmpty() == true)
 
 val AppThreadSnapshot.resolvedModel: String

--- a/apps/android/app/src/main/java/com/litter/android/ui/common/AgentRuntimePresentation.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/common/AgentRuntimePresentation.kt
@@ -85,6 +85,10 @@ val AgentRuntimeKind.supportsThreadPermissionOverrides: Boolean
 val AgentRuntimeKind.reportsEffectiveThreadPermissions: Boolean
     get() = !hasFixedFullAccess && (metadata?.capabilities?.reportsEffectiveThreadPermissions ?: true)
 
+/** Whether this runtime freezes reasoning effort after thread activity begins. */
+val AgentRuntimeKind.locksReasoningEffortAfterActivity: Boolean
+    get() = metadata?.capabilities?.locksReasoningEffortAfterActivity == true
+
 val AgentRuntimeKind.hasFixedFullAccess: Boolean
     get() = this == "pi" || this == "local-studio"
 

--- a/apps/android/app/src/main/java/com/litter/android/ui/common/ModelSelectorPanel.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/common/ModelSelectorPanel.kt
@@ -49,7 +49,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.litter.android.state.ampReasoningEffortLocked
+import com.litter.android.state.reasoningEffortLocked
 import com.litter.android.ui.LitterTextStyle
 import com.litter.android.ui.LitterTheme
 import com.litter.android.ui.LocalAppModel
@@ -176,10 +176,9 @@ fun ModelSelectorPanel(
                 ?: visibleModels.firstOrNull()
         }
     }
-    val selectedModelIsAmp = selectedModelDefinition?.agentRuntimeKind == "amp"
-    val ampEffortLocked = selectedModelIsAmp && thread?.ampReasoningEffortLocked == true
-    val supportedEfforts = remember(selectedModelDefinition, ampEffortLocked) {
-        if (ampEffortLocked) {
+    val effortLocked = thread?.reasoningEffortLocked == true
+    val supportedEfforts = remember(selectedModelDefinition, effortLocked) {
+        if (effortLocked) {
             emptyList()
         } else {
             selectedModelDefinition?.supportedReasoningEfforts ?: emptyList()
@@ -200,13 +199,13 @@ fun ModelSelectorPanel(
             ?: selectedModelDefinition?.defaultReasoningEffort?.let(::effortLabel)
     }
 
-    LaunchedEffect(launchState.reasoningEffort, selectedModelDefinition, supportedEfforts, ampEffortLocked) {
+    LaunchedEffect(launchState.reasoningEffort, selectedModelDefinition, supportedEfforts, effortLocked) {
         val pendingEffort = launchState.reasoningEffort.trim()
         val defaultEffort = selectedModelDefinition?.defaultReasoningEffort
         if (pendingEffort.isEmpty()) {
             return@LaunchedEffect
         }
-        if (ampEffortLocked) {
+        if (effortLocked) {
             appModel.launchState.updateReasoningEffort(null)
             return@LaunchedEffect
         }
@@ -333,7 +332,7 @@ fun ModelSelectorPanel(
                                 agentRuntimeKind = model.agentRuntimeKind,
                             )
                             appModel.launchState.updateReasoningEffort(
-                                if (ampEffortLocked && model.agentRuntimeKind == "amp") {
+                                if (effortLocked) {
                                     null
                                 } else {
                                     model.defaultReasoningEffortSelection()
@@ -373,7 +372,7 @@ fun ModelSelectorPanel(
             )
         }
 
-        if (ampEffortLocked) {
+        if (effortLocked) {
             Text(
                 text = "Reasoning effort is locked after the first message.",
                 color = LitterTheme.textSecondary,
@@ -515,29 +514,32 @@ internal fun effortLabel(value: ReasoningEffort): String = when (value) {
 private fun ModelInfo.defaultReasoningEffortSelection(): String? =
     if (supportedReasoningEfforts.isEmpty()) null else effortLabel(defaultReasoningEffort)
 
-private val AmpVisibleModes = setOf("smart", "rush", "deep")
-
-private fun normalizedAmpModeName(value: String): String =
+private fun normalizedModeName(value: String, runtimeKind: AgentRuntimeKind): String =
     value.trim()
         .lowercase(Locale.ROOT)
-        .removePrefix("amp/")
-        .removePrefix("amp:")
+        .removePrefix("$runtimeKind/")
+        .removePrefix("$runtimeKind:")
+        .removePrefix("$runtimeKind\\")
 
-private fun ModelInfo.ampModeName(): String =
-    normalizedAmpModeName(id)
+private fun ModelInfo.modeName(): String =
+    normalizedModeName(id, agentRuntimeKind)
         .ifEmpty {
-            normalizedAmpModeName(model)
+            normalizedModeName(model, agentRuntimeKind)
         }
 
 internal fun ModelInfo.modelPickerDisplayName(): String =
-    if (agentRuntimeKind == "amp") {
-        ampModeName().ifEmpty { displayName.ifBlank { id } }
+    if (agentRuntimeKind.metadata?.capabilities?.visibleModes != null) {
+        modeName().ifEmpty { displayName.ifBlank { id } }
     } else {
         displayName.ifBlank { id }
     }
 
-private fun ModelInfo.isVisibleModelOption(): Boolean =
-    agentRuntimeKind != "amp" || ampModeName() in AmpVisibleModes
+internal fun ModelInfo.isVisibleModelOption(): Boolean {
+    val modes = agentRuntimeKind.metadata?.capabilities?.visibleModes ?: return true
+    return modeName() in modes.mapTo(mutableSetOf()) {
+        normalizedModeName(it, agentRuntimeKind)
+    }
+}
 
 private data class RuntimeModelBucket(
     val kind: AgentRuntimeKind,

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ComposerBar.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ComposerBar.kt
@@ -91,7 +91,7 @@ import com.litter.android.state.ComposerImageAttachment
 import com.litter.android.state.ComposerFileAttachment
 import com.litter.android.state.AppComposerPayload
 import com.litter.android.state.VoiceTranscriptionManager
-import com.litter.android.state.ampReasoningEffortLocked
+import com.litter.android.state.reasoningEffortLocked
 import com.litter.android.util.LLog
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
@@ -432,7 +432,7 @@ fun ComposerBar(
             val launchState = appModel.launchState.snapshot.value
             val pendingModel = launchState.selectedModel.trim().ifEmpty { null }
             val thread = appModel.snapshot.value?.threads?.find { it.key == threadKey }
-            val effort = if (thread?.ampReasoningEffortLocked == true) {
+            val effort = if (thread?.reasoningEffortLocked == true) {
                 null
             } else {
                 launchState.reasoningEffort.trim().ifEmpty { null }

--- a/apps/android/app/src/main/java/com/litter/android/ui/discovery/AlleycatAddServerSheet.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/discovery/AlleycatAddServerSheet.kt
@@ -129,6 +129,7 @@ fun AlleycatAddServerSheet(
     var showPaste by remember { mutableStateOf(false) }
     var pasteJson by remember { mutableStateOf("") }
     var cameraDenied by remember { mutableStateOf(false) }
+    var cameraError by remember { mutableStateOf<String?>(null) }
 
     fun loadAgents(params: AppAlleycatPairPayload) {
         isLoadingAgents = true
@@ -192,6 +193,7 @@ fun AlleycatAddServerSheet(
     }
 
     fun requestCameraAndScan() {
+        cameraError = null
         when {
             ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) ==
                 PackageManager.PERMISSION_GRANTED -> {
@@ -280,6 +282,10 @@ fun AlleycatAddServerSheet(
                 handleScannedPayload(payload)
             },
             onCancel = { showScanner = false },
+            onError = {
+                showScanner = false
+                cameraError = "Camera unavailable. Paste the pairing JSON instead."
+            },
         )
         return
     }
@@ -348,6 +354,13 @@ fun AlleycatAddServerSheet(
                 modifier = Modifier
                     .padding(top = 4.dp)
                     .clickable { openAppSettings(context) },
+            )
+        }
+        cameraError?.let { message ->
+            Text(
+                text = message,
+                color = LitterTheme.warning,
+                fontSize = 11.sp,
             )
         }
 
@@ -686,6 +699,7 @@ private fun QrScannerScreen(
     pairingMode: AlleycatPairingMode,
     onScanned: (String) -> Unit,
     onCancel: () -> Unit,
+    onError: () -> Unit,
 ) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -729,6 +743,7 @@ private fun QrScannerScreen(
                             onScanned(payload)
                         }
                     },
+                    onError = onError,
                 )
                 previewView
             },
@@ -961,36 +976,37 @@ private fun bindCameraUseCases(
     barcodeScanner: com.google.mlkit.vision.barcode.BarcodeScanner,
     executor: java.util.concurrent.ExecutorService,
     onResult: (String) -> Unit,
+    onError: () -> Unit,
 ) {
     val providerFuture = ProcessCameraProvider.getInstance(context)
     providerFuture.addListener({
-        val provider = providerFuture.get()
-        val preview = Preview.Builder().build().also {
-            it.setSurfaceProvider(previewView.surfaceProvider)
-        }
-        val analysis = ImageAnalysis.Builder()
-            .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
-            .build()
-        analysis.setAnalyzer(executor) { proxy ->
-            val media = proxy.image
-            if (media == null) {
-                proxy.close()
-                return@setAnalyzer
-            }
-            val image = InputImage.fromMediaImage(media, proxy.imageInfo.rotationDegrees)
-            barcodeScanner.process(image)
-                .addOnSuccessListener { barcodes ->
-                    barcodes
-                        .firstOrNull { it.format == Barcode.FORMAT_QR_CODE }
-                        ?.rawValue
-                        ?.let(onResult)
-                }
-                .addOnFailureListener { err ->
-                    Log.w(LOG_TAG, "barcode analyze failed", err)
-                }
-                .addOnCompleteListener { proxy.close() }
-        }
         runCatching {
+            val provider = providerFuture.get()
+            val preview = Preview.Builder().build().also {
+                it.setSurfaceProvider(previewView.surfaceProvider)
+            }
+            val analysis = ImageAnalysis.Builder()
+                .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                .build()
+            analysis.setAnalyzer(executor) { proxy ->
+                val media = proxy.image
+                if (media == null) {
+                    proxy.close()
+                    return@setAnalyzer
+                }
+                val image = InputImage.fromMediaImage(media, proxy.imageInfo.rotationDegrees)
+                barcodeScanner.process(image)
+                    .addOnSuccessListener { barcodes ->
+                        barcodes
+                            .firstOrNull { it.format == Barcode.FORMAT_QR_CODE }
+                            ?.rawValue
+                            ?.let(onResult)
+                    }
+                    .addOnFailureListener { err ->
+                        Log.w(LOG_TAG, "barcode analyze failed", err)
+                    }
+                    .addOnCompleteListener { proxy.close() }
+            }
             provider.unbindAll()
             provider.bindToLifecycle(
                 lifecycleOwner,
@@ -999,7 +1015,8 @@ private fun bindCameraUseCases(
                 analysis,
             )
         }.onFailure {
-            Log.w(LOG_TAG, "bindToLifecycle failed", it)
+            Log.w(LOG_TAG, "camera initialization failed", it)
+            onError()
         }
     }, ContextCompat.getMainExecutor(context))
 }

--- a/apps/android/app/src/test/java/com/litter/android/ui/common/ModelSelectorCompatibilityTest.kt
+++ b/apps/android/app/src/test/java/com/litter/android/ui/common/ModelSelectorCompatibilityTest.kt
@@ -1,0 +1,86 @@
+package com.litter.android.ui.common
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import uniffi.codex_mobile_client.AppAgentCapabilities
+import uniffi.codex_mobile_client.AppAgentMetadata
+import uniffi.codex_mobile_client.ModelInfo
+import uniffi.codex_mobile_client.ReasoningEffort
+
+class ModelSelectorCompatibilityTest {
+    @After
+    fun resetMetadataProvider() {
+        AgentRuntimeMetadataProvider.lookup = null
+        AgentRuntimeMetadataProvider.all = null
+    }
+
+    @Test
+    fun `mode filtering consumes runtime visible modes`() {
+        AgentRuntimeMetadataProvider.lookup = { runtime ->
+            if (runtime == "amp") ampMetadata() else null
+        }
+
+        assertTrue(model("low").isVisibleModelOption())
+        assertTrue(model("amp/medium").isVisibleModelOption())
+        assertTrue(model("high").isVisibleModelOption())
+        assertTrue(model("ultra").isVisibleModelOption())
+        assertFalse(model("smart").isVisibleModelOption())
+        assertEquals("medium", model("amp/medium").modelPickerDisplayName())
+    }
+
+    @Test
+    fun `reasoning effort lock is capability driven`() {
+        AgentRuntimeMetadataProvider.lookup = { runtime ->
+            AppAgentMetadata(
+                name = runtime,
+                displayName = runtime,
+                presentation = null,
+                capabilities = capabilities(
+                    visibleModes = null,
+                    locksReasoningEffortAfterActivity = runtime == "custom-agent",
+                ),
+            )
+        }
+
+        assertTrue("custom-agent".locksReasoningEffortAfterActivity)
+        assertFalse("amp".locksReasoningEffortAfterActivity)
+    }
+
+    private fun ampMetadata() = AppAgentMetadata(
+        name = "amp",
+        displayName = "Amp",
+        presentation = null,
+        capabilities = capabilities(
+            visibleModes = listOf("low", "medium", "high", "ultra"),
+            locksReasoningEffortAfterActivity = false,
+        ),
+    )
+
+    private fun capabilities(
+        visibleModes: List<String>?,
+        locksReasoningEffortAfterActivity: Boolean,
+    ) = AppAgentCapabilities(
+        locksReasoningEffortAfterActivity = locksReasoningEffortAfterActivity,
+        visibleModes = visibleModes,
+        supportsSshBridge = false,
+        usesDirectCodexPort = false,
+        supportsThreadPermissionOverrides = false,
+        reportsEffectiveThreadPermissions = false,
+    )
+
+    private fun model(id: String) = ModelInfo(
+        id = id,
+        model = id,
+        displayName = id,
+        description = "",
+        hidden = false,
+        supportedReasoningEfforts = emptyList(),
+        defaultReasoningEffort = ReasoningEffort.NONE,
+        inputModalities = emptyList(),
+        isDefault = id == "medium",
+        agentRuntimeKind = "amp",
+    )
+}

--- a/apps/ios/Sources/Litter/Views/HeaderView.swift
+++ b/apps/ios/Sources/Litter/Views/HeaderView.swift
@@ -481,7 +481,7 @@ private func defaultReasoningEffortSelection(for model: ModelInfo) -> String {
 }
 
 /// Allowlist of model "mode" names the runtime advertises (e.g. Amp's
-/// `smart` / `rush` / `deep`). Pulled from `capabilities.visible_modes`
+/// `low` / `medium` / `high` / `ultra`). Pulled from `capabilities.visible_modes`
 /// in the alleycat manifest so the rule is per-agent, not Amp-hardcoded.
 private func visibleModeNames(for kind: AgentRuntimeKind) -> Set<String>? {
     kind.metadata?.capabilities?.visibleModes.map(Set.init)

--- a/shared/rust-bridge/codex-mobile-client/src/alleycat.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/alleycat.rs
@@ -681,15 +681,12 @@ pub async fn bind_alleycat_endpoint(
     let endpoint_builder = Endpoint::builder(iroh::endpoint::presets::N0)
         .transport_config(transport)
         .secret_key(secret_key);
-    // iroh-on-Android can't use the system DNS resolver / system CA
-    // roots from inside a packaged app — fall back to public DNS +
-    // embedded CA roots there. iOS/macOS pick these up natively.
+    // iroh-on-Android can't use system CA roots from inside a packaged
+    // app, so use embedded roots there. The resolver itself uses the
+    // Android context installed during native bootstrap.
     #[cfg(target_os = "android")]
-    let endpoint_builder = endpoint_builder
-        .dns_resolver(iroh::dns::DnsResolver::with_nameserver(
-            std::net::SocketAddr::from(([8, 8, 8, 8], 53)),
-        ))
-        .ca_roots_config(iroh::tls::CaRootsConfig::embedded());
+    let endpoint_builder =
+        endpoint_builder.ca_roots_config(iroh::tls::CaRootsConfig::embedded());
     info!("alleycat: binding shared iroh endpoint");
     endpoint_builder
         .bind()

--- a/shared/rust-bridge/codex-mobile-client/src/ffi/client.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/ffi/client.rs
@@ -52,85 +52,54 @@ macro_rules! req {
     };
 }
 
-const AMP_VISIBLE_MODES: [&str; 3] = ["smart", "rush", "deep"];
+const AMP_VISIBLE_MODES: [&str; 4] = ["low", "medium", "high", "ultra"];
 const MODEL_LIST_RUNTIME_TIMEOUT: Duration = Duration::from_secs(20);
 
 fn normalize_amp_mode_name(value: &str) -> String {
-    value
-        .trim()
+    let normalized = value.trim().to_ascii_lowercase();
+    let mode = normalized
         .trim_start_matches("amp/")
-        .trim_start_matches("amp:")
-        .to_ascii_lowercase()
+        .trim_start_matches("amp:");
+    match mode {
+        "rush" => "low".to_string(),
+        "smart" | "deep" => "medium".to_string(),
+        "large" => "ultra".to_string(),
+        _ => mode.to_string(),
+    }
 }
 
 fn amp_mode_description(mode: &str) -> &'static str {
     match mode {
-        "smart" => "Balanced Amp mode for everyday coding tasks.",
-        "rush" => "Faster Amp mode for quick edits and short answers.",
-        "deep" => "Deeper Amp mode for complex implementation and debugging.",
+        "low" => "Fast responses for simple, well-defined tasks.",
+        "medium" => "Balanced performance for everyday coding tasks.",
+        "high" => "More reasoning for complex coding tasks.",
+        "ultra" => "Maximum capability for the hardest coding tasks.",
         _ => "Amp agent mode.",
     }
-}
-
-fn amp_mode_reasoning_efforts(
-    mode: &str,
-) -> (Vec<types::ReasoningEffortOption>, types::ReasoningEffort) {
-    let efforts = match mode {
-        "smart" => vec![
-            types::ReasoningEffort::High,
-            types::ReasoningEffort::XHigh,
-            types::ReasoningEffort::Max,
-        ],
-        "deep" => vec![
-            types::ReasoningEffort::Low,
-            types::ReasoningEffort::Medium,
-            types::ReasoningEffort::XHigh,
-        ],
-        _ => Vec::new(),
-    };
-    let default = match mode {
-        "smart" => types::ReasoningEffort::High,
-        "deep" => types::ReasoningEffort::Medium,
-        _ => types::ReasoningEffort::None,
-    };
-    (
-        efforts
-            .into_iter()
-            .map(|reasoning_effort| types::ReasoningEffortOption {
-                reasoning_effort,
-                description: String::new(),
-            })
-            .collect(),
-        default,
-    )
 }
 
 fn amp_mode_models() -> Vec<types::ModelInfo> {
     AMP_VISIBLE_MODES
         .into_iter()
-        .map(|mode| {
-            let (supported_reasoning_efforts, default_reasoning_effort) =
-                amp_mode_reasoning_efforts(mode);
-            types::ModelInfo {
-                id: mode.to_string(),
-                model: mode.to_string(),
-                upgrade: None,
-                upgrade_model: None,
-                upgrade_copy: None,
-                model_link: None,
-                migration_markdown: None,
-                availability_nux_message: None,
-                display_name: mode.to_string(),
-                description: amp_mode_description(mode).to_string(),
-                hidden: false,
-                supported_reasoning_efforts,
-                default_reasoning_effort,
-                input_modalities: vec![types::InputModality::Text],
-                supports_personality: false,
-                is_default: mode == "smart",
-                agent_runtime_kind: "amp".to_string(),
-                provider_id: None,
-            }
+        .map(|mode| types::ModelInfo {
+            id: mode.to_string(),
+            model: mode.to_string(),
+            upgrade: None,
+            upgrade_model: None,
+            upgrade_copy: None,
+            model_link: None,
+            migration_markdown: None,
+            availability_nux_message: None,
+            display_name: mode.to_string(),
+            description: amp_mode_description(mode).to_string(),
+            hidden: false,
+            supported_reasoning_efforts: Vec::new(),
+            default_reasoning_effort: types::ReasoningEffort::None,
+            input_modalities: vec![types::InputModality::Text],
+            supports_personality: false,
+            is_default: mode == "medium",
+            agent_runtime_kind: "amp".to_string(),
+            provider_id: None,
         })
         .collect()
 }
@@ -171,16 +140,14 @@ fn normalize_model_info_for_runtime(
         if !AMP_VISIBLE_MODES.contains(&mode.as_str()) {
             return false;
         }
-        let (supported_reasoning_efforts, default_reasoning_effort) =
-            amp_mode_reasoning_efforts(&mode);
         model_info.id = mode.clone();
         model_info.model = mode.clone();
         model_info.display_name = mode.clone();
         model_info.description = amp_mode_description(&mode).to_string();
         model_info.hidden = false;
-        model_info.supported_reasoning_efforts = supported_reasoning_efforts;
-        model_info.default_reasoning_effort = default_reasoning_effort;
-        model_info.is_default = mode == "smart";
+        model_info.supported_reasoning_efforts.clear();
+        model_info.default_reasoning_effort = types::ReasoningEffort::None;
+        model_info.is_default = mode == "medium";
     } else if has_qualified_catalog {
         if let Some(provider_id) = derive_model_provider_id(&model_info.id) {
             model_info.provider_id = Some(provider_id.to_string());
@@ -1082,12 +1049,7 @@ impl AppClient {
             let mut failed_runtime_kinds = HashSet::new();
             for (runtime_kind, result) in futures::future::join_all(tasks).await {
                 match result {
-                    Ok(Ok(runtime_models)) => {
-                        models.extend(runtime_models);
-                        if runtime_kind == "amp" {
-                            append_missing_amp_mode_models(&mut models);
-                        }
-                    }
+                    Ok(Ok(runtime_models)) => models.extend(runtime_models),
                     _ if runtime_kind == "amp" => append_missing_amp_mode_models(&mut models),
                     Ok(Err(error)) => {
                         failed_runtime_kinds.insert(runtime_kind.clone());
@@ -3014,14 +2976,13 @@ mod tests {
     use super::{
         ImageViewSource, append_cached_models_for_failed_runtimes, append_missing_amp_mode_models,
         choose_saved_app_update_server_id, image_read_command, is_mobile_hidden_skill,
-        list_runtime_kinds,
-        normalize_model_info_for_runtime, normalized_image_path, runtime_exposes_model_choices,
-        splice_generative_ui_preamble,
+        list_runtime_kinds, normalize_model_info_for_runtime, normalized_image_path,
+        runtime_exposes_model_choices, splice_generative_ui_preamble,
     };
     use crate::store::snapshot::ServerTransportDiagnostics;
     use crate::store::{AppSnapshot, ServerHealthSnapshot, ServerSnapshot};
     use crate::types::models::{AbsolutePath, AppDynamicToolSpec, SkillMetadata, SkillScope};
-    use crate::types::{AgentRuntimeKind, ModelInfo, ReasoningEffort, ReasoningEffortOption};
+    use crate::types::{AgentRuntimeKind, ModelInfo, ReasoningEffort};
     use crate::widget_guidelines::GENERATIVE_UI_PREAMBLE;
     use std::collections::{HashMap, HashSet};
 
@@ -3160,43 +3121,47 @@ mod tests {
             .filter(|model| model.agent_runtime_kind == "amp".to_string())
             .map(|model| model.id.as_str())
             .collect::<Vec<_>>();
-        assert_eq!(amp_ids, vec!["smart", "rush", "deep"]);
+        assert_eq!(amp_ids, vec!["low", "medium", "high", "ultra"]);
         assert_eq!(
             models
                 .iter()
-                .find(|model| model.id == "smart")
+                .find(|model| model.id == "medium")
                 .map(|model| model.is_default),
             Some(true)
+        );
+        assert!(
+            models
+                .iter()
+                .filter(|model| model.agent_runtime_kind == "amp")
+                .all(|model| model.supported_reasoning_efforts.is_empty()
+                    && model.default_reasoning_effort == ReasoningEffort::None)
         );
     }
 
     #[test]
     fn amp_mode_fallback_preserves_advertised_modes() {
-        let mut models = vec![test_model("smart", "amp".to_string())];
+        let mut models = vec![test_model("medium", "amp".to_string())];
 
         append_missing_amp_mode_models(&mut models);
         append_missing_amp_mode_models(&mut models);
 
-        let smart_count = models
+        let medium_count = models
             .iter()
             .filter(|model| {
                 model.agent_runtime_kind == "amp".to_string()
-                    && (model.id == "smart" || model.id == "amp/smart")
+                    && (model.id == "medium" || model.id == "amp/medium")
             })
             .count();
-        assert_eq!(smart_count, 1);
-        assert!(models.iter().any(|model| model.id == "rush"));
-        assert!(models.iter().any(|model| model.id == "deep"));
-        assert!(!models.iter().any(|model| model.id == "large"));
+        assert_eq!(medium_count, 1);
+        assert!(models.iter().any(|model| model.id == "low"));
+        assert!(models.iter().any(|model| model.id == "high"));
+        assert!(models.iter().any(|model| model.id == "ultra"));
     }
 
     #[test]
-    fn amp_model_normalization_uses_amp_mode_efforts() {
-        let mut model = test_model("amp/smart", "codex".to_string());
-        model.supported_reasoning_efforts = vec![ReasoningEffortOption {
-            reasoning_effort: ReasoningEffort::Low,
-            description: "High".to_string(),
-        }];
+    fn amp_model_normalization_uses_current_mode_without_effort() {
+        let mut model = test_model("AMP/SMART", "codex".to_string());
+        model.supported_reasoning_efforts = vec![];
         model.default_reasoning_effort = ReasoningEffort::Low;
 
         assert!(normalize_model_info_for_runtime(
@@ -3205,31 +3170,23 @@ mod tests {
         ));
 
         assert_eq!(model.agent_runtime_kind, "amp".to_string());
-        assert_eq!(model.id, "smart");
-        assert_eq!(model.display_name, "smart");
-        assert_eq!(
-            model
-                .supported_reasoning_efforts
-                .iter()
-                .map(|option| option.reasoning_effort.clone())
-                .collect::<Vec<_>>(),
-            vec![
-                ReasoningEffort::High,
-                ReasoningEffort::XHigh,
-                ReasoningEffort::Max
-            ]
-        );
-        assert_eq!(model.default_reasoning_effort, ReasoningEffort::High);
+        assert_eq!(model.id, "medium");
+        assert_eq!(model.display_name, "medium");
+        assert!(model.supported_reasoning_efforts.is_empty());
+        assert_eq!(model.default_reasoning_effort, ReasoningEffort::None);
+        assert!(model.is_default);
     }
 
     #[test]
-    fn amp_model_normalization_filters_hidden_large_mode() {
+    fn amp_model_normalization_maps_legacy_large_mode_to_ultra() {
         let mut model = test_model("large", "codex".to_string());
 
-        assert!(!normalize_model_info_for_runtime(
+        assert!(normalize_model_info_for_runtime(
             &mut model,
             "amp".to_string()
         ));
+        assert_eq!(model.id, "ultra");
+        assert_eq!(model.default_reasoning_effort, ReasoningEffort::None);
     }
 
     #[test]
@@ -3241,7 +3198,7 @@ mod tests {
 
     #[test]
     fn failed_runtime_cache_preserves_only_failed_runtime_models() {
-        let mut models = vec![test_model("smart", "amp".to_string())];
+        let mut models = vec![test_model("medium", "amp".to_string())];
         let mut seen_model_ids = models
             .iter()
             .map(|model| (model.agent_runtime_kind.clone(), model.id.clone()))
@@ -3249,7 +3206,7 @@ mod tests {
         let cached_models = vec![
             test_model("opus", "claude".to_string()),
             test_model("gpt-5.5", "codex".to_string()),
-            test_model("smart", "amp".to_string()),
+            test_model("medium", "amp".to_string()),
         ];
         let failed_runtime_kinds = HashSet::from(["claude".to_string()]);
 
@@ -3269,7 +3226,9 @@ mod tests {
         assert_eq!(
             models
                 .iter()
-                .filter(|model| model.agent_runtime_kind == "amp".to_string() && model.id == "smart")
+                .filter(
+                    |model| model.agent_runtime_kind == "amp".to_string() && model.id == "medium"
+                )
                 .count(),
             1
         );


### PR DESCRIPTION
## Motivation

Litter still projected legacy Amp modes and effort behavior. Android pairing could also crash on devices reporting no usable camera, while hard-coded DNS made `npx kittylitter` pairing unreliable.

## Solution

- Consume current Amp capabilities: `low`, `medium`, `high`, `ultra`; default `medium`; no effort override.
- Keep fallback catalogs limited to runtime failures.
- Make Android mode filtering and effort locking metadata-driven.
- Fall back to pasted pairing JSON when CameraX cannot initialize.
- Use the initialized Android resolver with embedded CA roots.

Depends on alleycat compatibility update: https://github.com/0xSero/alleycat/pull/41

## Verification

- `cargo test -p codex-mobile-client amp_`
- `./gradlew :app:testDebugUnitTest`
- USB Android pairing via `npx kittylitter pair`
- New Amp turn, same-thread continuation, and cold-restart continuation
