### PR TITLE
ios: persist TestFlight beta metadata

### DIFF
--- a/.github/workflows/ios-testflight-finalize.yml
+++ b/.github/workflows/ios-testflight-finalize.yml
@@ -1,0 +1,76 @@
+name: iOS TestFlight Finalize
+
+on:
+  workflow_dispatch:
+    inputs:
+      marketing_version:
+        description: "Existing TestFlight marketing version"
+        required: true
+        type: string
+      build_number:
+        description: "Existing TestFlight build number"
+        required: true
+        type: string
+      beta_group_names:
+        description: "Comma-separated TestFlight beta groups"
+        required: false
+        default: "Internal Testers,Beta Testers"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  finalize-testflight:
+    runs-on: macos-26
+    timeout-minutes: 15
+    environment: release
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate required secrets
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY_P8_B64: ${{ secrets.ASC_PRIVATE_KEY_P8_B64 }}
+          IOS_APP_STORE_APP_ID: ${{ secrets.IOS_APP_STORE_APP_ID }}
+        run: |
+          set -euo pipefail
+          required=(ASC_KEY_ID ASC_ISSUER_ID ASC_PRIVATE_KEY_P8_B64 IOS_APP_STORE_APP_ID)
+          for name in "${required[@]}"; do
+            if [[ -z "${!name:-}" ]]; then
+              echo "Missing required secret: $name" >&2
+              exit 1
+            fi
+          done
+
+      - name: Install dependencies
+        run: |
+          brew install jq
+          HOMEBREW_NO_AUTO_UPDATE=0 brew install asc
+
+      - name: Decode App Store Connect API key
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_PRIVATE_KEY_P8_B64: ${{ secrets.ASC_PRIVATE_KEY_P8_B64 }}
+        run: |
+          set -euo pipefail
+          ASC_KEY_PATH="$RUNNER_TEMP/AuthKey_${ASC_KEY_ID}.p8"
+          echo "$ASC_PRIVATE_KEY_P8_B64" | base64 --decode > "$ASC_KEY_PATH"
+          chmod 600 "$ASC_KEY_PATH"
+          echo "ASC_PRIVATE_KEY_PATH=$ASC_KEY_PATH" >> "$GITHUB_ENV"
+
+      - name: Finalize existing TestFlight build
+        env:
+          APP_STORE_APP_ID: ${{ secrets.IOS_APP_STORE_APP_ID }}
+          MARKETING_VERSION: ${{ inputs.marketing_version }}
+          BUILD_NUMBER: ${{ inputs.build_number }}
+          BETA_GROUP_NAMES: ${{ inputs.beta_group_names }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY_PATH: ${{ env.ASC_PRIVATE_KEY_PATH }}
+        run: ./apps/ios/scripts/testflight-finalize.sh

--- a/apps/ios/scripts/release-common.sh
+++ b/apps/ios/scripts/release-common.sh
@@ -5,6 +5,7 @@ IOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 ROOT_DIR="$(cd "$IOS_DIR/../.." && pwd)"
 IOS_PROJECT_YML="${IOS_PROJECT_YML:-$IOS_DIR/project.yml}"
 TESTFLIGHT_WHATS_NEW_FILE="${TESTFLIGHT_WHATS_NEW_FILE:-$ROOT_DIR/docs/releases/testflight-whats-new.md}"
+TESTFLIGHT_BETA_DESCRIPTION_FILE="${TESTFLIGHT_BETA_DESCRIPTION_FILE:-$ROOT_DIR/docs/releases/testflight-beta-description.txt}"
 FASTLANE_DIR="${FASTLANE_DIR:-$IOS_DIR/fastlane}"
 
 require_cmd() {

--- a/apps/ios/scripts/testflight-finalize.sh
+++ b/apps/ios/scripts/testflight-finalize.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=release-common.sh
+source "$SCRIPT_DIR/release-common.sh"
+
+APP_BUNDLE_ID="${APP_BUNDLE_ID:-com.sigkitten.litter}"
+APP_STORE_APP_ID="${APP_STORE_APP_ID:-}"
+MARKETING_VERSION="${MARKETING_VERSION:-}"
+BUILD_NUMBER="${BUILD_NUMBER:-}"
+BUILD_ID="${BUILD_ID:-}"
+INTERNAL_BETA_GROUP_NAME="${INTERNAL_BETA_GROUP_NAME:-Internal Testers}"
+BETA_GROUP_NAMES="${BETA_GROUP_NAMES:-$INTERNAL_BETA_GROUP_NAME,Beta Testers}"
+ASSIGN_BETA_GROUP="${ASSIGN_BETA_GROUP:-1}"
+SUBMIT_BETA_REVIEW="${SUBMIT_BETA_REVIEW:-1}"
+BUILD_POLL_TIMEOUT_SECONDS="${BUILD_POLL_TIMEOUT_SECONDS:-900}"
+BUILD_POLL_INTERVAL_SECONDS="${BUILD_POLL_INTERVAL_SECONDS:-15}"
+WHAT_TO_TEST="${WHAT_TO_TEST:-}"
+WHAT_TO_TEST_LOCALE="${WHAT_TO_TEST_LOCALE:-en-US}"
+WHAT_TO_TEST_FILE="${WHAT_TO_TEST_FILE:-$TESTFLIGHT_WHATS_NEW_FILE}"
+BETA_APP_DESCRIPTION="${BETA_APP_DESCRIPTION:-}"
+BETA_APP_DESCRIPTION_LOCALE="${BETA_APP_DESCRIPTION_LOCALE:-en-US}"
+BETA_APP_DESCRIPTION_FILE="${BETA_APP_DESCRIPTION_FILE:-$TESTFLIGHT_BETA_DESCRIPTION_FILE}"
+
+require_cmd asc
+require_cmd jq
+
+APP_STORE_APP_ID="$(resolve_app_store_app_id "$APP_STORE_APP_ID" "$APP_BUNDLE_ID")"
+
+if [[ -z "$BUILD_ID" ]]; then
+    if [[ -z "$MARKETING_VERSION" || -z "$BUILD_NUMBER" ]]; then
+        echo "MARKETING_VERSION and BUILD_NUMBER are required when BUILD_ID is not set." >&2
+        exit 1
+    fi
+    BUILD_ID="$(find_build_id "$APP_STORE_APP_ID" "$MARKETING_VERSION" "$BUILD_NUMBER" 50)"
+fi
+if [[ -z "$BUILD_ID" ]]; then
+    echo "Unable to find TestFlight build $MARKETING_VERSION / $BUILD_NUMBER." >&2
+    exit 1
+fi
+
+if [[ -z "$BETA_APP_DESCRIPTION" && -f "$BETA_APP_DESCRIPTION_FILE" ]]; then
+    BETA_APP_DESCRIPTION="$(cat "$BETA_APP_DESCRIPTION_FILE")"
+fi
+if [[ -z "$(trim "$BETA_APP_DESCRIPTION")" ]]; then
+    echo "Missing TestFlight Beta App Description." >&2
+    echo "Set BETA_APP_DESCRIPTION, or populate $BETA_APP_DESCRIPTION_FILE." >&2
+    exit 1
+fi
+
+localization_id="$(
+    asc testflight app-localizations list \
+        --app "$APP_STORE_APP_ID" \
+        --locale "$BETA_APP_DESCRIPTION_LOCALE" \
+        --output json |
+        jq -r --arg locale "$BETA_APP_DESCRIPTION_LOCALE" \
+            '.data[]? | select(.attributes.locale == $locale) | .id' |
+        head -n 1
+)"
+if [[ -n "$localization_id" ]]; then
+    echo "==> Updating TestFlight Beta App Description ($BETA_APP_DESCRIPTION_LOCALE)"
+    asc testflight app-localizations update \
+        --id "$localization_id" \
+        --description "$BETA_APP_DESCRIPTION" \
+        --output json >/dev/null
+else
+    echo "==> Creating TestFlight Beta App Description ($BETA_APP_DESCRIPTION_LOCALE)"
+    asc testflight app-localizations create \
+        --app "$APP_STORE_APP_ID" \
+        --locale "$BETA_APP_DESCRIPTION_LOCALE" \
+        --description "$BETA_APP_DESCRIPTION" \
+        --output json >/dev/null
+fi
+
+if [[ -z "$WHAT_TO_TEST" && -f "$WHAT_TO_TEST_FILE" ]]; then
+    WHAT_TO_TEST="$(cat "$WHAT_TO_TEST_FILE")"
+fi
+if [[ -z "$(trim "$WHAT_TO_TEST")" ]]; then
+    echo "Missing TestFlight changelog (What to Test)." >&2
+    echo "Set WHAT_TO_TEST, or populate $WHAT_TO_TEST_FILE." >&2
+    exit 1
+fi
+
+echo "==> Ensuring What to Test notes are set for $WHAT_TO_TEST_LOCALE"
+if ! asc builds test-notes update \
+        --build-id "$BUILD_ID" \
+        --locale "$WHAT_TO_TEST_LOCALE" \
+        --whats-new "$WHAT_TO_TEST" \
+        --output json >/dev/null 2>&1; then
+    asc builds test-notes create \
+        --build-id "$BUILD_ID" \
+        --locale "$WHAT_TO_TEST_LOCALE" \
+        --whats-new "$WHAT_TO_TEST" \
+        --output json >/dev/null
+fi
+
+external_group_requested=0
+if [[ "$ASSIGN_BETA_GROUP" == "1" ]]; then
+    beta_group_ids=()
+    groups_json="$(asc testflight groups list --app "$APP_STORE_APP_ID" --output json)"
+    IFS=',' read -r -a requested_group_names <<<"$BETA_GROUP_NAMES"
+    for raw_group_name in "${requested_group_names[@]}"; do
+        group_name="$(trim "$raw_group_name")"
+        [[ -n "$group_name" ]] || continue
+
+        beta_group_id="$(
+            jq -r --arg name "$group_name" \
+                '.data[]? | select(.attributes.name == $name) | .id' <<<"$groups_json" |
+                head -n 1
+        )"
+        if [[ -z "$beta_group_id" ]]; then
+            create_cmd=(
+                asc testflight groups create
+                --app "$APP_STORE_APP_ID"
+                --name "$group_name"
+                --output json
+            )
+            if [[ "$group_name" == "$INTERNAL_BETA_GROUP_NAME" ]]; then
+                create_cmd+=(--internal)
+            else
+                external_group_requested=1
+            fi
+            beta_group_id="$("${create_cmd[@]}" | jq -r '.data.id // empty')"
+        elif [[ "$group_name" != "$INTERNAL_BETA_GROUP_NAME" ]]; then
+            external_group_requested=1
+        fi
+
+        if [[ -n "$beta_group_id" ]]; then
+            beta_group_ids+=("$beta_group_id")
+        fi
+    done
+
+    if [[ "${#beta_group_ids[@]}" -eq 0 ]]; then
+        echo "No TestFlight beta groups resolved from: $BETA_GROUP_NAMES" >&2
+        exit 1
+    fi
+
+    group_csv="$(IFS=,; printf '%s' "${beta_group_ids[*]}")"
+    echo "==> Assigning build $BUILD_ID to beta groups: $BETA_GROUP_NAMES"
+    deadline="$(( $(date +%s) + BUILD_POLL_TIMEOUT_SECONDS ))"
+    assigned=0
+    while [[ "$(date +%s)" -lt "$deadline" ]]; do
+        if asc builds add-groups \
+                --build-id "$BUILD_ID" \
+                --group "$group_csv" \
+                --output json >/dev/null 2>&1; then
+            assigned=1
+            break
+        fi
+        sleep "$BUILD_POLL_INTERVAL_SECONDS"
+    done
+    if [[ "$assigned" -ne 1 ]]; then
+        echo "Failed to assign build $BUILD_ID to beta groups '$BETA_GROUP_NAMES' within timeout." >&2
+        exit 1
+    fi
+fi
+
+echo "==> Validating TestFlight readiness"
+asc validate testflight \
+    --app "$APP_STORE_APP_ID" \
+    --build "$BUILD_ID" \
+    --strict \
+    --output json >/dev/null
+
+if [[ "$ASSIGN_BETA_GROUP" == "1" && "$SUBMIT_BETA_REVIEW" == "1" && "$external_group_requested" -eq 1 ]]; then
+    submission_id="$(
+        asc testflight review submissions list --build-id "$BUILD_ID" --output json |
+            jq -r '.data[0].id // empty'
+    )"
+    if [[ -n "$submission_id" ]]; then
+        echo "==> Beta App Review submission already exists: $submission_id"
+    else
+        echo "==> Submitting build $BUILD_ID for Beta App Review"
+        asc testflight review submit --build-id "$BUILD_ID" --confirm --output json >/dev/null
+    fi
+fi
+
+echo "==> TestFlight build finalized"
+echo "    App ID:       $APP_STORE_APP_ID"
+echo "    Version:      $MARKETING_VERSION"
+echo "    Build:        $BUILD_NUMBER"
+echo "    Build record: $BUILD_ID"

