### PR TITLE
Fix Local Studio pairing scope and daemon release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,8 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+      - name: Verify kittylitter release version
+        run: ./tools/scripts/check-kittylitter-release-version.sh
       - name: Install dist
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0

--- a/apps/android/app/src/main/java/com/litter/android/ui/discovery/AlleycatAddServerSheet.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/discovery/AlleycatAddServerSheet.kt
@@ -98,6 +98,9 @@ enum class AlleycatPairingMode {
     LocalStudio,
 }
 
+internal fun AlleycatPairingMode.includesAgent(name: String): Boolean =
+    this != AlleycatPairingMode.LocalStudio || name == "local-studio"
+
 private const val LOG_TAG = "AlleycatSheet"
 
 @Composable
@@ -144,7 +147,10 @@ fun AlleycatAddServerSheet(
                 }
                 if (parsedParams?.nodeId == params.nodeId) {
                     agents = loaded
-                    selectedAgentNames = loaded.filter { it.available }.map { it.name }.toSet()
+                    selectedAgentNames = loaded
+                        .filter { it.available && pairingMode.includesAgent(it.name) }
+                        .map { it.name }
+                        .toSet()
                     isLoadingAgents = false
                 }
             } catch (e: Exception) {
@@ -212,7 +218,9 @@ fun AlleycatAddServerSheet(
 
     fun connect() {
         val params = parsedParams ?: return
-        val selectedAgents = agents.filter { it.available && it.name in selectedAgentNames }
+        val selectedAgents = agents.filter {
+            it.available && pairingMode.includesAgent(it.name) && it.name in selectedAgentNames
+        }
         val fallbackAgent = selectedAgents.firstOrNull() ?: return
         val trimmedDisplay = displayName.trim()
         val resolvedName = trimmedDisplay.ifEmpty { resolvedSuggestedDisplayName(params, pairingMode) }
@@ -264,10 +272,7 @@ fun AlleycatAddServerSheet(
         }
     }
 
-    // A Local Studio pairing credential grants access to the whole
-    // controller. Keep Codex and every other enabled runtime attached so
-    // their model catalogs remain available in the shared picker.
-    val availableAgents = agents.filter { it.available }
+    val availableAgents = agents.filter { it.available && pairingMode.includesAgent(it.name) }
     val selectedAgents = availableAgents.filter { it.name in selectedAgentNames }
     val canConnect =
         !isConnecting && !isLoadingAgents && parsedParams != null && selectedAgents.isNotEmpty()

--- a/apps/android/app/src/test/java/com/litter/android/ui/discovery/AlleycatPairingModeTest.kt
+++ b/apps/android/app/src/test/java/com/litter/android/ui/discovery/AlleycatPairingModeTest.kt
@@ -1,0 +1,21 @@
+package com.litter.android.ui.discovery
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AlleycatPairingModeTest {
+    @Test
+    fun localStudioModeIncludesOnlyLocalStudio() {
+        assertTrue(AlleycatPairingMode.LocalStudio.includesAgent("local-studio"))
+        assertFalse(AlleycatPairingMode.LocalStudio.includesAgent("codex"))
+        assertFalse(AlleycatPairingMode.LocalStudio.includesAgent("pi"))
+    }
+
+    @Test
+    fun kittyLitterModeIncludesEveryAgent() {
+        assertTrue(AlleycatPairingMode.Kittylitter.includesAgent("local-studio"))
+        assertTrue(AlleycatPairingMode.Kittylitter.includesAgent("codex"))
+        assertTrue(AlleycatPairingMode.Kittylitter.includesAgent("pi"))
+    }
+}

--- a/apps/ios/Litter.xcodeproj/project.pbxproj
+++ b/apps/ios/Litter.xcodeproj/project.pbxproj
@@ -174,6 +174,7 @@
 		40BE68DE19BEE162E0F2C25B /* MessageRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2325BAE1FF0D41A4D5ADE3AD /* MessageRecorder.swift */; };
 		40F262594905BCA726B1DF88 /* HomeBottomBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2A455B0E2E7C8B6EE59A93 /* HomeBottomBar.swift */; };
 		41EBAC505474E27E708900E0 /* home_cat_entrance.png in Resources */ = {isa = PBXBuildFile; fileRef = D70AE5F73F3A58B628BFC08D /* home_cat_entrance.png */; };
