### PR TITLE
ci: move supported actions to Node 24

### DIFF
--- a/.github/dist-build-setup.yml
+++ b/.github/dist-build-setup.yml
@@ -28,7 +28,7 @@
     } >> "$GITHUB_ENV"
 
 - name: Install sccache
-  uses: mozilla-actions/sccache-action@v0.0.9
+  uses: mozilla-actions/sccache-action@v0.0.11
 
 - name: Resolve Alleycat to latest main
   shell: bash

--- a/.github/workflows/android-apk-release.yml
+++ b/.github/workflows/android-apk-release.yml
@@ -16,7 +16,7 @@ jobs:
       run_release: ${{ steps.filter.outputs.run_release }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
 
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
@@ -97,14 +97,14 @@ jobs:
 
       - name: Setup sccache
         if: env.SCCACHE_ENDPOINT != '' && env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != ''
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Sync codex submodule
         run: ./apps/ios/scripts/sync-codex.sh --preserve-current
 
       - name: Restore generated mobile bindings cache
         id: mobile-bindings-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             shared/rust-bridge/generated
@@ -125,7 +125,7 @@ jobs:
             shared/rust-bridge/generated \
 
       - name: Upload shared prep artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: shared-prep
           path: .ci-prep/shared
@@ -149,19 +149,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
+        with:
+          cmdline-tools-version: '12266719'
 
       - name: Install Android platforms and NDK
         run: |
@@ -195,7 +197,7 @@ jobs:
 
       - name: Setup sccache
         if: env.SCCACHE_ENDPOINT != '' && env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != ''
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Prime sccache
         if: env.SCCACHE_ENDPOINT != '' && env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != ''
@@ -207,7 +209,7 @@ jobs:
           sccache --show-stats || true
 
       - name: Download shared prep artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: shared-prep
           path: .ci-prep/shared
@@ -234,7 +236,7 @@ jobs:
         run: make rust-android
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Decode upload keystore
         env:
@@ -264,7 +266,7 @@ jobs:
 
       - name: Upload build artifact (manual runs)
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: app-release
           path: |
@@ -273,7 +275,7 @@ jobs:
 
       - name: Publish GitHub Release (tag runs)
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             apps/android/app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/android-play-release.yml
+++ b/.github/workflows/android-play-release.yml
@@ -60,12 +60,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"
@@ -97,7 +97,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.source_ref || github.sha }}
           submodules: recursive
@@ -130,14 +130,14 @@ jobs:
 
       - name: Setup sccache
         if: env.SCCACHE_ENDPOINT != '' && env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != ''
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Sync codex submodule
         run: ./apps/ios/scripts/sync-codex.sh --preserve-current
 
       - name: Restore generated mobile bindings cache
         id: mobile-bindings-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             shared/rust-bridge/generated
@@ -158,7 +158,7 @@ jobs:
             shared/rust-bridge/generated \
 
       - name: Upload shared prep artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: shared-prep
           path: .ci-prep/shared
@@ -181,20 +181,22 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.source_ref || github.sha }}
           submodules: recursive
           fetch-depth: 0
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
+        with:
+          cmdline-tools-version: '12266719'
 
       - name: Install Android platforms and NDK
         run: |
@@ -228,7 +230,7 @@ jobs:
 
       - name: Setup sccache
         if: env.SCCACHE_ENDPOINT != '' && env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != ''
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Prime sccache
         if: env.SCCACHE_ENDPOINT != '' && env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != ''
@@ -240,7 +242,7 @@ jobs:
           sccache --show-stats || true
 
       - name: Download shared prep artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: shared-prep
           path: .ci-prep/shared
@@ -262,7 +264,7 @@ jobs:
         run: env -u RUSTC_WRAPPER cargo install cargo-ndk --locked
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Decode release credentials
         env:
@@ -402,7 +404,7 @@ jobs:
 
       - name: Upload Android release artifacts
         if: always() && steps.build_android_release.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: android-play-release-${{ github.run_number }}
           if-no-files-found: error

--- a/.github/workflows/ios-app-store-release.yml
+++ b/.github/workflows/ios-app-store-release.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/ios-testflight-finalize.yml
+++ b/.github/workflows/ios-testflight-finalize.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate required secrets
         env:

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
@@ -106,7 +106,7 @@ jobs:
 
       - name: Setup sccache
         if: env.SCCACHE_ENDPOINT != '' && env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != ''
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Prime sccache
         if: env.SCCACHE_ENDPOINT != '' && env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != ''
@@ -141,7 +141,7 @@ jobs:
             apps/ios/Sources/Litter/Bridge/UniFFICodexClient.generated.swift
 
       - name: Upload iOS release prep artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ios-release-prep
           path: .ci-prep/ios
@@ -165,7 +165,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
@@ -184,7 +184,7 @@ jobs:
           asc --version
 
       - name: Download iOS release prep artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ios-release-prep
           path: .ci-prep/ios

