### PR TITLE
fix: preserve Local Studio session identity

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -34,7 +34,7 @@ android {
         minSdk = 26
         targetSdk = 36
         versionCode = 200000254
-        versionName = "1.7.0"
+        versionName = "2.0.0"
         buildConfigField("boolean", "ENABLE_ON_DEVICE_BRIDGE", "true")
         buildConfigField("String", "RUNTIME_STARTUP_MODE", "\"hybrid\"")
         buildConfigField("String", "APP_RUNTIME_TRANSPORT", "\"app_bridge_rpc_transport\"")

--- a/apps/android/app/src/main/java/com/litter/android/state/SnapshotExtensions.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/SnapshotExtensions.kt
@@ -96,7 +96,8 @@ val AppServerSnapshot.connectionProgressDetail: String?
 val AppServerSnapshot.statusLabel: String
     get() = when {
         connectionProgressLabel != null -> connectionProgressLabel!!
-        transportState == AppServerTransportState.CONNECTED && !isLocal && account == null -> "Sign in required"
+        transportState == AppServerTransportState.CONNECTED && requiresOpenaiAuth && account == null ->
+            "Sign in required"
         else -> transportState.displayLabel
     }
 
@@ -105,7 +106,8 @@ val AppServerSnapshot.statusColor: Color
         currentConnectionStep?.state == AppConnectionStepState.FAILED -> Color(0xFFFF6B6B)
         currentConnectionStep?.state == AppConnectionStepState.AWAITING_USER_INPUT -> WarningOrange
         connectionProgressLabel != null -> AccentGreen
-        transportState == AppServerTransportState.CONNECTED && !isLocal && account == null -> WarningOrange
+        transportState == AppServerTransportState.CONNECTED && requiresOpenaiAuth && account == null ->
+            WarningOrange
         else -> transportState.accentColor
     }
 
@@ -121,7 +123,7 @@ val AppServerSnapshot.statusDotState: com.litter.android.ui.common.StatusDotStat
             com.litter.android.ui.common.StatusDotState.PENDING
         connectionProgressLabel != null ->
             com.litter.android.ui.common.StatusDotState.PENDING