+		421906FCD9348DE5EA7447D2 /* AlleycatPairingModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D9B7168247D5201C4795A69 /* AlleycatPairingModeTests.swift */; };
 		421F71E305371CDE71D5A10D /* github-light.json in Resources */ = {isa = PBXBuildFile; fileRef = 760BBA087DD7F86B27829E23 /* github-light.json */; };
 		421FFC77E9CD0E243F365BBF /* HomeVoiceOrbButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592BE0CE703BB2B31738D8C2 /* HomeVoiceOrbButton.swift */; };
 		42A4C9ADE94A9529F8C009B8 /* WatchSnapshotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E180C9F641FCFD7E60D943 /* WatchSnapshotStore.swift */; };
@@ -964,6 +965,7 @@
 		89172C83E4194291FF873A88 /* houston.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = houston.json; sourceTree = "<group>"; };
 		892D583790A9BD90CFD89701 /* LockScreenCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenCardView.swift; sourceTree = "<group>"; };
 		8BE99A02238FD8184F77DD49 /* WallpaperAdjustView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallpaperAdjustView.swift; sourceTree = "<group>"; };
+		8D9B7168247D5201C4795A69 /* AlleycatPairingModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlleycatPairingModeTests.swift; sourceTree = "<group>"; };
 		8F98D2E0622F1A4DADC1E888 /* cat_transmission_01.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = cat_transmission_01.png; sourceTree = "<group>"; };
 		923C3634CB4FDDA1286DB63F /* LitterLiveActivity.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = LitterLiveActivity.entitlements; sourceTree = "<group>"; };
 		92B1669CE17E1EB46A17C610 /* kitty-litter-dark.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "kitty-litter-dark.json"; sourceTree = "<group>"; };
@@ -1230,6 +1232,7 @@
 		42471419A8813CCF74840C78 /* LitterTests */ = {
 			isa = PBXGroup;
 			children = (
+				8D9B7168247D5201C4795A69 /* AlleycatPairingModeTests.swift */,
 				49496FAE8491262D2C8CC657 /* AppSnapshotRuntimeTests.swift */,
 				F3474B8EA8D3148C94A7583F /* AppStatePermissionTests.swift */,
 				33402D8F29D5CAA2DD07ED9F /* ChatGPTOAuthTests.swift */,
@@ -2246,6 +2249,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				421906FCD9348DE5EA7447D2 /* AlleycatPairingModeTests.swift in Sources */,
 				D24451D266FD2443C0D7CBC4 /* AppSnapshotRuntimeTests.swift in Sources */,
 				620FC2343DCFADD1034E9CCB /* AppStatePermissionTests.swift in Sources */,
 				46C5F0B53F9EF54FE8F311A4 /* ChatGPTOAuthTests.swift in Sources */,

--- a/apps/ios/Sources/Litter/Views/AlleycatAddServerSheet.swift
+++ b/apps/ios/Sources/Litter/Views/AlleycatAddServerSheet.swift
@@ -32,6 +32,10 @@ enum AlleycatPairingMode: String, Equatable, Identifiable {
             "In Local Studio, open Profile → Phone connection. Scan its QR code or paste Copy connection JSON."
         }
     }
+
+    func includesAgent(named name: String) -> Bool {
+        self != .localStudio || name == "local-studio"
+    }
 }
 
 struct AlleycatAddServerSheet: View {
@@ -377,10 +381,7 @@ struct AlleycatAddServerSheet: View {
     }
 
     private var availableAgents: [AppAlleycatAgentInfo] {
-        // A Local Studio pairing credential grants access to the whole
-        // controller. Keep Codex and every other enabled runtime attached so
-        // their model catalogs remain available in the shared picker.
-        agents.filter(\.available)
+        agents.filter { $0.available && pairingMode.includesAgent(named: $0.name) }
     }
 
     private var selectedAgents: [AppAlleycatAgentInfo] {
@@ -432,7 +433,9 @@ struct AlleycatAddServerSheet: View {
                     guard parsedParams?.nodeId == params.nodeId else { return }
                     agents = loaded
                     selectedAgentNames = Set(
-                        loaded.filter(\.available).map(\.name)
+                        loaded
+                            .filter { $0.available && pairingMode.includesAgent(named: $0.name) }
+                            .map(\.name)
                     )
                     isLoadingAgents = false
                     agentError = nil

--- a/apps/ios/Tests/LitterTests/AlleycatPairingModeTests.swift
+++ b/apps/ios/Tests/LitterTests/AlleycatPairingModeTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import Litter
+
+final class AlleycatPairingModeTests: XCTestCase {
+    func testLocalStudioModeIncludesOnlyLocalStudio() {
+        XCTAssertTrue(AlleycatPairingMode.localStudio.includesAgent(named: "local-studio"))
+        XCTAssertFalse(AlleycatPairingMode.localStudio.includesAgent(named: "codex"))
+        XCTAssertFalse(AlleycatPairingMode.localStudio.includesAgent(named: "pi"))
+    }
+
+    func testKittyLitterModeIncludesEveryAgent() {
+        XCTAssertTrue(AlleycatPairingMode.kittylitter.includesAgent(named: "local-studio"))
+        XCTAssertTrue(AlleycatPairingMode.kittylitter.includesAgent(named: "codex"))
+        XCTAssertTrue(AlleycatPairingMode.kittylitter.includesAgent(named: "pi"))
+    }
+}

--- a/services/kittylitter/Cargo.lock
+++ b/services/kittylitter/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "kittylitter"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "alleycat",
  "anyhow",

--- a/services/kittylitter/Cargo.toml
+++ b/services/kittylitter/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "kittylitter"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 license = "GPL-3.0-only"
 authors = ["The Alleycat Authors"]

--- a/shared/rust-bridge/codex-mobile-client/src/mobile_client/mod.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/mobile_client/mod.rs
@@ -702,8 +702,19 @@ fn alleycat_requested_runtime_kinds(
         .collect()
 }
 
-fn local_studio_controller_uses_all_agents(server_id: &str) -> bool {
+fn is_local_studio_controller(server_id: &str) -> bool {
     server_id.starts_with("alleycat:local-studio:")
+}
+
+fn alleycat_agent_is_requested(
+    local_studio_controller: bool,
+    selected_agent_names: &HashSet<String>,
+    agent_name: &str,
+) -> bool {
+    if local_studio_controller {
+        return agent_name == "local-studio";
+    }
+    selected_agent_names.is_empty() || selected_agent_names.contains(agent_name)
 }
 
 fn merge_alleycat_agent_inventory(
@@ -1815,35 +1826,32 @@ impl MobileClient {
             "MobileClient: connect_remote_over_alleycat start server_id={} node_id={} agent={} selected_agents={:?} wire={:?}",
             server_id, params.node_id, agent_name, selected_agent_names, wire
         );
-        // Local Studio's phone credential authorizes the whole controller,
-        // and its mobile surface is expected to expose every enabled runtime
-        // (including Codex). Older clients persisted only `local-studio` here,
-        // so expand these saved connections during reconnect as well as on a
-        // fresh pair instead of permanently hiding the other model catalogs.
-        let use_all_controller_agents = local_studio_controller_uses_all_agents(&server_id);
+        let local_studio_controller = is_local_studio_controller(&server_id);
         let selected_agent_names = selected_agent_names
             .into_iter()
             .map(|name| name.trim().to_string())
             .filter(|name| !name.is_empty())
             .collect::<Vec<_>>();
-        let selected_agent_intent = selected_agent_names.join(",");
+        let selected_agent_intent = if local_studio_controller {
+            "local-studio".to_string()
+        } else {
+            selected_agent_names.join(",")
+        };
         let selected_agent_names = selected_agent_names
             .into_iter()
             .collect::<std::collections::HashSet<_>>();
-        // Local Studio can answer before its Pi/Codex bridges have registered.
-        // Stabilize the same inventory used by the pairing scanner and connect
-        // path so an empty first probe cannot permanently hide those agents.
         let agent_inventory = self
-            .list_alleycat_agents(params.clone(), use_all_controller_agents)
+            .list_alleycat_agents(params.clone(), local_studio_controller)
             .await?;
         let mut seen_runtime_kinds = std::collections::HashSet::new();
         let requested_agents = agent_inventory
             .into_iter()
             .filter_map(|agent| {
-                if !use_all_controller_agents
-                    && !selected_agent_names.is_empty()
-                    && !selected_agent_names.contains(&agent.name)
-                {
+                if !alleycat_agent_is_requested(
+                    local_studio_controller,
+                    &selected_agent_names,
+                    &agent.name,
+                ) {
                     return None;
                 }
                 let runtime_kind =
@@ -1855,22 +1863,29 @@ impl MobileClient {
             })
             .collect::<Vec<_>>();
         let runtime_agents = if requested_agents.is_empty() {
-            if !use_all_controller_agents
-                && !selected_agent_names.is_empty()
-                && !selected_agent_names.contains(&agent_name)
-            {
+            let fallback_agent_name = if local_studio_controller {
+                "local-studio".to_string()
+            } else {
+                agent_name.clone()
+            };
+            if !alleycat_agent_is_requested(
+                local_studio_controller,
+                &selected_agent_names,
+                &fallback_agent_name,
+            ) {
                 self.app_store
                     .update_server_health(server_id.as_str(), ServerHealthSnapshot::Disconnected);
                 return Err(TransportError::ConnectionFailed(
                     "no selected Alleycat runtime streams are available".to_string(),
                 ));
             }
-            let runtime_kind = crate::alleycat::agent_runtime_kind(&agent_name, &agent_name)
-                .unwrap_or("codex".to_string());
+            let runtime_kind =
+                crate::alleycat::agent_runtime_kind(&fallback_agent_name, &fallback_agent_name)
+                    .unwrap_or("codex".to_string());
             vec![(
                 runtime_kind,
                 AlleycatAgentInfo {
-                    name: agent_name.clone(),
+                    name: fallback_agent_name,
                     display_name: display_name.clone(),
                     wire,
                     available: true,
@@ -1883,8 +1898,7 @@ impl MobileClient {
         };
         let requested_runtime_kinds = alleycat_requested_runtime_kinds(&runtime_agents);
         let requested_agent_names = alleycat_runtime_agent_names(&runtime_agents);
-        let persisted_agent_names = if use_all_controller_agents || selected_agent_intent.is_empty()
-        {
+        let persisted_agent_names = if selected_agent_intent.is_empty() {
             requested_agent_names.clone()
         } else {
             selected_agent_intent
@@ -1971,7 +1985,7 @@ impl MobileClient {
             }
         };
 
-        let dial_retry_delays = alleycat_dial_retry_delays(use_all_controller_agents);
+        let dial_retry_delays = alleycat_dial_retry_delays(local_studio_controller);
         let dial_tasks = runtime_agents.into_iter().map(|(runtime_kind, agent)| {
             let reconnect_transport = AlleycatReconnectTransport::new(
                 params.clone(),
@@ -2042,7 +2056,7 @@ impl MobileClient {
                 "no available Alleycat runtime streams connected".to_string(),
             ));
         }
-        if use_all_controller_agents {
+        if local_studio_controller {
             let connected_runtime_kinds = runtime_resources
                 .iter()
                 .map(|resource| resource.runtime_kind.clone())
@@ -2050,13 +2064,13 @@ impl MobileClient {
             let missing = missing_runtime_kinds(&connected_runtime_kinds, &requested_runtime_kinds);
             if !missing.is_empty() {
                 warn!(
-                    "MobileClient: refusing partial Local Studio controller session server_id={} missing_runtimes={:?}",
+                    "MobileClient: refusing incomplete Local Studio session server_id={} missing_runtimes={:?}",
                     server_id, missing
                 );
                 self.app_store
                     .update_server_health(server_id.as_str(), ServerHealthSnapshot::Disconnected);
                 return Err(TransportError::ConnectionFailed(format!(
-                    "Local Studio controller did not connect every advertised runtime: {}",
+                    "Local Studio did not connect its advertised runtime: {}",
                     missing.join(", ")
                 )));
             }

--- a/shared/rust-bridge/codex-mobile-client/src/mobile_client/tests.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/mobile_client/tests.rs
@@ -474,13 +474,31 @@ mod mobile_client_tests {
     }
 
     #[test]
-    fn local_studio_controller_connections_expand_legacy_agent_selection() {
-        assert!(local_studio_controller_uses_all_agents(
+    fn local_studio_controller_connections_preserve_local_studio_scope() {
+        assert!(is_local_studio_controller(
             "alleycat:local-studio:controller-node"
         ));
-        assert!(!local_studio_controller_uses_all_agents(
-            "alleycat:controller-node"
+        assert!(!is_local_studio_controller("alleycat:controller-node"));
+        let all_agents = HashSet::from([
+            "local-studio".to_string(),
+            "codex".to_string(),
+            "pi".to_string(),
+        ]);
+        assert!(alleycat_agent_is_requested(
+            true,
+            &all_agents,
+            "local-studio"
         ));
+        assert!(!alleycat_agent_is_requested(true, &all_agents, "codex"));
+        assert!(!alleycat_agent_is_requested(true, &all_agents, "pi"));
+        assert!(alleycat_agent_is_requested(
+            false,
+            &all_agents,
+            "local-studio"
+        ));
+        assert!(alleycat_agent_is_requested(false, &all_agents, "codex"));
+        assert!(alleycat_agent_is_requested(false, &all_agents, "pi"));
+        assert!(alleycat_agent_is_requested(false, &HashSet::new(), "codex"));
         assert_eq!(
             alleycat_inventory_refresh_delays(true),
             ALLEYCAT_AGENT_INVENTORY_REFRESH_DELAYS_MS

--- a/tools/scripts/check-kittylitter-release-version.sh
+++ b/tools/scripts/check-kittylitter-release-version.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+manifest="services/kittylitter/Cargo.toml"
+version=$(awk -F'"' '/^version/ { print $2; exit }' "$manifest")
+
+if [[ -z "$version" ]]; then
+  echo "could not parse kittylitter version from $manifest" >&2
+  exit 1
+fi
+
+tag="v$version"
+if ! git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+  exit 0
+fi
+
+git fetch --no-tags origin "refs/tags/$tag:refs/tags/$tag"
+if git diff --quiet "$tag" -- services/kittylitter; then
+  exit 0
+fi
+
+echo "kittylitter source changed after $tag was released; bump the package version" >&2
+exit 1


### PR DESCRIPTION
## What changed
- restrict the Local Studio pairing tab to the `local-studio` agent on iOS, Android, and saved reconnects
- keep the KittyLitter pairing path on the full available agent catalog, including `local-studio`
- bump kittylitter to 0.3.5 so current Local Studio provider support is published
- fail release builds when daemon source changes without a version bump

## Verification
- iOS focused XCTest: `AlleycatPairingModeTests`
- Android focused unit test: `AlleycatPairingModeTest`
- shared Rust scope/reconnect regression assertions added
- release daemon built in release mode and reported `kittylitter 0.3.5`
- release-version guard passes for unreleased 0.3.5
- `git diff --check`