### PR TITLE
android: request notification permission once

### DIFF
--- a/apps/android/app/src/main/java/com/litter/android/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/litter/android/MainActivity.kt
@@ -1,7 +1,11 @@
 package com.litter.android
 
+import android.Manifest
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -40,11 +44,19 @@ class MainActivity : ComponentActivity() {
         const val EXTRA_NOTIFICATION_SERVER_ID = "litter.notification.serverId"
         const val EXTRA_NOTIFICATION_THREAD_ID = "litter.notification.threadId"
         const val EXTRA_OPEN_PET_SETTINGS = "litter.openPetSettings"
+        const val NOTIFICATION_PERMISSION_REQUESTED_KEY = "notification_permission_requested"
     }
 
     private var appModel: AppModel? = null
     private val lifecycleController = AppLifecycleController()
     private var openPetSettingsRequest by mutableStateOf(0)
+    private val notificationPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            LLog.i(
+                "MainActivity",
+                if (granted) "Notification permission granted" else "Notification permission not granted",
+            )
+        }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         // Must be called before super.onCreate to hand off the system splash
@@ -209,6 +221,7 @@ class MainActivity : ComponentActivity() {
             LLog.i("MainActivity", "Firebase is not configured; skipping FCM token fetch: ${e.message}")
             return
         }
+        requestNotificationPermissionIfNeeded()
 
         messaging.token
             .addOnSuccessListener { token ->
@@ -224,4 +237,29 @@ class MainActivity : ComponentActivity() {
                 LLog.e("MainActivity", "Failed to fetch FCM token", error)
             }
     }
+
+    private fun requestNotificationPermissionIfNeeded() {
+        val preferences = getSharedPreferences("litter_push", MODE_PRIVATE)
+        if (!shouldRequestNotificationPermission(
+                sdkInt = Build.VERSION.SDK_INT,
+                isGranted = checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED,
+                wasAlreadyRequested = preferences.getBoolean(NOTIFICATION_PERMISSION_REQUESTED_KEY, false),
+            )
+        ) {
+            return
+        }
+
+        // Persist before launching so a system-dialog dismissal cannot produce a
+        // permission prompt on every future app launch.
+        preferences.edit().putBoolean(NOTIFICATION_PERMISSION_REQUESTED_KEY, true).apply()
+        notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+    }
+
 }
+
+internal fun shouldRequestNotificationPermission(
+    sdkInt: Int,
+    isGranted: Boolean,
+    wasAlreadyRequested: Boolean,
+): Boolean =
+    sdkInt >= Build.VERSION_CODES.TIRAMISU && !isGranted && !wasAlreadyRequested

--- a/apps/android/app/src/test/java/com/litter/android/MainActivityNotificationPermissionTest.kt
+++ b/apps/android/app/src/test/java/com/litter/android/MainActivityNotificationPermissionTest.kt
@@ -1,0 +1,44 @@
+package com.litter.android
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MainActivityNotificationPermissionTest {
+
+    @Test
+    fun `only Android 13 and newer needs the notification runtime prompt`() {
+        assertFalse(
+            shouldRequestNotificationPermission(
+                sdkInt = 32,
+                isGranted = false,
+                wasAlreadyRequested = false,
+            ),
+        )
+        assertTrue(
+            shouldRequestNotificationPermission(
+                sdkInt = 33,
+                isGranted = false,
+                wasAlreadyRequested = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `granted and previously dismissed notification prompts are not repeated`() {
+        assertFalse(
+            shouldRequestNotificationPermission(
+                sdkInt = 36,
+                isGranted = true,
+                wasAlreadyRequested = false,
+            ),
+        )
+        assertFalse(
+            shouldRequestNotificationPermission(
+                sdkInt = 36,
+                isGranted = false,
+                wasAlreadyRequested = true,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Purpose
Request Android 13+ notification permission once after Firebase is available, so background turn status notifications can reach the user.

## Behavior
- No prompt on Android 12 and below.
- No prompt when already granted or after the initial system dialog is shown.
- Unconfigured Firebase builds do not prompt.

## Verification
- Android unit-test report: `MainActivityNotificationPermissionTest` — 2 tests, 0 failures, 0 errors.
- `git diff --check`

The local Gradle client hung during post-test cleanup after producing the passing report; Mobile CI will run the full Android suite.