-        transportState == AppServerTransportState.CONNECTED && !isLocal && account == null ->
+        transportState == AppServerTransportState.CONNECTED && requiresOpenaiAuth && account == null ->
             com.litter.android.ui.common.StatusDotState.PENDING
         transportState == AppServerTransportState.CONNECTED ->
             com.litter.android.ui.common.StatusDotState.OK

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/HeaderBar.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/HeaderBar.kt
@@ -280,7 +280,7 @@ fun HeaderBar(
                     scope.launch {
                         isReloading = true
                         try {
-                            if (server != null && !server.isLocal && server.account == null) {
+                            if (server?.requiresOpenaiAuth == true && server.account == null) {
                                 val authUrl = appModel.client.startRemoteSshOauthLogin(
                                     thread.key.serverId,
                                 )

--- a/apps/android/app/src/main/java/com/litter/android/ui/home/HomeDashboardScreen.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/home/HomeDashboardScreen.kt
@@ -181,9 +181,9 @@ fun HomeDashboardScreen(
     var pinnedKeys by remember { mutableStateOf(SavedThreadsStore.pinnedKeys(context)) }
     var hiddenKeys by remember { mutableStateOf(SavedThreadsStore.hiddenKeys(context)) }
 
-    // Home list = pinned first (preserving pin order). If nothing is pinned,
-    // show the 10 most-recent sessions. Hidden threads are excluded from
-    // both halves.
+    // Home list = pinned first (preserving pin order). Local Studio also keeps
+    // recent sessions visible after a pin so newly synced Pi sessions do not
+    // disappear behind legacy pinned rows. Hidden threads stay excluded.
     val homeSessions = remember(pinnedKeys, hiddenKeys, servers, allSessions) {
         mergeHomeSessions(pinnedKeys, hiddenKeys, servers, allSessions)
     }
@@ -1372,13 +1372,15 @@ private fun EmptyHomeFatCat(modifier: Modifier = Modifier) {
 
 /**
  * Merge rule:
- * - If the user has pinned anything, the home list is just their pins
- *   (in pin order, most-recent-pinned first). No auto-fill from recent.
+ * - If the user has pinned anything, the home list starts with their pins
+ *   (in pin order, most-recent-pinned first).
+ * - Local Studio appends its unpinned recent sessions so a pin cannot hide
+ *   newly synced Pi sessions. Other runtimes keep the existing pins-only rule.
  * - If nothing is pinned, fill the list with up to 10 most-recent
  *   sessions so the home screen isn't empty.
  * - Hidden threads are always excluded.
  */
-private fun mergeHomeSessions(
+internal fun mergeHomeSessions(
     pinned: List<PinnedThreadKey>,
     hidden: List<PinnedThreadKey>,
     servers: List<AppServerSnapshot>,
@@ -1393,12 +1395,29 @@ private fun mergeHomeSessions(
             PinnedThreadKey(serverId = it.key.serverId, threadId = it.key.threadId)
         }
         val serversById = servers.associateBy { it.serverId }
-        return pinned.mapNotNull { key ->
+        val pinnedSessions = pinned.mapNotNull { key ->
             if (key in hiddenSet) return@mapNotNull null
             byKey[key] ?: serversById[key.serverId]?.let { server ->
                 placeholderPinnedSession(key, server)
             }
         }
+        val pinnedSet = pinned.toSet()
+        val localStudioServerIds = servers.asSequence()
+            .filter { server ->
+                usesServerConfiguredModelDefault(
+                    server.agentRuntimes.filter { it.available }.map { it.kind },
+                )
+            }
+            .map { it.serverId }
+            .toSet()
+        val localStudioRecent = candidates.filter { session ->
+            session.key.serverId in localStudioServerIds &&
+                PinnedThreadKey(
+                    serverId = session.key.serverId,
+                    threadId = session.key.threadId,
+                ) !in pinnedSet
+        }
+        return pinnedSessions + localStudioRecent
     }
     return candidates.take(10)
 }
@@ -1411,7 +1430,15 @@ private fun placeholderPinnedSession(
         serverId = pinned.serverId,
         threadId = pinned.threadId,
     ),
-    agentRuntimeKind = "codex",
+    agentRuntimeKind = if (
+        usesServerConfiguredModelDefault(
+            server.agentRuntimes.filter { it.available }.map { it.kind },
+        )
+    ) {
+        "local-studio"
+    } else {
+        "codex"
+    },
     serverDisplayName = server.displayName,
     serverHost = server.host,
     title = "Loading thread",

--- a/apps/android/app/src/main/play/release-notes/en-US/default.txt
+++ b/apps/android/app/src/main/play/release-notes/en-US/default.txt
@@ -1,5 +1,5 @@
-Litter 1.7.0
-- More reliable Local Studio discovery for Pi, Codex, and other agents
-- Renamed sessions now show their chosen title
-- Smoother streaming Markdown and table rendering
-- More reliable image attachments in new conversations
+Litter 2.0.0
+- Local Studio sessions stay visible and correctly labeled
+- New Local Studio conversations always use its built-in Pi runtime
+- Reliable reconnect and resume without sessions disappearing
+- Correct connection status without false OpenAI sign-in prompts

--- a/apps/android/app/src/main/play/release-notes/en-US/internal.txt
+++ b/apps/android/app/src/main/play/release-notes/en-US/internal.txt
@@ -1,1 +1,1 @@
-Litter 1.7.0: stable Local Studio cold-start discovery for Pi/Codex/other agents, explicit renamed-session titles, smoother Markdown/table streaming, and reliable padded image attachments.
+Litter 2.0.0: Local Studio-only routing for list, start, stream, tools, resume, and hydration; persistent Local Studio session identity; visible recent sessions alongside legacy pins; Pi full-access/no-approval defaults; and accurate non-OpenAI connection status.

--- a/apps/android/app/src/test/java/com/litter/android/HomeDashboardSupportTests.kt
+++ b/apps/android/app/src/test/java/com/litter/android/HomeDashboardSupportTests.kt
@@ -1,11 +1,24 @@
 package com.litter.android
 
 import com.litter.android.ui.home.HomeDashboardSupport
+import com.litter.android.ui.home.mergeHomeSessions
 import com.litter.android.ui.home.usesServerConfiguredModelDefault
+import com.litter.android.state.statusDotState
+import com.litter.android.state.statusLabel
+import com.litter.android.ui.common.StatusDotState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import uniffi.codex_mobile_client.AgentRuntimeInfo
+import uniffi.codex_mobile_client.AppServerCapabilities
+import uniffi.codex_mobile_client.AppServerHealth
+import uniffi.codex_mobile_client.AppServerSnapshot
+import uniffi.codex_mobile_client.AppServerTransportState
+import uniffi.codex_mobile_client.AppSessionSummary
+import uniffi.codex_mobile_client.AppSubagentStatus
+import uniffi.codex_mobile_client.PinnedThreadKey
+import uniffi.codex_mobile_client.ThreadKey
 
 class HomeDashboardSupportTests {
 
@@ -23,6 +36,48 @@ class HomeDashboardSupportTests {
                 listOf("local-studio", "codex"),
             ),
         )
+    }
+
+    @Test
+    fun `Local Studio pins retain recent sessions and use Local Studio placeholders`() {
+        val server = server("studio", "local-studio")
+        val stalePin = PinnedThreadKey(serverId = "studio", threadId = "stale")
+
+        val result = mergeHomeSessions(
+            pinned = listOf(stalePin),
+            hidden = emptyList(),
+            servers = listOf(server),
+            allSessions = listOf(session("studio", "recent", "local-studio")),
+        )
+
+        assertEquals(listOf("stale", "recent"), result.map { it.key.threadId })
+        assertEquals(listOf("local-studio", "local-studio"), result.map { it.agentRuntimeKind })
+    }
+
+    @Test
+    fun `Codex pins keep the existing pins-only behavior`() {
+        val server = server("codex", "codex")
+
+        val result = mergeHomeSessions(
+            pinned = listOf(PinnedThreadKey(serverId = "codex", threadId = "stale")),
+            hidden = emptyList(),
+            servers = listOf(server),
+            allSessions = listOf(session("codex", "recent", "codex")),
+        )
+
+        assertEquals(listOf("stale"), result.map { it.key.threadId })
+        assertEquals(listOf("codex"), result.map { it.agentRuntimeKind })
+    }
+
+    @Test
+    fun `Local Studio does not show a false OpenAI sign-in warning`() {
+        val studio = server("studio", "local-studio")
+        val codex = server("codex", "codex", requiresOpenaiAuth = true)
+
+        assertEquals("Connected", studio.statusLabel)
+        assertEquals(StatusDotState.OK, studio.statusDotState)
+        assertEquals("Sign in required", codex.statusLabel)
+        assertEquals(StatusDotState.PENDING, codex.statusDotState)
     }
 
     @Test
@@ -63,4 +118,75 @@ class HomeDashboardSupportTests {
         assertEquals("", HomeDashboardSupport.relativeTime(null))
         assertEquals("", HomeDashboardSupport.relativeTime(0L))
     }
+
+    private fun server(
+        id: String,
+        runtimeKind: String,
+        requiresOpenaiAuth: Boolean = false,
+    ) = AppServerSnapshot(
+        serverId = id,
+        displayName = id,
+        host = "$id.local",
+        port = 8390u,
+        wakeMac = null,
+        isLocal = false,
+        health = AppServerHealth.CONNECTED,
+        transportState = AppServerTransportState.CONNECTED,
+        capabilities = AppServerCapabilities(
+            canUseTransportActions = true,
+            canBrowseDirectories = true,
+            canStartThreads = true,
+            canResumeThreads = true,
+            supportsTurnPagination = true,
+        ),
+        account = null,
+        requiresOpenaiAuth = requiresOpenaiAuth,
+        rateLimits = null,
+        rateLimitsByRuntime = emptyList(),
+        availableModels = null,
+        agentRuntimes = listOf(
+            AgentRuntimeInfo(
+                kind = runtimeKind,
+                name = runtimeKind,
+                displayName = runtimeKind,
+                available = true,
+            ),
+        ),
+        connectionProgress = null,
+        usageStats = null,
+        codexVersion = null,
+    )
+
+    private fun session(serverId: String, threadId: String, runtimeKind: String) = AppSessionSummary(
+        key = ThreadKey(serverId = serverId, threadId = threadId),
+        agentRuntimeKind = runtimeKind,
+        serverDisplayName = serverId,
+        serverHost = "$serverId.local",
+        title = threadId,
+        preview = threadId,
+        cwd = "/tmp",
+        model = "",
+        modelProvider = "",
+        parentThreadId = null,
+        forkedFromId = null,
+        agentNickname = null,
+        agentRole = null,
+        agentDisplayLabel = null,
+        agentStatus = AppSubagentStatus.UNKNOWN,
+        updatedAt = null,
+        hasActiveTurn = false,
+        isResumed = false,
+        isSubagent = false,
+        isFork = false,
+        lastResponsePreview = null,
+        lastResponseTurnId = null,
+        lastUserMessage = null,
+        lastToolLabel = null,
+        recentToolLog = emptyList(),
+        lastTurnStartMs = null,
+        lastTurnEndMs = null,
+        stats = null,
+        tokenUsage = null,
+        goal = null,
+    )
 }

--- a/apps/ios/Litter.xcodeproj/project.pbxproj
+++ b/apps/ios/Litter.xcodeproj/project.pbxproj
@@ -2926,7 +2926,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*]" = "$(inherited) $(PROJECT_DIR)/GeneratedRust/ios-device";
 				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*]" = "$(inherited) $(PROJECT_DIR)/GeneratedRust/ios-sim";
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 2.0.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "$(inherited) -lc++ -lz -lresolv -lcodex_mobile_client";
@@ -3076,7 +3076,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*]" = "$(inherited) $(PROJECT_DIR)/GeneratedRust/ios-device";
 				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*]" = "$(inherited) $(PROJECT_DIR)/GeneratedRust/ios-sim";
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 2.0.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -3165,7 +3165,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*]" = "$(inherited) $(PROJECT_DIR)/GeneratedRust/ios-device";
 				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*]" = "$(inherited) $(PROJECT_DIR)/GeneratedRust/ios-sim";
-				MARKETING_VERSION = 1.7.0;
+				MARKETING_VERSION = 2.0.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "$(inherited) -lc++ -lz -lresolv -lcodex_mobile_client";

