### PR TITLE
ci: unblock pinned store releases

### DIFF
--- a/.github/workflows/android-play-release.yml
+++ b/.github/workflows/android-play-release.yml
@@ -3,6 +3,11 @@ name: Android Play Release
 on:
   workflow_dispatch:
     inputs:
+      source_ref:
+        description: "Git ref to build. Defaults to the dispatched commit."
+        required: false
+        default: ""
+        type: string
       track:
         description: "Upload track (destination if promote_track is blank)."
         required: false
@@ -88,6 +93,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.source_ref || github.sha }}
           submodules: recursive
           fetch-depth: 0
 
@@ -171,6 +177,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.source_ref || github.sha }}
           submodules: recursive
           fetch-depth: 0
 

--- a/apps/ios/scripts/app-store-release.sh
+++ b/apps/ios/scripts/app-store-release.sh
@@ -95,11 +95,15 @@ asc versions attach-build \
     --output json >/dev/null
 
 echo "==> Validating App Store submission readiness"
-asc validate \
+validate_log="$BUILD_DIR/validation.json"
+if ! asc validate \
     --app "$APP_STORE_APP_ID" \
     --version-id "$VERSION_ID" \
     --strict \
-    --output json >/dev/null
+    --output json >"$validate_log" 2>&1; then
+    cat "$validate_log" >&2
+    exit 1
+fi
 
 echo "==> Submitting build for App Store review"
 SUBMISSION_ID="$(


### PR DESCRIPTION
## Purpose
Unblock the requested Litter 1.7.0 store promotion without rebuilding current 2.0.0 source under a 1.7 label.

## Changes
- allow Android Play release jobs dispatched from protected `main` to build a pinned release source ref
- print App Store validation failures so submission blockers are actionable

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/android-play-release.yml", aliases: true)'`\n- `bash -n apps/ios/scripts/app-store-release.sh`\n- `git diff --check`