--- a/apps/ios/scripts/testflight-upload.sh
+++ b/apps/ios/scripts/testflight-upload.sh
@@ -366,89 +366,20 @@ if [[ -n "$build_id" && "$AUTO_ASSIGN_ENCRYPTION_DECLARATION" == "1" ]]; then
     fi
 fi
 
-if [[ -n "$build_id" && -n "$WHAT_TO_TEST" ]]; then
-    echo "==> Ensuring What to Test notes are set for $WHAT_TO_TEST_LOCALE"
-    # Try update first (works if localization already exists), fall back to create.
-    if ! asc builds test-notes update \
-            --build-id "$build_id" \
-            --locale "$WHAT_TO_TEST_LOCALE" \
-            --whats-new "$WHAT_TO_TEST" \
-            --output json >/dev/null 2>&1; then
-        asc builds test-notes create \
-            --build-id "$build_id" \
-            --locale "$WHAT_TO_TEST_LOCALE" \
-            --whats-new "$WHAT_TO_TEST" \
-            --output json >/dev/null
-    fi
-fi
-
-if [[ "$ASSIGN_BETA_GROUP" == "1" && -n "$build_id" ]]; then
-    beta_group_ids=()
-    external_group_requested=0
-
-    IFS=',' read -r -a requested_group_names <<<"$BETA_GROUP_NAMES"
-    for raw_group_name in "${requested_group_names[@]}"; do
-        group_name="$(trim "$raw_group_name")"
-        [[ -n "$group_name" ]] || continue
-
-        beta_group_id="$(
-            asc testflight groups list --app "$APP_STORE_APP_ID" --output json |
-                jq -r --arg name "$group_name" '.data[] | select(.attributes.name == $name) | .id' |
-                head -n 1
-        )"
-
-        if [[ -z "$beta_group_id" ]]; then
-            create_cmd=(
-                asc testflight groups create
-                --app "$APP_STORE_APP_ID"
-                --name "$group_name"
-                --output json
-            )
-            if [[ "$group_name" == "$INTERNAL_BETA_GROUP_NAME" ]]; then
-                create_cmd+=(--internal)
-            else
-                external_group_requested=1
-            fi
-            beta_group_id="$(
-                "${create_cmd[@]}" |
-                    jq -r '.data.id // empty'
-            )"
-        elif [[ "$group_name" != "$INTERNAL_BETA_GROUP_NAME" ]]; then
-            external_group_requested=1
-        fi
-
-        if [[ -n "$beta_group_id" ]]; then
-            beta_group_ids+=("$beta_group_id")
-        fi
-    done
-
-    if [[ "${#beta_group_ids[@]}" -gt 0 ]]; then
-        group_csv="$(IFS=,; printf '%s' "${beta_group_ids[*]}")"
-        echo "==> Assigning build $build_id to beta groups: $BETA_GROUP_NAMES"
-        deadline="$(( $(date +%s) + BUILD_POLL_TIMEOUT_SECONDS ))"
-        assigned=0
-        while [[ "$(date +%s)" -lt "$deadline" ]]; do
-            if asc builds add-groups --build-id "$build_id" --group "$group_csv" --output json >/dev/null 2>&1; then
-                assigned=1
-                break
-            fi
-            sleep "$BUILD_POLL_INTERVAL_SECONDS"
-        done
-        if [[ "$assigned" -ne 1 ]]; then
-            echo "Failed to assign build $build_id to beta groups '$BETA_GROUP_NAMES' within timeout." >&2
-            exit 1
-        fi
-
-        if [[ "$SUBMIT_BETA_REVIEW" == "1" && "$external_group_requested" -eq 1 ]]; then
-            echo "==> Submitting build $build_id for Beta App Review"
-            asc testflight review submit --build-id "$build_id" --confirm --output json >/dev/null
-        fi
-    fi
-fi
-
 if [[ -n "$build_id" ]]; then