--- a/apps/ios/Sources/Litter/Models/AppServerSnapshot+UI.swift
+++ b/apps/ios/Sources/Litter/Models/AppServerSnapshot+UI.swift
@@ -54,7 +54,7 @@ extension AppServerSnapshot {
         if let connectionProgressLabel {
             return connectionProgressLabel
         }
-        if transportState == .connected, !isLocal, account == nil {
+        if transportState == .connected, requiresOpenaiAuth, account == nil {
             return "Sign in required"
         }
         return transportState.displayLabel
@@ -70,7 +70,7 @@ extension AppServerSnapshot {
         if connectionProgressLabel != nil {
             return LitterTheme.accent
         }
-        if transportState == .connected, !isLocal, account == nil {
+        if transportState == .connected, requiresOpenaiAuth, account == nil {
             return .orange
         }
         return transportState.accentColor
@@ -88,7 +88,7 @@ extension AppServerSnapshot {
         if connectionProgressLabel != nil {
             return .pending
         }
-        if transportState == .connected, !isLocal, account == nil {
+        if transportState == .connected, requiresOpenaiAuth, account == nil {
             return .pending
         }
         switch transportState {

--- a/apps/ios/Sources/Litter/Views/HeaderView.swift
+++ b/apps/ios/Sources/Litter/Views/HeaderView.swift
@@ -153,7 +153,7 @@ struct HeaderView: View {
                     return LitterTheme.danger
                 }
             }
-            return server.account == nil ? .orange : LitterTheme.success
+            return server.requiresOpenaiAuth && server.account == nil ? .orange : LitterTheme.success
         case .disconnected:
             return LitterTheme.danger
         case .unknown:
@@ -395,7 +395,7 @@ struct ConversationToolbarControls: View {
                 if await handleRemoteLoginIfNeeded() {
                     return
                 }
-                if server?.account == nil {
+                if server?.requiresOpenaiAuth == true, server?.account == nil {
                     appState.showSettings = true
                 } else {
                     do {
@@ -443,7 +443,7 @@ struct ConversationToolbarControls: View {
         guard let server, !server.isLocal else {
             return false
         }
-        guard server.account == nil else {
+        guard server.requiresOpenaiAuth, server.account == nil else {
             return false
         }
         do {

--- a/apps/ios/Sources/Litter/Views/HomeDashboardModel.swift
+++ b/apps/ios/Sources/Litter/Views/HomeDashboardModel.swift
@@ -54,9 +54,9 @@ final class HomeDashboardModel {
     }
 
     private(set) var connectedServers: [HomeDashboardServer] = []
-    /// Home list source: pinned threads first (in pin order). If nothing is
-    /// pinned, show the 10 most-recent sessions. Hidden threads are always
-    /// excluded.
+    /// Home list source: pinned threads first (in pin order). Local Studio
+    /// also keeps recent sessions visible after a pin so newly synced Pi
+    /// sessions remain discoverable. Hidden threads are always excluded.
     private(set) var recentSessions: [HomeDashboardRecentSession] = []
     /// Every session we know about across connected servers, newest first —
     /// used by the search view so the user can pick any thread.
@@ -273,7 +273,8 @@ final class HomeDashboardModel {
         recentSessions = Self.mergedHomeSessions(
             pinned: pinnedKeys,
             hidden: hiddenKeys,
-            allSessions: snapshot.recentSessions
+            allSessions: snapshot.recentSessions,
+            servers: snapshot.connectedServers
         )
         lastSessionSummaries = snapshot.sessionSummaries
         projects = deriveProjects(sessions: snapshot.sessionSummaries)
@@ -321,15 +322,18 @@ final class HomeDashboardModel {
     }
 
     /// Merge rule:
-    /// - If the user has pinned anything, the home list is just their pins
-    ///   (in pin order, most-recent-pinned first). No auto-fill from recent.
+    /// - If the user has pinned anything, the home list starts with their pins
+    ///   (in pin order, most-recent-pinned first).
+    /// - Local Studio appends its unpinned recent sessions so a pin cannot hide
+    ///   newly synced Pi sessions. Other runtimes keep the pins-only rule.
     /// - If nothing is pinned, fill the list with up to 10 most-recent
     ///   sessions so the home screen isn't empty.
     /// - Hidden threads are always excluded.
     private static func mergedHomeSessions(
         pinned: [SavedThreadsStore.PinnedKey],
         hidden: [SavedThreadsStore.PinnedKey],
-        allSessions: [HomeDashboardRecentSession]
+        allSessions: [HomeDashboardRecentSession],
+        servers: [HomeDashboardServer]
     ) -> [HomeDashboardRecentSession] {
         let hiddenSet = Set(hidden)
         let candidates = allSessions.filter {
@@ -340,7 +344,22 @@ final class HomeDashboardModel {
                 (SavedThreadsStore.PinnedKey(threadKey: $0.key), $0)
             })
             let resolvedPins = pinned.compactMap { byKey[$0] }
-            return resolvedPins.isEmpty ? Array(candidates.prefix(10)) : resolvedPins
+            guard !resolvedPins.isEmpty else {
+                return Array(candidates.prefix(10))
+            }
+            let pinnedSet = Set(pinned)
+            let localStudioServerIds = Set(
+                servers.filter { server in
+                    usesServerConfiguredModelDefault(
+                        server.agentRuntimes.filter(\.available).map(\.kind)
+                    )
+                }.map(\.id)
+            )
+            let localStudioRecent = candidates.filter { session in
+                localStudioServerIds.contains(session.key.serverId) &&
+                    !pinnedSet.contains(SavedThreadsStore.PinnedKey(threadKey: session.key))
+            }
+            return resolvedPins + localStudioRecent
         }
         return Array(candidates.prefix(10))
     }

--- a/apps/ios/Tests/LitterTests/HomeDashboardSupportTests.swift
+++ b/apps/ios/Tests/LitterTests/HomeDashboardSupportTests.swift
@@ -14,6 +14,98 @@ final class HomeDashboardSupportTests: XCTestCase {
         )
     }
 
+    func testLocalStudioPinsKeepNewlySyncedSessionsVisible() async {
+        let appModel = AppModel()
+        let pinnedKey = SavedThreadsStore.PinnedKey(
+            threadKey: ThreadKey(serverId: "studio", threadId: "pinned")
+        )
+        let model = HomeDashboardModel(
+            persistence: persistence(pinned: [pinnedKey]),
+            observedRefreshDelayNanoseconds: 0
+        )
+        model.bind(appModel: appModel)
+        model.activate()
+
+        appModel.applySnapshot(
+            makeSnapshot(
+                servers: [
+                    makeServerSnapshot(
+                        id: "studio",
+                        name: "Local Studio",
+                        runtimeKind: .localStudio
+                    )
+                ],
+                threads: [
+                    makeThreadSnapshot(
+                        serverId: "studio",
+                        threadId: "pinned",
+                        updatedAt: 20,
+                        runtimeKind: .localStudio
+                    ),
+                    makeThreadSnapshot(
+                        serverId: "studio",
+                        threadId: "recent",
+                        updatedAt: 40,
+                        runtimeKind: .localStudio
+                    )
+                ],
+                activeThread: nil
+            )
+        )
+        await waitUntil("Local Studio keeps its pinned and recent sessions") {
+            model.recentSessions.map(\.key.threadId) == ["pinned", "recent"]
+        }
+
+        XCTAssertEqual(model.recentSessions.map(\.key.threadId), ["pinned", "recent"])
+    }
+
+    func testCodexPinsKeepExistingPinsOnlyBehavior() async {
+        let appModel = AppModel()
+        let pinnedKey = SavedThreadsStore.PinnedKey(
+            threadKey: ThreadKey(serverId: "codex", threadId: "pinned")
+        )
+        let model = HomeDashboardModel(
+            persistence: persistence(pinned: [pinnedKey]),
+            observedRefreshDelayNanoseconds: 0
+        )
+        model.bind(appModel: appModel)
+        model.activate()
+
+        appModel.applySnapshot(
+            makeSnapshot(
+                servers: [makeServerSnapshot(id: "codex", name: "Codex")],
+                threads: [
+                    makeThreadSnapshot(serverId: "codex", threadId: "pinned", updatedAt: 20),
+                    makeThreadSnapshot(serverId: "codex", threadId: "recent", updatedAt: 40)
+                ],
+                activeThread: nil
+            )
+        )
+        await waitUntil("Codex keeps its existing pins-only home list") {
+            model.recentSessions.map(\.key.threadId) == ["pinned"]
+        }
+
+        XCTAssertEqual(model.recentSessions.map(\.key.threadId), ["pinned"])
+    }
+
+    func testLocalStudioDoesNotShowFalseOpenAISignInWarning() {
+        let studio = makeServerSnapshot(
+            id: "studio",
+            name: "Local Studio",
+            runtimeKind: .localStudio
+        )
+        let codex = makeServerSnapshot(
+            id: "codex",
+            name: "Codex",
+            requiresOpenaiAuth: true
+        )
+
+        XCTAssertEqual(studio.statusLabel, "Connected")
+        XCTAssertEqual(studio.statusDotState, .ok)
+        XCTAssertEqual(codex.statusLabel, "Sign in required")
+        XCTAssertEqual(codex.statusDotState, .pending)
+    }
+
     func testRecentConnectedSessionsFiltersDisconnectedServersAndLimitsToThreeNewest() {
         let servers = [
             makeServerSnapshot(id: "server-a", name: "Server A"),
@@ -297,7 +389,12 @@ final class HomeDashboardSupportTests: XCTestCase {
         XCTAssertGreaterThan(model.rebuildCount, rebuildCountBeforeDeactivate)
     }
 
-    private func makeThreadSnapshot(serverId: String, threadId: String, updatedAt: TimeInterval) -> AppThreadSnapshot {
+    private func makeThreadSnapshot(
+        serverId: String,
+        threadId: String,
+        updatedAt: TimeInterval,
+        runtimeKind: AgentRuntimeKind = .codex
+    ) -> AppThreadSnapshot {
         AppThreadSnapshot(
             key: ThreadKey(serverId: serverId, threadId: threadId),
             info: ThreadInfo(
@@ -317,7 +414,7 @@ final class HomeDashboardSupportTests: XCTestCase {
                 createdAt: nil,
                 updatedAt: Int64(updatedAt)
             ),
-            agentRuntimeKind: .codex,
+            agentRuntimeKind: runtimeKind,
             collaborationMode: .default,
             model: nil,
             reasoningEffort: nil,
@@ -406,7 +503,9 @@ final class HomeDashboardSupportTests: XCTestCase {
         host: String? = nil,
         port: UInt16 = 8390,
         isLocal: Bool = false,
-        health: AppServerHealth = .connected
+        health: AppServerHealth = .connected,
+        runtimeKind: AgentRuntimeKind = .codex,
+        requiresOpenaiAuth: Bool = false
     ) -> AppServerSnapshot {
         AppServerSnapshot(
             serverId: id,
@@ -425,11 +524,18 @@ final class HomeDashboardSupportTests: XCTestCase {
                 supportsTurnPagination: true
             ),
             account: nil,
-            requiresOpenaiAuth: false,
+            requiresOpenaiAuth: requiresOpenaiAuth,
             rateLimits: nil,
             rateLimitsByRuntime: [],
             availableModels: nil,
-            agentRuntimes: [AgentRuntimeInfo(kind: .codex, name: "codex", displayName: "Codex", available: true)],
+            agentRuntimes: [
+                AgentRuntimeInfo(
+                    kind: runtimeKind,
+                    name: runtimeKind,
+                    displayName: runtimeKind.displayLabel,
+                    available: true
+                )
+            ],
             connectionProgress: nil,
             usageStats: nil,
             codexVersion: nil
@@ -444,6 +550,29 @@ final class HomeDashboardSupportTests: XCTestCase {
             lastError: nil,
             transcriptEntries: [],
             handoffThreadKey: nil
+        )
+    }
+
+    private func persistence(
+        pinned: [SavedThreadsStore.PinnedKey]
+    ) -> HomeDashboardPersistence {
+        var pinnedKeys = pinned
+        return HomeDashboardPersistence(
+            rememberedServers: { [] },
+            pinnedKeys: { pinnedKeys },
+            hiddenKeys: { [] },
+            addPinned: { key in
+                if !pinnedKeys.contains(key) {
+                    pinnedKeys.append(key)
+                }
+            },
+            removePinned: { key in pinnedKeys.removeAll { $0 == key } },
+            hide: { _ in },
+            unhide: { _ in },
+            selectedServerId: { nil },
+            setSelectedServerId: { _ in },
+            selectedProjectId: { nil },
+            setSelectedProjectId: { _ in }
         )
     }
 

--- a/apps/ios/fastlane/metadata/en-US/release_notes.txt
+++ b/apps/ios/fastlane/metadata/en-US/release_notes.txt
@@ -1,6 +1,6 @@
-More reliable Local Studio pairing and clearer session history.
+Local Studio sessions now stay visible, correctly labeled, and connected to the right runtime.
 
-- Wait for Pi, Codex, and other Local Studio agents to finish registering before selection.
-- Show your explicit renamed-session title instead of the first-message preview.
-- Restore Photos attachments safely without reopening transient library paths.
-- Keep generic KittyLitter pairing fast while improving Local Studio cold starts.
+- Start every new Local Studio conversation through its built-in Pi runtime.
+- Keep newly synchronized sessions visible even when older sessions are pinned.
+- Resume and reconnect without sessions disappearing or changing into Codex sessions.
+- Show the correct connected status without asking Local Studio users to sign in to OpenAI.

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -23,7 +23,7 @@ settings:
   base:
     SWIFT_VERSION: "5.9"
     SWIFT_STRICT_CONCURRENCY: targeted
-    MARKETING_VERSION: "1.7.0"
+    MARKETING_VERSION: "2.0.0"
     CURRENT_PROJECT_VERSION: "200000254"
     SWIFT_OBJC_BRIDGING_HEADER: Sources/Litter/Bridge/codex_bridge_objc.h
     OTHER_LDFLAGS: "$(inherited) -lc++ -lz -lresolv -lcodex_mobile_client"

--- a/docs/releases/testflight-whats-new.md
+++ b/docs/releases/testflight-whats-new.md
@@ -1,15 +1,17 @@
 Summary
 
-- Improved Local Studio cold-start discovery so Pi, Codex, and other enabled agents appear before selection.
-- Renamed sessions now prefer their explicit title over first-message preview text.
-- Restored Photos attachments no longer reopen transient Photos-library paths.
-- Kept generic KittyLitter pairing immediate while Local Studio uses a bounded registration wait.
+- Preserved Local Studio session identity across listing, streaming, hydration, and reconnect.
+- Routed new Local Studio conversations through its built-in Pi runtime from the first request.
+- Kept newly synchronized Local Studio sessions visible alongside legacy pinned sessions.
+- Removed false OpenAI sign-in warnings from Local Studio connections.
+- Enforced full filesystem access with no approval prompts for Pi and Local Studio Pi sessions.
 
 What to test
 
-- Local Studio cold start: paste a connection JSON immediately after the controller starts and confirm Pi and Codex appear before Connect is enabled.
-- Agent selection: confirm every available Local Studio agent can be selected, connected, and used for a streamed turn.
-- KittyLitter: pair with a generic KittyLitter host and confirm the scanner remains responsive without the Local Studio wait.
-- Session names: rename a session, reopen the session list, and confirm the explicit title wins over preview text.
-- Photos: attach a Photos image, reopen the conversation, and confirm the rendered attachment does not resolve an internal `.photoslibrary` path.
-- Core chat: verify reasoning, tool calling, streaming text, images, reconnect, and thread resume on both Codex and Pi sessions.
+- Upgrade from 1.6 or 1.7 with existing Local Studio pins and confirm current sessions remain visible and every Local Studio row keeps its label.
+- Start a Local Studio conversation from mobile, stream the reply, use shell and file tools, then reopen it in both Litter and Local Studio.
+- Background and foreground the app during and after a turn; confirm the session and completed content survive reconnect and resume.
+- Confirm Local Studio shows connected without an OpenAI sign-in warning.
+- Confirm Pi and Local Studio Pi never request approval and can read and write the selected workspace.
+- Confirm ordinary Codex, Pi, and generic KittyLitter connections retain their existing discovery and permission behavior.
+- Verify reasoning, tool calls, streaming text, images, compaction, and older-turn hydration on iOS and Android.

--- a/shared/rust-bridge/codex-mobile-client/src/ffi/reconnect.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/ffi/reconnect.rs
@@ -61,6 +61,14 @@ fn server_counts_as_connected_for_reconnect(
     matches!(server.health, ServerHealthSnapshot::Connected)
 }
 
+fn server_supports_account_probe(server: &crate::store::snapshot::ServerSnapshot) -> bool {
+    server.agent_runtimes.is_empty()
+        || server
+            .agent_runtimes
+            .iter()
+            .any(|runtime| runtime.kind == "codex")
+}
+
 #[derive(uniffi::Object)]
 pub struct ReconnectController {
     inner: Arc<MobileClient>,
@@ -220,7 +228,11 @@ impl ReconnectController {
                 let remote_connected: Vec<String> = snapshot
                     .servers
                     .values()
-                    .filter(|s| !s.is_local && s.health == ServerHealthSnapshot::Connected)
+                    .filter(|s| {
+                        !s.is_local
+                            && s.health == ServerHealthSnapshot::Connected
+                            && server_supports_account_probe(s)
+                    })
                     .map(|s| s.server_id.clone())
                     .collect();
 
@@ -575,12 +587,16 @@ async fn reconnect_server_inner(
 
 #[cfg(test)]
 mod tests {
-    use super::{resolved_local_display_name, server_counts_as_connected_for_reconnect};
+    use super::{
+        resolved_local_display_name, server_counts_as_connected_for_reconnect,
+        server_supports_account_probe,
+    };
     use crate::reconnect::SavedServerRecord;
     use crate::store::snapshot::{
         AppSnapshot, AppVoiceSessionSnapshot, ServerHealthSnapshot, ServerSnapshot,
         ServerTransportDiagnostics,
     };
+    use crate::types::AgentRuntimeInfo;
     use std::collections::HashMap;
 
     fn empty_snapshot() -> AppSnapshot {
@@ -634,6 +650,24 @@ mod tests {
         assert!(!server_counts_as_connected_for_reconnect(
             &server_with_health(ServerHealthSnapshot::Unresponsive)
         ));
+    }
+
+    #[test]
+    fn account_probe_skips_local_studio_only_runtime() {
+        let mut local_studio = server_with_health(ServerHealthSnapshot::Connected);
+        local_studio.agent_runtimes = vec![AgentRuntimeInfo {
+            kind: "local-studio".to_string(),
+            name: "local-studio".to_string(),
+            display_name: "Local Studio".to_string(),
+            available: true,
+        }];
+        assert!(!server_supports_account_probe(&local_studio));
+
+        local_studio.agent_runtimes[0].kind = "codex".to_string();
+        assert!(server_supports_account_probe(&local_studio));
+        assert!(server_supports_account_probe(&server_with_health(
+            ServerHealthSnapshot::Connected
+        )));
     }
 
     #[test]

--- a/shared/rust-bridge/codex-mobile-client/src/ffi/reconnect.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/ffi/reconnect.rs
@@ -62,11 +62,10 @@ fn server_counts_as_connected_for_reconnect(
 }
 
 fn server_supports_account_probe(server: &crate::store::snapshot::ServerSnapshot) -> bool {
-    server.agent_runtimes.is_empty()
-        || server
-            .agent_runtimes
-            .iter()
-            .any(|runtime| runtime.kind == "codex")
+    !matches!(
+        server.agent_runtimes.as_slice(),
+        [runtime] if runtime.kind == "local-studio"
+    )
 }
 
 #[derive(uniffi::Object)]
@@ -664,6 +663,9 @@ mod tests {
         assert!(!server_supports_account_probe(&local_studio));
 
         local_studio.agent_runtimes[0].kind = "codex".to_string();
+        assert!(server_supports_account_probe(&local_studio));
+
+        local_studio.agent_runtimes[0].kind = "pi".to_string();
         assert!(server_supports_account_probe(&local_studio));
         assert!(server_supports_account_probe(&server_with_health(
             ServerHealthSnapshot::Connected

--- a/shared/rust-bridge/codex-mobile-client/src/mobile_client/dynamic_tools.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/mobile_client/dynamic_tools.rs
@@ -8,6 +8,31 @@ pub(super) struct DynamicToolSessionTarget {
     config: ServerConfig,
 }
 
+fn local_studio_only_runtime(runtime_kinds: &[AgentRuntimeKind]) -> Option<AgentRuntimeKind> {
+    (runtime_kinds == ["local-studio".to_string()]).then(|| "local-studio".to_string())
+}
+
+fn reconcile_list_sessions_page(
+    app_store: &AppStoreReducer,
+    server_id: &str,
+    runtime_kinds: &[AgentRuntimeKind],
+    threads: &[ThreadInfo],
+) {
+    if local_studio_only_runtime(runtime_kinds).is_some() {
+        // list_sessions is intentionally capped to a single page. Local Studio
+        // session inventory is durable and additive here: a partial tool result
+        // must neither delete older sessions nor relabel the visible page as
+        // Codex. Explicit thread/archive remains the removal signal.
+        app_store.upsert_thread_list_page_for_runtime(
+            server_id,
+            "local-studio".to_string(),
+            threads,
+        );
+    } else {
+        app_store.sync_thread_list(server_id, threads);
+    }
+}
+
 pub(super) async fn handle_dynamic_tool_call_request(
     session: Arc<ServerSession>,
     sessions: Arc<RwLock<HashMap<String, Arc<ServerSession>>>>,
@@ -251,8 +276,10 @@ pub(super) async fn list_sessions_tool_output(
     let mut errors = Vec::new();
 
     for target in targets {
+        let runtime_kinds = target.session.runtime_kinds();
         let response = dynamic_tool_request_typed::<upstream::ThreadListResponse, _>(
             &target.session,
+            local_studio_only_runtime(&runtime_kinds),
             "thread/list",
             &upstream::ThreadListParams {
                 cursor: None,
@@ -276,7 +303,12 @@ pub(super) async fn list_sessions_tool_output(
                     .into_iter()
                     .filter_map(thread_info_from_upstream_thread)
                     .collect::<Vec<_>>();
-                app_store.sync_thread_list(&target.server_id, &threads);
+                reconcile_list_sessions_page(
+                    app_store.as_ref(),
+                    &target.server_id,
+                    &runtime_kinds,
+                    &threads,
+                );
                 items.extend(threads.into_iter().map(|thread| {
                     serde_json::json!({
                         "id": thread.id,
@@ -370,6 +402,7 @@ pub(super) async fn list_sessions_tool_output(
 
 pub(super) async fn dynamic_tool_request_typed<R, P>(
     session: &Arc<ServerSession>,
+    runtime_kind: Option<AgentRuntimeKind>,
     method: &str,
     params: &P,
 ) -> Result<R, String>
@@ -379,12 +412,77 @@ where
 {
     let params_json = serde_json::to_value(params)
         .map_err(|error| format!("serialize {method} params: {error}"))?;
-    let response = session
-        .request(method, params_json)
-        .await
-        .map_err(|error| format!("{method} request failed: {error}"))?;
+    let response = if let Some(runtime_kind) = runtime_kind {
+        session
+            .request_for_runtime(runtime_kind, method, params_json)
+            .await
+    } else {
+        session.request(method, params_json).await
+    }
+    .map_err(|error| format!("{method} request failed: {error}"))?;
     serde_json::from_value(response)
         .map_err(|error| format!("deserialize {method} response: {error}"))
+}
+
+#[cfg(test)]
+mod local_studio_tests {
+    use super::*;
+    use crate::store::snapshot::ThreadSnapshot;
+    use crate::types::ThreadSummaryStatus;
+
+    fn thread(id: &str) -> ThreadInfo {
+        ThreadInfo {
+            id: id.to_string(),
+            title: None,
+            status: ThreadSummaryStatus::Idle,
+            preview: None,
+            cwd: None,
+            path: None,
+            model: None,
+            model_provider: None,
+            agent_nickname: None,
+            agent_role: None,
+            parent_thread_id: None,
+            forked_from_id: None,
+            agent_status: None,
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    #[test]
+    fn local_studio_tool_page_is_additive_and_keeps_runtime_identity() {
+        let store = AppStoreReducer::new();
+        let mut older = ThreadSnapshot::from_info("local-studio-server", thread("older"));
+        older.agent_runtime_kind = "local-studio".to_string();
+        store.upsert_thread_snapshot(older);
+
+        reconcile_list_sessions_page(
+            &store,
+            "local-studio-server",
+            &["local-studio".to_string()],
+            &[thread("newer")],
+        );
+
+        let snapshot = store.snapshot();
+        assert_eq!(snapshot.threads.len(), 2);
+        assert!(snapshot.threads.values().all(|thread| {
+            thread.key.server_id != "local-studio-server"
+                || thread.agent_runtime_kind == "local-studio"
+        }));
+    }
+
+    #[test]
+    fn non_local_studio_tool_page_keeps_existing_reconcile_behavior() {
+        let store = AppStoreReducer::new();
+        store.upsert_thread_snapshot(ThreadSnapshot::from_info("server", thread("older")));
+
+        reconcile_list_sessions_page(&store, "server", &["codex".to_string()], &[thread("newer")]);
+
+        let snapshot = store.snapshot();
+        assert_eq!(snapshot.threads.len(), 1);
+        assert!(snapshot.threads.keys().any(|key| key.thread_id == "newer"));
+    }
 }
 
 /// If a waiter is registered for the thread that emitted this

--- a/shared/rust-bridge/codex-mobile-client/src/mobile_client/event_loop.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/mobile_client/event_loop.rs
@@ -1174,6 +1174,12 @@ fn note_notification_runtime(
         server_id: server_id.to_string(),
         thread_id,
     };
+    if runtime_kind == "local-studio"
+        && !matches!(notification, upstream::ServerNotification::ThreadStarted(_))
+        && app_store.thread_snapshot(&key).is_none()
+    {
+        return;
+    }
     app_store.set_thread_agent_runtime(&key, runtime_kind);
 }
 
@@ -1230,12 +1236,59 @@ fn client_request_wire_method(request: &upstream::ClientRequest) -> &'static str
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::store::snapshot::ThreadSnapshot;
     use codex_app_server_protocol::{
         CommandAction, CommandExecutionSource, CommandExecutionStatus, ThreadItem,
     };
     use serde::Deserialize;
     use serde::de::Error as _;
     use serde_json::json;
+
+    #[test]
+    fn unknown_local_studio_archive_does_not_leave_a_pending_runtime_route() {
+        let store = AppStoreReducer::new();
+        let notification: upstream::ServerNotification = serde_json::from_value(json!({
+            "method": "thread/archived",
+            "params": { "threadId": "thread-1" }
+        }))
+        .expect("archive notification should deserialize");
+
+        note_notification_runtime(
+            &store,
+            "alleycat:local-studio:controller",
+            "local-studio".to_string(),
+            &notification,
+        );
+        store.upsert_thread_snapshot(ThreadSnapshot::from_info(
+            "alleycat:local-studio:controller",
+            ThreadInfo {
+                id: "thread-1".to_string(),
+                title: None,
+                status: ThreadSummaryStatus::Idle,
+                preview: None,
+                cwd: None,
+                path: None,
+                model: None,
+                model_provider: None,
+                agent_nickname: None,
+                agent_role: None,
+                parent_thread_id: None,
+                forked_from_id: None,
+                agent_status: None,
+                created_at: None,
+                updated_at: None,
+            },
+        ));
+
+        let key = ThreadKey {
+            server_id: "alleycat:local-studio:controller".to_string(),
+            thread_id: "thread-1".to_string(),
+        };
+        assert_eq!(
+            store.thread_snapshot(&key).unwrap().agent_runtime_kind,
+            "codex"
+        );
+    }
 
     #[test]
     fn suspicious_relative_path_entries_reports_relative_values_in_known_path_fields() {

--- a/shared/rust-bridge/codex-mobile-client/src/mobile_client/mod.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/mobile_client/mod.rs
@@ -1051,6 +1051,18 @@ impl MobileClient {
             }
         }
 
+        if self
+            .app_store
+            .snapshot()
+            .servers
+            .get(server_id)
+            .is_some_and(|server| {
+                server.agent_runtimes.len() == 1 && server.agent_runtimes[0].kind == "local-studio"
+            })
+        {
+            return "local-studio".to_string();
+        }
+
         "codex".to_string()
     }
 

--- a/shared/rust-bridge/codex-mobile-client/src/mobile_client/tests.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/mobile_client/tests.rs
@@ -347,6 +347,28 @@ mod mobile_client_tests {
     }
 
     #[test]
+    fn thread_start_runtime_uses_sole_local_studio_runtime() {
+        let client = MobileClient::new();
+        client
+            .app_store
+            .upsert_server(&make_server_config("srv"), ServerHealthSnapshot::Connected);
+        client.app_store.update_server_agent_runtimes(
+            "srv",
+            vec![AgentRuntimeInfo {
+                kind: "local-studio".to_string(),
+                name: "local-studio".to_string(),
+                display_name: "Local Studio".to_string(),
+                available: true,
+            }],
+        );
+
+        assert_eq!(
+            client.runtime_for_thread_start("srv", None, None),
+            "local-studio".to_string()
+        );
+    }
+
+    #[test]
     fn thread_start_runtime_explicit_agent_wins_over_duplicate_model() {
         let client = MobileClient::new();
         client

--- a/shared/rust-bridge/codex-mobile-client/src/mobile_client/tests.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/mobile_client/tests.rs
@@ -559,38 +559,99 @@ mod mobile_client_tests {
     }
 
     #[test]
-    fn pi_runtimes_always_start_full_access() {
+    fn pi_runtimes_always_use_full_access_without_approvals() {
         let client = MobileClient::new();
-        for (runtime, approval_policy, sandbox) in [
-            ("pi", None, None),
-            (
-                "pi",
-                Some(upstream::AskForApproval::OnRequest),
-                Some(upstream::SandboxMode::WorkspaceWrite),
-            ),
-            ("local-studio", None, None),
-        ] {
-            let mut request = upstream::ClientRequest::ThreadStart {
-                request_id: upstream::RequestId::Integer(1),
-                params: upstream::ThreadStartParams {
-                    approval_policy,
-                    sandbox,
-                    ..Default::default()
+        for runtime in ["pi", "local-studio"] {
+            let mut requests = vec![
+                upstream::ClientRequest::ThreadStart {
+                    request_id: upstream::RequestId::Integer(1),
+                    params: upstream::ThreadStartParams::default(),
                 },
-            };
-            client.normalize_model_selection_for_request("srv", runtime.into(), &mut request);
-            let upstream::ClientRequest::ThreadStart { params, .. } = request else {
-                panic!("expected thread/start");
-            };
-            assert_eq!(
-                params.approval_policy,
-                Some(upstream::AskForApproval::Never)
-            );
-            assert_eq!(
-                params.sandbox,
-                Some(upstream::SandboxMode::DangerFullAccess)
-            );
+                upstream::ClientRequest::ThreadResume {
+                    request_id: upstream::RequestId::Integer(2),
+                    params: upstream::ThreadResumeParams::default(),
+                },
+                upstream::ClientRequest::ThreadFork {
+                    request_id: upstream::RequestId::Integer(3),
+                    params: upstream::ThreadForkParams::default(),
+                },
+                upstream::ClientRequest::TurnStart {
+                    request_id: upstream::RequestId::Integer(4),
+                    params: upstream::TurnStartParams::default(),
+                },
+            ];
+
+            for request in &mut requests {
+                client.normalize_model_selection_for_request("srv", runtime.into(), request);
+                match request {
+                    upstream::ClientRequest::ThreadStart { params, .. } => {
+                        assert_eq!(
+                            params.approval_policy,
+                            Some(upstream::AskForApproval::Never)
+                        );
+                        assert_eq!(
+                            params.sandbox,
+                            Some(upstream::SandboxMode::DangerFullAccess)
+                        );
+                    }
+                    upstream::ClientRequest::ThreadResume { params, .. } => {
+                        assert_eq!(
+                            params.approval_policy,
+                            Some(upstream::AskForApproval::Never)
+                        );
+                        assert_eq!(
+                            params.sandbox,
+                            Some(upstream::SandboxMode::DangerFullAccess)
+                        );
+                    }
+                    upstream::ClientRequest::ThreadFork { params, .. } => {
+                        assert_eq!(
+                            params.approval_policy,
+                            Some(upstream::AskForApproval::Never)
+                        );
+                        assert_eq!(
+                            params.sandbox,
+                            Some(upstream::SandboxMode::DangerFullAccess)
+                        );
+                    }
+                    upstream::ClientRequest::TurnStart { params, .. } => {
+                        assert_eq!(
+                            params.approval_policy,
+                            Some(upstream::AskForApproval::Never)
+                        );
+                        assert_eq!(
+                            params.sandbox_policy,
+                            Some(upstream::SandboxPolicy::DangerFullAccess)
+                        );
+                    }
+                    _ => unreachable!(),
+                }
+            }
         }
+    }
+
+    #[test]
+    fn codex_permission_overrides_remain_unchanged() {
+        let client = MobileClient::new();
+        let mut request = upstream::ClientRequest::ThreadStart {
+            request_id: upstream::RequestId::Integer(1),
+            params: upstream::ThreadStartParams {
+                approval_policy: Some(upstream::AskForApproval::OnRequest),
+                sandbox: Some(upstream::SandboxMode::WorkspaceWrite),
+                ..Default::default()
+            },
+        };
+
+        client.normalize_model_selection_for_request("srv", "codex".into(), &mut request);
+
+        let upstream::ClientRequest::ThreadStart { params, .. } = request else {
+            unreachable!();
+        };
+        assert_eq!(
+            params.approval_policy,
+            Some(upstream::AskForApproval::OnRequest)
+        );
+        assert_eq!(params.sandbox, Some(upstream::SandboxMode::WorkspaceWrite));
     }
 
     #[test]

--- a/shared/rust-bridge/codex-mobile-client/src/store/reducer.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/store/reducer.rs
@@ -97,6 +97,11 @@ fn dedupe_agent_runtimes(runtimes: Vec<AgentRuntimeInfo>) -> Vec<AgentRuntimeInf
 
 pub struct AppStoreReducer {
     snapshot: RwLock<AppSnapshot>,
+    /// Local Studio notifications can arrive before the asynchronous store
+    /// listener has inserted their thread. Preserve that transport-owned
+    /// identity until the first snapshot lands instead of defaulting the new
+    /// thread to Codex.
+    pending_local_studio_thread_routes: RwLock<HashSet<ThreadKey>>,
     last_thread_state_updates: RwLock<
         HashMap<
             ThreadKey,
@@ -145,6 +150,7 @@ impl AppStoreReducer {
         let (updates_tx, _) = broadcast::channel(1024);
         Self {
             snapshot: RwLock::new(AppSnapshot::default()),
+            pending_local_studio_thread_routes: RwLock::new(HashSet::new()),
             last_thread_state_updates: RwLock::new(HashMap::new()),
             last_thread_item_upserts: RwLock::new(HashMap::new()),
             dynamic_tool_arg_buffers: RwLock::new(HashMap::new()),
@@ -332,10 +338,11 @@ impl AppStoreReducer {
         {
             let mut snapshot = self.snapshot.write().expect("app store lock poisoned");
             let active_thread_key = snapshot.active_thread.clone();
-            snapshot.threads.retain(|key, _| {
+            snapshot.threads.retain(|key, thread| {
                 let keep = key.server_id != server_id
                     || incoming_ids.contains(&key.thread_id)
-                    || active_thread_key.as_ref() == Some(key);
+                    || active_thread_key.as_ref() == Some(key)
+                    || thread.agent_runtime_kind == "local-studio";
                 if !keep {
                     removed_thread_keys.push(key.clone());
                 }
@@ -367,7 +374,9 @@ impl AppStoreReducer {
                         entry.model = next_model;
                         updated_thread_keys.push(key.clone());
                     }
-                    if entry.agent_runtime_kind != runtime_kind {
+                    if entry.agent_runtime_kind != runtime_kind
+                        && entry.agent_runtime_kind != "local-studio"
+                    {
                         entry.agent_runtime_kind = runtime_kind.clone();
                         updated_thread_keys.push(key);
                     }
@@ -490,10 +499,11 @@ impl AppStoreReducer {
         {
             let mut snapshot = self.snapshot.write().expect("app store lock poisoned");
             let active_thread_key = snapshot.active_thread.clone();
-            snapshot.threads.retain(|key, _| {
+            snapshot.threads.retain(|key, thread| {
                 let keep = key.server_id != server_id
                     || incoming_ids.contains(&key.thread_id)
-                    || active_thread_key.as_ref() == Some(key);
+                    || active_thread_key.as_ref() == Some(key)
+                    || thread.agent_runtime_kind == "local-studio";
                 if !keep {
                     removed_thread_keys.push(key.clone());
                 }
@@ -586,6 +596,14 @@ impl AppStoreReducer {
         let key = thread.key.clone();
         {
             let mut snapshot = self.snapshot.write().expect("app store lock poisoned");
+            if self
+                .pending_local_studio_thread_routes
+                .write()
+                .expect("pending Local Studio route lock poisoned")
+                .remove(&key)
+            {
+                thread.agent_runtime_kind = "local-studio".to_string();
+            }
             let existing = snapshot.threads.get(&key).cloned();
             if let Some(existing) = existing.as_ref() {
                 // Diagnostic for the duplicate-user-message bug (task #11):
@@ -1310,8 +1328,18 @@ impl AppStoreReducer {
         let changed = {
             let mut snapshot = self.snapshot.write().expect("app store lock poisoned");
             let Some(thread) = snapshot.threads.get_mut(key) else {
+                if runtime_kind == "local-studio" {
+                    self.pending_local_studio_thread_routes
+                        .write()
+                        .expect("pending Local Studio route lock poisoned")
+                        .insert(key.clone());
+                }
                 return;
             };
+            self.pending_local_studio_thread_routes
+                .write()
+                .expect("pending Local Studio route lock poisoned")
+                .remove(key);
             if thread.agent_runtime_kind == runtime_kind {
                 false
             } else {
@@ -2229,11 +2257,19 @@ impl AppStoreReducer {
     {
         let inserted = {
             let mut snapshot = self.snapshot.write().expect("app store lock poisoned");
+            let pending_local_studio_route = self
+                .pending_local_studio_thread_routes
+                .write()
+                .expect("pending Local Studio route lock poisoned")
+                .remove(&key);
             let inserted = !snapshot.threads.contains_key(&key);
             let thread = snapshot
                 .threads
                 .entry(key.clone())
                 .or_insert_with(|| ThreadSnapshot::from_info(&key.server_id, info.clone()));
+            if pending_local_studio_route {
+                thread.agent_runtime_kind = "local-studio".to_string();
+            }
             thread.info.id = info.id;
             if info.title.is_some() {
                 thread.info.title = info.title;
@@ -3708,6 +3744,64 @@ mod tests {
             reducer.thread_snapshot(&key).unwrap().agent_runtime_kind,
             "pi".to_string()
         );
+    }
+
+    #[test]
+    fn pending_local_studio_route_labels_thread_created_by_async_event() {
+        let reducer = AppStoreReducer::new();
+        let key = ThreadKey {
+            server_id: "alleycat:local-studio:controller".to_string(),
+            thread_id: "thread-1".to_string(),
+        };
+
+        reducer.set_thread_agent_runtime(&key, "local-studio".to_string());
+        reducer.upsert_or_merge_thread(key.clone(), make_thread_info("thread-1"), |_| {});
+
+        assert_eq!(
+            reducer.thread_snapshot(&key).unwrap().agent_runtime_kind,
+            "local-studio"
+        );
+    }
+
+    #[test]
+    fn pending_thread_route_behavior_is_local_studio_only() {
+        let reducer = AppStoreReducer::new();
+        let key = ThreadKey {
+            server_id: "alleycat:controller".to_string(),
+            thread_id: "thread-1".to_string(),
+        };
+
+        reducer.set_thread_agent_runtime(&key, "pi".to_string());
+        reducer.upsert_or_merge_thread(key.clone(), make_thread_info("thread-1"), |_| {});
+
+        assert_eq!(
+            reducer.thread_snapshot(&key).unwrap().agent_runtime_kind,
+            "codex"
+        );
+    }
+
+    #[test]
+    fn destructive_sync_never_prunes_or_relabels_local_studio_threads() {
+        let reducer = AppStoreReducer::new();
+        for id in ["listed", "outside-page"] {
+            let mut thread = ThreadSnapshot::from_info("srv", make_thread_info(id));
+            thread.agent_runtime_kind = "local-studio".to_string();
+            reducer.upsert_thread_snapshot(thread);
+        }
+
+        reducer.sync_thread_list("srv", &[make_thread_info("listed")]);
+
+        let snapshot = reducer.snapshot();
+        for id in ["listed", "outside-page"] {
+            let key = ThreadKey {
+                server_id: "srv".to_string(),
+                thread_id: id.to_string(),
+            };
+            assert_eq!(
+                snapshot.threads.get(&key).unwrap().agent_runtime_kind,
+                "local-studio"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Purpose

Keep Local Studio sessions visible and correctly labeled across mobile reconnects and scanner refreshes, without changing ordinary Codex or generic multi-agent behavior, and prepare the validated 2.0.0 mobile release.

## Changes

- route Local Studio-only session listing and new thread starts explicitly to the Local Studio runtime
- reconcile Local Studio list pages additively so partial pages cannot prune durable sessions
- preserve Local Studio identity when notifications arrive before asynchronous thread insertion
- keep current Local Studio sessions visible alongside legacy pins on both mobile platforms
- skip OpenAI account probes and sign-in warnings for Local Studio-only connections
- force Pi and Local Studio Pi to never request approvals and to use full filesystem access for start, resume, fork, and turns
- preserve existing Codex permission and generic scanner behavior
- set iOS and Android release version to 2.0.0

## Verification

- shared Rust: 797 total, 792 passed, 5 environment-dependent tests ignored, 0 failed
- Android unit tests: 52 passed, 0 failed
- iOS unit tests: 216 passed, 0 failed
- iOS UI tests: 7 executed, 0 failed, 1 intentional live-screenshot skip
- real Kittylitter/Iroh Local Studio E2E: 20 passed, 0 failed
  - exact streamed response and reasoning/item lifecycle
  - tool calling, shell execution, file write/read ordering, and full filesystem access
  - reconnect cursor and mid-turn disconnect hydration
  - desktop-to-phone resume and phone-to-desktop visibility
  - compaction and post-compaction continuation
- Android emulator upgrade from persisted 1.6 data to 2.0.0
  - existing sessions remained visible and Local Studio-labeled
  - new thread routed through Local Studio Pi
  - streamed exact response remained after background/foreground and reinstall
  - no Local Studio account/read probe after reconnect
- exact native versions verified: 2.0.0 / build 200000254

## Companion fix

- Local Studio packaged Pi provider-data fix: sybil-solutions/local-studio#358
