### PR TITLE
ios: show TestFlight validation failures

### DIFF
--- a/apps/ios/scripts/testflight-finalize.sh
+++ b/apps/ios/scripts/testflight-finalize.sh
@@ -161,7 +161,7 @@ asc validate testflight \
     --app "$APP_STORE_APP_ID" \
     --build "$BUILD_ID" \
     --strict \
-    --output json >/dev/null
+    --output table
 
 if [[ "$ASSIGN_BETA_GROUP" == "1" && "$SUBMIT_BETA_REVIEW" == "1" && "$external_group_requested" -eq 1 ]]; then
     submission_id="$(


### PR DESCRIPTION
## Purpose

The no-rebuild TestFlight finalizer reached strict readiness validation, but redirected ASC's diagnostic output to `/dev/null`, leaving only exit code 1 in the recovery run.

## Change

Render the strict TestFlight validation table in the workflow log. This changes no release behavior and exposes only App Store Connect readiness metadata, not credentials.

## Verification

- `bash -n apps/ios/scripts/testflight-finalize.sh`
- `./apps/ios/scripts/tests/testflight-finalize.test.sh`
- `shellcheck -x -P apps/ios/scripts apps/ios/scripts/release-common.sh apps/ios/scripts/testflight-finalize.sh apps/ios/scripts/tests/testflight-finalize.test.sh`
- `git diff --check`

Self-review: no blocking findings; the patch only removes output suppression from the existing strict validation command.