--- a/.github/workflows/mac-direct-dist.yml
+++ b/.github/workflows/mac-direct-dist.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
@@ -58,7 +58,7 @@ jobs:
           targets: aarch64-apple-ios-macabi,x86_64-apple-ios-macabi,i686-unknown-linux-musl
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Prepare Mac Catalyst release assets
         env:
@@ -80,7 +80,7 @@ jobs:
             apps/ios/Sources/Litter/Bridge/UniFFICodexClient.generated.swift
 
       - name: Upload Mac release prep artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: mac-release-prep-direct
           path: .ci-prep/mac
@@ -96,7 +96,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
@@ -138,7 +138,7 @@ jobs:
           xcodebuild -version
 
       - name: Download Mac release prep artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: mac-release-prep-direct
           path: .ci-prep/mac
@@ -235,7 +235,7 @@ jobs:
           shasum -a 256 "$DMG_PATH"
 
       - name: Upload DMG as workflow artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ steps.locate.outputs.dmg_name }}
           path: |

--- a/.github/workflows/mac-testflight.yml
+++ b/.github/workflows/mac-testflight.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
@@ -58,7 +58,7 @@ jobs:
           targets: aarch64-apple-ios-macabi,x86_64-apple-ios-macabi,i686-unknown-linux-musl
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Prime sccache
         run: |
@@ -93,7 +93,7 @@ jobs:
             apps/ios/Sources/Litter/Bridge/UniFFICodexClient.generated.swift
 
       - name: Upload Mac release prep artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: mac-release-prep
           path: .ci-prep/mac
@@ -109,7 +109,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
@@ -163,7 +163,7 @@ jobs:
           asc --version
 
       - name: Download Mac release prep artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: mac-release-prep
           path: .ci-prep/mac

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
@@ -81,14 +81,14 @@ jobs:
 
       - name: Setup sccache
         if: env.SCCACHE_ENDPOINT != '' && env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != ''
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Sync codex submodule
         run: ./apps/ios/scripts/sync-codex.sh --preserve-current
 
       - name: Restore generated mobile bindings cache
         id: mobile-bindings-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             shared/rust-bridge/generated
@@ -129,7 +129,7 @@ jobs:
             apps/ios/GeneratedRust/Headers
 
       - name: Upload shared prep artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: shared-prep
           path: .ci-prep/shared
@@ -150,19 +150,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
+        with:
+          cmdline-tools-version: '12266719'
 
       - name: Install Android platforms and NDK
         run: |
@@ -196,10 +198,10 @@ jobs:
 
       - name: Setup sccache
         if: env.SCCACHE_ENDPOINT != '' && env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != ''
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Download shared prep artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: shared-prep
           path: .ci-prep/shared
@@ -226,7 +228,7 @@ jobs:
         run: make rust-android
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Assemble debug
         run: apps/android/gradlew -p apps/android :app:assembleDebug
@@ -239,7 +241,7 @@ jobs:
 
       - name: Upload Android test report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: android-test-report
           path: apps/android/app/build/reports/tests/testDebugUnitTest
@@ -261,7 +263,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
@@ -298,10 +300,10 @@ jobs:
 
       - name: Setup sccache
         if: env.SCCACHE_ENDPOINT != '' && env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != ''
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Download shared prep artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: shared-prep
           path: .ci-prep/shared

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -43,13 +43,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
 
       - name: Detect release changes
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             release_android:
@@ -172,13 +172,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Setup Java
         if: needs.detect-release-changes.outputs.release_android == 'true'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"
@@ -232,7 +232,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
@@ -267,7 +267,7 @@ jobs:
 
       - name: Setup sccache
         if: env.SCCACHE_ENDPOINT != '' && env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != ''
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Prime sccache
         if: env.SCCACHE_ENDPOINT != '' && env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != ''
@@ -283,7 +283,7 @@ jobs:
 
       - name: Restore generated mobile bindings cache
         id: mobile-bindings-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             shared/rust-bridge/generated
@@ -343,7 +343,7 @@ jobs:
             apps/ios/GeneratedRust/.swift-bindings.hash
 
       - name: Upload shared prep artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: shared-prep
           path: .ci-prep/shared
@@ -367,19 +367,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
+        with:
+          cmdline-tools-version: '12266719'
 
       - name: Install Android platforms and NDK
         run: |
@@ -413,7 +415,7 @@ jobs:
 
       - name: Setup sccache
         if: env.SCCACHE_ENDPOINT != '' && env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != ''
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Prime sccache
         if: env.SCCACHE_ENDPOINT != '' && env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != ''
@@ -425,7 +427,7 @@ jobs:
           sccache --show-stats || true
 
       - name: Download shared prep artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: shared-prep
           path: .ci-prep/shared
