### PR TITLE
android: remove unused battery exemption permission

### DIFF
--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />


### PR DESCRIPTION
## Purpose

Remove an unused special Android permission. The app never requests a battery-optimization exemption, checks exemption state, or opens the exemption settings flow, so the manifest declaration grants no current behavior and creates unnecessary Play-policy surface.

## Verification

- repository-wide Android source sweep found no consumer of REQUEST_IGNORE_BATTERY_OPTIMIZATIONS, ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS, or isIgnoringBatteryOptimizations
- merged debug manifest processing passed
- Android unit suite passed: 52 tests
- git diff --check passed

This does not address POST_NOTIFICATIONS runtime consent; that remains a separate user-visible flow requiring UX and device validation.