### PR TITLE
Fix release cache fallbacks

### DIFF
--- a/.github/workflows/android-apk-release.yml
+++ b/.github/workflows/android-apk-release.yml
@@ -83,7 +83,20 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Configure sccache
+        run: |
+          if [ -n "${SCCACHE_ENDPOINT:-}" ] && [ -n "${AWS_ACCESS_KEY_ID:-}" ] && [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+            echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          else
+            echo "SCCACHE_BUCKET=" >> "$GITHUB_ENV"
+            echo "SCCACHE_ENDPOINT=" >> "$GITHUB_ENV"
+            echo "SCCACHE_S3_KEY_PREFIX=" >> "$GITHUB_ENV"
+            echo "AWS_ACCESS_KEY_ID=" >> "$GITHUB_ENV"
+            echo "AWS_SECRET_ACCESS_KEY=" >> "$GITHUB_ENV"
+          fi
+
       - name: Setup sccache
+        if: env.SCCACHE_ENDPOINT != '' && env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != ''
         uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Sync codex submodule
@@ -100,7 +113,6 @@ jobs:
       - name: Generate shared mobile bindings
         if: steps.mobile-bindings-cache.outputs.cache-hit != 'true'
         env:
-          RUSTC_WRAPPER: sccache
           CARGO_INCREMENTAL: "0"
         run: |
           cd shared/rust-bridge
@@ -169,10 +181,24 @@ jobs:
         with:
           targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android
 
+      - name: Configure sccache
+        run: |
+          if [ -n "${SCCACHE_ENDPOINT:-}" ] && [ -n "${AWS_ACCESS_KEY_ID:-}" ] && [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+            echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          else
+            echo "SCCACHE_BUCKET=" >> "$GITHUB_ENV"
+            echo "SCCACHE_ENDPOINT=" >> "$GITHUB_ENV"
+            echo "SCCACHE_S3_KEY_PREFIX=" >> "$GITHUB_ENV"
+            echo "AWS_ACCESS_KEY_ID=" >> "$GITHUB_ENV"
+            echo "AWS_SECRET_ACCESS_KEY=" >> "$GITHUB_ENV"
+          fi
+
       - name: Setup sccache
+        if: env.SCCACHE_ENDPOINT != '' && env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != ''
         uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Prime sccache
+        if: env.SCCACHE_ENDPOINT != '' && env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != ''
         run: |
           export SCCACHE_ERROR_LOG="$RUNNER_TEMP/sccache-android.log"
           rm -f "$SCCACHE_ERROR_LOG"
@@ -205,7 +231,6 @@ jobs:
       - name: Build Rust JNI libs
         env:
           ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/30.0.14904198
-          RUSTC_WRAPPER: sccache
         run: make rust-android
 
       - name: Setup Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,20 +137,31 @@ jobs:
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
       - name: "Configure sccache env for R2 backend"
+        id: sccache-config
+        env:
+          SCCACHE_R2_ENDPOINT: ${{ secrets.SCCACHE_R2_ENDPOINT }}
+          SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}
+          SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}
         run: |
-          {
-            echo "RUSTC_WRAPPER=sccache"
-            echo "SCCACHE_BUCKET=rust-cache"
-            echo "SCCACHE_REGION=auto"
-            echo "SCCACHE_S3_USE_SSL=true"
-            echo "SCCACHE_S3_KEY_PREFIX=ci/kittylitter-release"
-            echo "SCCACHE_LOG=warn"
-            echo "SCCACHE_ENDPOINT=${{ secrets.SCCACHE_R2_ENDPOINT }}"
-            echo "AWS_ACCESS_KEY_ID=${{ secrets.SCCACHE_R2_ACCESS_KEY_ID }}"
-            echo "AWS_SECRET_ACCESS_KEY=${{ secrets.SCCACHE_R2_SECRET_ACCESS_KEY }}"
-          } >> "$GITHUB_ENV"
+          if [[ -n "$SCCACHE_R2_ENDPOINT" && -n "$SCCACHE_R2_ACCESS_KEY_ID" && -n "$SCCACHE_R2_SECRET_ACCESS_KEY" ]]; then
+            {
+              echo "RUSTC_WRAPPER=sccache"
+              echo "SCCACHE_BUCKET=rust-cache"
+              echo "SCCACHE_REGION=auto"
+              echo "SCCACHE_S3_USE_SSL=true"
+              echo "SCCACHE_S3_KEY_PREFIX=ci/kittylitter-release"
+              echo "SCCACHE_LOG=warn"
+              echo "SCCACHE_ENDPOINT=$SCCACHE_R2_ENDPOINT"
+              echo "AWS_ACCESS_KEY_ID=$SCCACHE_R2_ACCESS_KEY_ID"
+              echo "AWS_SECRET_ACCESS_KEY=$SCCACHE_R2_SECRET_ACCESS_KEY"
+            } >> "$GITHUB_ENV"
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
         shell: "bash"
       - name: "Install sccache"
+        if: steps.sccache-config.outputs.enabled == 'true'
         uses: "mozilla-actions/sccache-action@v0.0.9"
       - name: "Resolve Alleycat to latest main"
         run: "./tools/scripts/update-alleycat-main.sh --kittylitter"


### PR DESCRIPTION
## What changed
- enable R2-backed sccache only when endpoint and both credentials are available
- build cargo-dist artifacts normally when protected cache configuration is unavailable
- apply the same fallback to Android APK shared preparation and JNI release builds

## Why
The v0.3.5 cargo-dist run failed on every platform before compilation because an empty protected cache configuration resolved to `s3.auto.amazonaws.com`. The independent Android APK run failed similarly when its unprotected prep job received an endpoint but empty access keys.

## Verification
- both workflow YAML files parse
- `git diff --check` passes
- shell branch checks cover missing-cache fallback and complete-cache enablement
- explicit unconditional Android `RUSTC_WRAPPER` overrides removed