-    echo "==> Validating TestFlight readiness"
-    asc validate testflight --app "$APP_STORE_APP_ID" --build "$build_id" --strict --output json >/dev/null
+    BUILD_ID="$build_id" \
+    APP_STORE_APP_ID="$APP_STORE_APP_ID" \
+    MARKETING_VERSION="$MARKETING_VERSION" \
+    BUILD_NUMBER="$BUILD_NUMBER" \
+    INTERNAL_BETA_GROUP_NAME="$INTERNAL_BETA_GROUP_NAME" \
+    BETA_GROUP_NAMES="$BETA_GROUP_NAMES" \
+    ASSIGN_BETA_GROUP="$ASSIGN_BETA_GROUP" \
+    SUBMIT_BETA_REVIEW="$SUBMIT_BETA_REVIEW" \
+    BUILD_POLL_TIMEOUT_SECONDS="$BUILD_POLL_TIMEOUT_SECONDS" \
+    BUILD_POLL_INTERVAL_SECONDS="$BUILD_POLL_INTERVAL_SECONDS" \
+    WHAT_TO_TEST="$WHAT_TO_TEST" \
+    WHAT_TO_TEST_LOCALE="$WHAT_TO_TEST_LOCALE" \
+    "$SCRIPT_DIR/testflight-finalize.sh"
 fi
 
 if [[ "$PROJECT_VERSION_BUMP_REQUIRED" == "1" ]]; then

