### PR TITLE
release: clear 1.7 store blockers

### DIFF
--- a/.github/workflows/android-play-release.yml
+++ b/.github/workflows/android-play-release.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: ""
         type: string
+      publish_to_play:
+        description: "Publish the signed bundle to Google Play. Disable to produce artifacts for a manual upload."
+        required: false
+        default: true
+        type: boolean
       track:
         description: "Upload track (destination if promote_track is blank)."
         required: false
@@ -66,6 +71,7 @@ jobs:
           java-version: "21"
 
       - name: Verify Google Play release access
+        if: inputs.publish_to_play
         env:
           ANDROID_UPLOAD_KEYSTORE_B64: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_B64 }}
           LITTER_UPLOAD_STORE_PASSWORD: ${{ secrets.LITTER_UPLOAD_STORE_PASSWORD }}
@@ -353,6 +359,7 @@ jobs:
             -PLITTER_UPLOAD_KEY_PASSWORD="$LITTER_UPLOAD_KEY_PASSWORD"
 
       - name: Publish and promote Android bundle to Google Play
+        if: inputs.publish_to_play
         env:
           JAVA_HOME: ${{ env.JAVA_HOME }}
           ANDROID_SDK_ROOT: ${{ env.ANDROID_HOME }}

--- a/apps/ios/scripts/app-store-release.sh
+++ b/apps/ios/scripts/app-store-release.sh
@@ -94,6 +94,13 @@ asc versions attach-build \
     --build "$BUILD_ID" \
     --output json >/dev/null
 
+echo "==> Completing current App Store age-rating fields"
+asc age-rating edit \
+    --version-id "$VERSION_ID" \
+    --social-media false \
+    --social-media-age-restricted false \
+    --output json >/dev/null
+
 echo "==> Validating App Store submission readiness"
 validate_log="$BUILD_DIR/validation.json"
 if ! asc validate \


### PR DESCRIPTION
## Purpose
Clear the remaining blockers for the requested Litter 1.7.0 production promotion.

## Changes
- allow a signed Android AAB artifact-only run when the Play service account cannot publish
- set the two newly-required App Store social-media age-rating fields to false before validation

## Verification
- workflow YAML parsed successfully
- `bash -n apps/ios/scripts/app-store-release.sh`
- `git diff --check`