### PR TITLE
mobile: remove unused compatibility APIs

### DIFF
--- a/apps/android/app/src/main/java/com/litter/android/state/SavedServerStore.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/SavedServerStore.kt
@@ -333,34 +333,6 @@ object SavedServerStore {
         save(context, existing)
     }
 
-    /**
-     * Legacy Alleycat persistence path. Current remote-host pairings use
-     * [rememberAlleycat].
-     */
-    fun rememberAlleycat(
-        context: Context,
-        serverId: String,
-        displayName: String,
-        relayHost: String,
-    ) {
-        val server = SavedServer(
-            id = serverId,
-            name = displayName,
-            hostname = relayHost,
-            port = 0,
-            codexPorts = emptyList(),
-            sshPort = null,
-            source = "manual",
-            hasCodexServer = true,
-            rememberedByUser = true,
-            alleycatHost = relayHost,
-        )
-        val existing = load(context).toMutableList()
-        existing.removeAll { it.id == server.id || it.deduplicationKey == server.deduplicationKey }
-        existing.add(server)
-        save(context, existing)
-    }
-
     fun rememberAlleycat(
         context: Context,
         serverId: String,

--- a/apps/ios/Sources/Litter/Models/SavedServerStore.swift
+++ b/apps/ios/Sources/Litter/Models/SavedServerStore.swift
@@ -63,19 +63,6 @@ enum SavedServerStore {
         save(saved)
     }
 
-    /// Legacy Alleycat persistence path. Kept so old app builds can still
-    /// decode records; current host pairings use `rememberAlleycat`.
-    static func rememberAlleycat(_ server: DiscoveredServer, relayHost: String) {
-        var saved = load()
-        saved.removeAll { entry in matches(server, entry) }
-        saved.append(
-            SavedServer
-                .from(server, rememberedByUser: true)
-                .withAlleycatHost(relayHost)
-        )
-        save(saved)
-    }
-
     static func rememberAlleycat(
         _ server: DiscoveredServer,
         nodeId: String,

--- a/apps/ios/Sources/Litter/Models/WallpaperManager.swift
+++ b/apps/ios/Sources/Litter/Models/WallpaperManager.swift
@@ -138,10 +138,6 @@ final class WallpaperManager {
         FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
     }
 
-    // Legacy compat — some views still check this
-    var wallpaperImage: UIImage? { resolvedWallpaperImage }
-    var isWallpaperSet: Bool { resolvedConfig != nil && resolvedConfig?.type != WallpaperType.none }
-
     private init() {
         loadPrefs()
     }


### PR DESCRIPTION
## Purpose

Remove obsolete app-internal compatibility APIs whose callers were migrated, while retaining every legacy persisted-data decoder.

## Changes

- remove the unused iOS relay-host-only `rememberAlleycat` overload
- remove the unused Android relay-host-only `rememberAlleycat` overload
- remove two unused iOS wallpaper aliases

Net: 45 deletions across three files.

## Safety evidence

- repo-wide reference and history audit found zero current callers
- the sole Alleycat callers migrated to the node/relay/agent overload in `e3861e81`
- legacy saved-server fields, JSON/Codable decoding, Rust record fields, and migration tests remain intact
- wallpaper preferences and the live scoped `wallpaperImage(for:scope:themeManager:)` API remain intact

## Verification

- `git diff --check`
- Swift frontend parse of both changed Swift files
- Android `:app:compileDebugKotlin` (successful; only pre-existing deprecation warnings)