--- a/apps/ios/scripts/tests/testflight-finalize.test.sh
+++ b/apps/ios/scripts/tests/testflight-finalize.test.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FINALIZE_SCRIPT="$(cd "$SCRIPT_DIR/.." && pwd)/testflight-finalize.sh"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/testflight-finalize.XXXXXX")"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+mkdir -p "$TEST_ROOT/bin"
+cat >"$TEST_ROOT/bin/asc" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$MOCK_ASC_LOG"
+
+case "$1:$2:${3:-}" in
+    builds:list:--app)
+        printf '%s\n' '{"data":[{"id":"build-1","attributes":{"version":"200000258"}}]}'
+        ;;
+    testflight:app-localizations:list)
+        if [[ "${MOCK_LOCALIZATION_EXISTS:-0}" == "1" ]]; then
+            printf '%s\n' '{"data":[{"id":"localization-1","attributes":{"locale":"en-US"}}]}'
+        else
+            printf '%s\n' '{"data":[]}'
+        fi
+        ;;
+    testflight:app-localizations:create|testflight:app-localizations:update)
+        printf '%s\n' '{"data":{"id":"localization-1"}}'
+        ;;
+    builds:test-notes:update)
+        if [[ "${MOCK_NOTE_UPDATE_FAILS:-0}" == "1" ]]; then
+            exit 1
+        fi
+        printf '%s\n' '{"data":{"id":"note-1"}}'
+        ;;
+    builds:test-notes:create)
+        printf '%s\n' '{"data":{"id":"note-1"}}'
+        ;;
+    testflight:groups:list)
+        printf '%s\n' '{"data":[{"id":"internal-1","attributes":{"name":"Internal Testers"}},{"id":"external-1","attributes":{"name":"Beta Testers"}}]}'
+        ;;
+    builds:add-groups:--build-id)
+        printf '%s\n' '{"data":[]}'
+        ;;
+    validate:testflight:--app)
+        printf '%s\n' '{"valid":true}'
+        ;;
+    testflight:review:submissions)
+        if [[ "${MOCK_SUBMISSION_EXISTS:-0}" == "1" ]]; then
+            printf '%s\n' '{"data":[{"id":"submission-1"}]}'
+        else
+            printf '%s\n' '{"data":[]}'
+        fi
+        ;;
+    testflight:review:submit)
+        printf '%s\n' '{"data":{"id":"submission-1"}}'
+        ;;
+    *)
+        echo "Unexpected asc invocation: $*" >&2
+        exit 1
+        ;;
+esac
+EOF
+chmod +x "$TEST_ROOT/bin/asc"
+
+printf '%s\n' 'A durable beta description.' > "$TEST_ROOT/beta-description.txt"
+printf '%s\n' 'Exercise pairing, streaming, reasoning, and tool calls.' > "$TEST_ROOT/whats-new.md"
+
+run_finalize() {
+    PATH="$TEST_ROOT/bin:$PATH" \
+    APP_STORE_APP_ID="123456789" \
+    MARKETING_VERSION="1.7.0" \
+    BUILD_NUMBER="200000258" \
+    BETA_GROUP_NAMES="Internal Testers,Beta Testers" \
+    BETA_APP_DESCRIPTION_FILE="$TEST_ROOT/beta-description.txt" \
+    WHAT_TO_TEST_FILE="$TEST_ROOT/whats-new.md" \
+    BUILD_POLL_INTERVAL_SECONDS="0" \
+    BUILD_POLL_TIMEOUT_SECONDS="5" \
+    MOCK_ASC_LOG="$MOCK_ASC_LOG" \
+    MOCK_LOCALIZATION_EXISTS="${MOCK_LOCALIZATION_EXISTS:-0}" \
+    MOCK_NOTE_UPDATE_FAILS="${MOCK_NOTE_UPDATE_FAILS:-0}" \
+    MOCK_SUBMISSION_EXISTS="${MOCK_SUBMISSION_EXISTS:-0}" \
+    ASSIGN_BETA_GROUP="${ASSIGN_BETA_GROUP:-1}" \
+    "$FINALIZE_SCRIPT"
+}
+
+MOCK_ASC_LOG="$TEST_ROOT/create.log"
+MOCK_LOCALIZATION_EXISTS=0
+MOCK_NOTE_UPDATE_FAILS=1
+MOCK_SUBMISSION_EXISTS=0
+ASSIGN_BETA_GROUP=1
+run_finalize
+grep -q 'testflight app-localizations create' "$MOCK_ASC_LOG"
+grep -q 'builds test-notes create' "$MOCK_ASC_LOG"
+grep -q 'testflight review submit' "$MOCK_ASC_LOG"
+grep -q 'validate testflight' "$MOCK_ASC_LOG"
+
+MOCK_ASC_LOG="$TEST_ROOT/update.log"
+MOCK_LOCALIZATION_EXISTS=1
+MOCK_NOTE_UPDATE_FAILS=0
+MOCK_SUBMISSION_EXISTS=1
+run_finalize
+grep -q 'testflight app-localizations update' "$MOCK_ASC_LOG"
+grep -q 'builds test-notes update' "$MOCK_ASC_LOG"
+if grep -q 'testflight review submit' "$MOCK_ASC_LOG"; then
+    echo "Existing Beta App Review submission was submitted twice." >&2
+    exit 1
+fi
+
+MOCK_ASC_LOG="$TEST_ROOT/metadata-only.log"
+MOCK_LOCALIZATION_EXISTS=1
+MOCK_NOTE_UPDATE_FAILS=0
+MOCK_SUBMISSION_EXISTS=0
+ASSIGN_BETA_GROUP=0
+run_finalize
+grep -q 'testflight app-localizations update' "$MOCK_ASC_LOG"
+grep -q 'builds test-notes update' "$MOCK_ASC_LOG"
+grep -q 'validate testflight' "$MOCK_ASC_LOG"
+if grep -Eq 'testflight groups|builds add-groups|testflight review' "$MOCK_ASC_LOG"; then
+    echo "Metadata-only finalization changed TestFlight groups or review state." >&2
+    exit 1
+fi
+
+echo "testflight-finalize tests passed"

