### PR TITLE
ci: run release preflight script tests

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -110,6 +110,11 @@ jobs:
           CARGO_INCREMENTAL: "0"
         run: cargo test --manifest-path shared/rust-bridge/Cargo.toml -p codex-mobile-client
 
+      - name: Release script tests
+        run: |
+          bash apps/ios/scripts/tests/testflight-finalize.test.sh
+          python3 tools/scripts/tests/test_fetch_mobile_store_artifacts.py
+
       - name: Package shared mobile sources
         run: |
           mkdir -p apps/ios/GeneratedRust/Headers .ci-prep/shared


### PR DESCRIPTION
## Purpose
Run the tracked TestFlight finalization and mobile-store preflight tests in the existing shared mobile CI job.

## Verification
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/mobile-ci.yml'); puts 'mobile-ci.yml parses'"`\n- `bash apps/ios/scripts/tests/testflight-finalize.test.sh`\n- `python3 tools/scripts/tests/test_fetch_mobile_store_artifacts.py`\n- `git diff --check`