@@ -447,7 +449,7 @@ jobs:
         run: env -u RUSTC_WRAPPER cargo install cargo-ndk --locked
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Decode release credentials
         env:
@@ -585,7 +587,7 @@ jobs:
 
       - name: Upload Android release artifacts
         if: always() && steps.build_android_release.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: android-play-release-${{ github.run_number }}
           if-no-files-found: error
@@ -613,7 +615,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
@@ -650,10 +652,10 @@ jobs:
 
       - name: Setup sccache
         if: env.SCCACHE_ENDPOINT != '' && env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != ''
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Download shared prep artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: shared-prep
           path: .ci-prep/shared
@@ -695,7 +697,7 @@ jobs:
             apps/ios/Sources/Litter/Bridge/UniFFICodexClient.generated.swift
 
       - name: Upload iOS release prep artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ios-release-prep
           path: .ci-prep/ios
@@ -720,7 +722,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
@@ -739,7 +741,7 @@ jobs:
           asc --version
 
       - name: Download iOS release prep artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ios-release-prep
           path: .ci-prep/ios
@@ -911,7 +913,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
@@ -948,10 +950,10 @@ jobs:
 
       - name: Setup sccache
         if: env.SCCACHE_ENDPOINT != '' && env.AWS_ACCESS_KEY_ID != '' && env.AWS_SECRET_ACCESS_KEY != ''
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Download shared prep artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: shared-prep
           path: .ci-prep/shared
@@ -993,7 +995,7 @@ jobs:
             apps/ios/Sources/Litter/Bridge/UniFFICodexClient.generated.swift
 
       - name: Upload Mac release prep artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: mac-release-prep
           path: .ci-prep/mac
@@ -1010,7 +1012,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
@@ -1058,7 +1060,7 @@ jobs:
           asc --version
 
       - name: Download Mac release prep artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: mac-release-prep
           path: .ci-prep/mac
@@ -1186,7 +1188,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
@@ -1219,7 +1221,7 @@ jobs:
 
       - name: Download Mac release prep artifact
         if: steps.gate.outputs.configured == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: mac-release-prep
           path: .ci-prep/mac
@@ -1315,7 +1317,7 @@ jobs:
 
       - name: Upload DMG as workflow artifact
         if: steps.gate.outputs.configured == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ steps.locate.outputs.dmg_name }}
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,7 @@ jobs:
         shell: "bash"
       - name: "Install sccache"
         if: steps.sccache-config.outputs.enabled == 'true'
-        uses: "mozilla-actions/sccache-action@v0.0.9"
+        uses: "mozilla-actions/sccache-action@v0.0.11"
       - name: "Resolve Alleycat to latest main"
         run: "./tools/scripts/update-alleycat-main.sh --kittylitter"
         shell: "bash"


### PR DESCRIPTION
## Purpose

Remove the repository-owned GitHub Actions Node 20 drift wherever upstream has a compatible Node 24 release, while preserving existing build and release behavior.

## What changed

- Migrated 90 supported Node 20 action invocations across all 11 workflows:
  - `actions/checkout@v6`
  - `actions/cache@v5`
  - `actions/upload-artifact@v6`
  - `actions/download-artifact@v7`
  - `actions/setup-java@v5`
  - `gradle/actions/setup-gradle@v5`
  - `android-actions/setup-android@v4`
  - `mozilla-actions/sccache-action@v0.0.11`
  - `dorny/paths-filter@v4`
  - `softprops/action-gh-release@v3`
- Updated the cargo-dist setup fragment as well as generated `release.yml`, so regeneration will not restore the older sccache action.
- Pinned all four Android setup steps to command-line tools `12266719`; setup-android v4 otherwise changes the default to `14742923`, which would mix a toolchain upgrade into this runtime migration.
- Chose download-artifact v7 instead of v8 because v8 newly fails digest mismatches and changes direct-download behavior; that deserves a separate compatibility pass.

## Remaining upstream gap

The 14 `mlugg/setup-zig@v2` uses remain on Node 20. The latest upstream release is still v2.2.1 and its action manifest declares `node20`; there is no supported Node 24 major to adopt yet.

## Validation

- Parsed every `.github/**/*.yml` file successfully.
- `git diff --check`
- Confirmed zero stale targeted action versions remain.
- Confirmed all four `setup-android@v4` steps pin `cmdline-tools-version: 12266719`.
- Read the selected upstream action manifests and confirmed Node 24 for setup-java v5, setup-gradle v5, setup-android v4, sccache v0.0.11, paths-filter v4, and action-gh-release v3.
- Confirmed all statically declared runners are GitHub-hosted; no self-hosted runner compatibility migration is required.

Full mobile CI on this exact branch is the runtime acceptance gate. Release publication, TestFlight, Google Play, and authenticated version-bump pushes remain separate live acceptance surfaces and are not represented as exercised by YAML parsing or PR CI.