--- a/docs/releases/ios-testflight-checklist.md
+++ b/docs/releases/ios-testflight-checklist.md
@@ -21,9 +21,14 @@ credentials therefore fail before the expensive iOS build.
 1. Confirm `apps/ios/project.yml` bundle ID/version/build settings are correct.
 2. Build/archive in Xcode from `apps/ios/Litter.xcodeproj`.
 3. Update `docs/releases/testflight-whats-new.md` with changelog bullets for this build.
-4. Upload via `./apps/ios/scripts/testflight-upload.sh` (script auto-applies What to Test notes, assigns internal and external beta groups, submits Beta App Review by default, and auto-bumps to the next patch version if the committed repo version has already shipped live).
-5. Validate processing in App Store Connect.
-6. Confirm the build is attached to both internal and external TestFlight groups.
-7. Confirm Beta App Review submission/approval state for the external build, then verify release notes and tester instructions.
-8. If the workflow advanced to a new beta patch version, confirm `apps/ios/project.yml` and `docs/releases/testflight-whats-new.md` were updated for the next cycle.
-9. Smoke test install + login/session/message flow.
+4. Keep `docs/releases/testflight-beta-description.txt` populated with the evergreen Beta App Description.
+5. Upload via `./apps/ios/scripts/testflight-upload.sh` (script auto-applies the Beta App Description and What to Test notes, assigns internal and external beta groups, submits Beta App Review by default, and auto-bumps to the next patch version if the committed repo version has already shipped live).
+6. Validate processing in App Store Connect.
+7. Confirm the build is attached to both internal and external TestFlight groups.
+8. Confirm Beta App Review submission/approval state for the external build, then verify release notes and tester instructions.
+9. If the workflow advanced to a new beta patch version, confirm `apps/ios/project.yml` and `docs/releases/testflight-whats-new.md` were updated for the next cycle.
+10. Smoke test install + login/session/message flow.
+
+If upload succeeds but metadata or review submission fails, rerun only the
+finalization stage with the `iOS TestFlight Finalize` workflow and the existing
+marketing version/build number. Do not rebuild the IPA.

--- a/docs/releases/testflight-beta-description.txt
+++ b/docs/releases/testflight-beta-description.txt
@@ -1,0 +1,1 @@
+Litter is the native iOS client for Codex and Local Studio. Connect to local or remote servers, manage sessions, and run agentic coding workflows from your phone. Test pairing and discovery, Codex and Pi sessions, streaming responses, reasoning, tool calls, attachments, reconnects, and thread resume.

--- a/tools/scripts/check-app-store-release.sh
+++ b/tools/scripts/check-app-store-release.sh
@@ -2,9 +2,17 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 RELEASE_TEMP_DIR="${RUNNER_TEMP:?RUNNER_TEMP is required}"
 REQUIRE_WATCH_PROFILES="${REQUIRE_WATCH_PROFILES:-0}"
+BETA_APP_DESCRIPTION_FILE="${BETA_APP_DESCRIPTION_FILE:-$REPO_ROOT/docs/releases/testflight-beta-description.txt}"
 umask 077
+
+if [[ ! -s "$BETA_APP_DESCRIPTION_FILE" ]] ||
+    ! grep -q '[^[:space:]]' "$BETA_APP_DESCRIPTION_FILE"; then
+    echo "Missing TestFlight Beta App Description: $BETA_APP_DESCRIPTION_FILE" >&2
+    exit 1
+fi
 
 required=(
     ASC_KEY_ID


### PR DESCRIPTION
## Purpose

The 1.7.0 TestFlight upload completed successfully, but external beta submission failed afterward because App Store Connect had no Beta App Description. This makes that metadata durable and lets us finish an already-uploaded build without rebuilding the IPA.

## Changes

- store the evergreen TestFlight Beta App Description in the repository
- fail the release preflight when the description is missing or blank
- extract TestFlight metadata/group/review finalization from the upload script
- create or update the Beta App Description and What to Test notes before strict validation
- make Beta App Review submission idempotent
- add a short `iOS TestFlight Finalize` recovery workflow for existing builds
- document the no-rebuild recovery path

## Verification

- `bash -n apps/ios/scripts/testflight-finalize.sh apps/ios/scripts/testflight-upload.sh apps/ios/scripts/tests/testflight-finalize.test.sh tools/scripts/check-app-store-release.sh`
- `./apps/ios/scripts/tests/testflight-finalize.test.sh`
- `shellcheck -x -P apps/ios/scripts apps/ios/scripts/release-common.sh apps/ios/scripts/testflight-finalize.sh apps/ios/scripts/tests/testflight-finalize.test.sh tools/scripts/check-app-store-release.sh`
- parsed `.github/workflows/ios-testflight-finalize.yml` with Ruby YAML
- verified the release preflight rejects a missing description and accepts the committed description before moving to secret validation
- `git diff --check`

No UI changes; screenshots are not applicable.
