### PR TITLE
android: cover session tree derivation

### DIFF
--- a/apps/android/app/src/test/java/com/litter/android/SessionsDerivationTests.kt
+++ b/apps/android/app/src/test/java/com/litter/android/SessionsDerivationTests.kt
@@ -5,6 +5,9 @@ import com.litter.android.ui.sessions.WorkspaceSortMode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import uniffi.codex_mobile_client.AppSessionSummary
+import uniffi.codex_mobile_client.AppSubagentStatus
+import uniffi.codex_mobile_client.ThreadKey
 
 class SessionsDerivationTests {
 
@@ -20,17 +23,118 @@ class SessionsDerivationTests {
         assertEquals("~", SessionsDerivation.normalizedCwd(""))
     }
 
-    // Note: Full derivation tests require constructing AppSessionSummary objects,
-    // which depend on UniFFI-generated types. These tests would need the native
-    // library loaded. Integration tests should cover:
-    //
-    // - derive() builds correct parent→child tree from parentThreadId
-    // - derive() groups sessions by (serverId + cwd)
-    // - derive() filters by server ID
-    // - derive() filters by fork-only mode
-    // - derive() search matches title, cwd, model, agentDisplayLabel
-    // - derive() sorts by RECENT (max updatedAt desc)
-    // - derive() sorts by NAME (workspaceLabel asc)
-    // - derive() handles empty input
-    // - Orphaned children become root nodes
+    @Test
+    fun `derive nests a local studio fork with its parent and preserves the workspace group`() {
+        val parent = session(threadId = "desktop-thread", updatedAt = 100, cwd = "/Projects/Litter")
+        val child = session(
+            threadId = "phone-fork",
+            updatedAt = 200,
+            cwd = "/Projects/Litter",
+            parentThreadId = parent.key.threadId,
+            isFork = true,
+        )
+
+        val result = SessionsDerivation.derive(listOf(child, parent))
+
+        assertEquals(2, result.totalCount)
+        assertEquals(1, result.groups.size)
+        assertEquals("studio|/projects/litter", result.workspaceGroupKeys.single())
+        assertEquals("desktop-thread", result.groups.single().nodes.single().summary.key.threadId)
+        assertEquals("phone-fork", result.groups.single().nodes.single().children.single().summary.key.threadId)
+        assertEquals(parent.key, result.parentByKey.getValue(child.key).key)
+        assertEquals("studio|/projects/litter", result.workspaceGroupKeyByThreadKey.getValue(child.key))
+    }
+
+    @Test
+    fun `derive makes a filtered-out parent a root instead of hiding the child`() {
+        val parent = session(threadId = "parent", updatedAt = 100, title = "Desktop work")
+        val child = session(
+            threadId = "child",
+            updatedAt = 200,
+            title = "Phone follow-up",
+            parentThreadId = parent.key.threadId,
+            isFork = true,
+        )
+
+        val result = SessionsDerivation.derive(
+            summaries = listOf(parent, child),
+            forkOnly = true,
+        )
+
+        assertEquals(listOf(child.key), result.filteredThreadKeys)
+        assertEquals("child", result.groups.single().nodes.single().summary.key.threadId)
+        assertTrue(result.groups.single().nodes.single().children.isEmpty())
+        assertTrue(result.parentByKey.isEmpty())
+    }
+
+    @Test
+    fun `derive search matches Local Studio metadata and sorts workspace names`() {
+        val localStudio = session(
+            threadId = "studio",
+            updatedAt = 100,
+            cwd = "/work/Zebra",
+            agentDisplayLabel = "Local Studio",
+        )
+        val codex = session(
+            serverId = "codex",
+            threadId = "codex",
+            updatedAt = 200,
+            cwd = "/work/alpha",
+            title = "Other work",
+        )
+
+        val searched = SessionsDerivation.derive(
+            summaries = listOf(codex, localStudio),
+            searchQuery = "studio",
+        )
+        assertEquals(listOf(localStudio.key), searched.filteredThreadKeys)
+
+        val alphabetical = SessionsDerivation.derive(
+            summaries = listOf(localStudio, codex),
+            sortMode = WorkspaceSortMode.NAME,
+        )
+        assertEquals(listOf("alpha", "Zebra"), alphabetical.groups.map { it.workspaceLabel })
+    }
+
+    private fun session(
+        serverId: String = "studio",
+        threadId: String,
+        updatedAt: Long,
+        cwd: String = "/work/litter",
+        title: String = threadId,
+        parentThreadId: String? = null,
+        isFork: Boolean = false,
+        agentDisplayLabel: String? = null,
+    ) = AppSessionSummary(
+        key = ThreadKey(serverId = serverId, threadId = threadId),
+        agentRuntimeKind = if (serverId == "studio") "local-studio" else "codex",
+        serverDisplayName = if (serverId == "studio") "Local Studio" else "Codex",
+        serverHost = "$serverId.local",
+        title = title,
+        preview = title,
+        cwd = cwd,
+        model = "",
+        modelProvider = "",
+        parentThreadId = parentThreadId,
+        forkedFromId = parentThreadId,
+        agentNickname = null,
+        agentRole = null,
+        agentDisplayLabel = agentDisplayLabel,
+        agentStatus = AppSubagentStatus.UNKNOWN,
+        updatedAt = updatedAt,
+        hasActiveTurn = false,
+        isResumed = false,
+        isSubagent = false,
+        isFork = isFork,
+        lastResponsePreview = null,
+        lastResponseTurnId = null,
+        lastUserMessage = null,
+        lastToolLabel = null,
+        recentToolLog = emptyList(),
+        lastTurnStartMs = null,
+        lastTurnEndMs = null,
+        stats = null,
+        tokenUsage = null,
+        goal = null,
+    )
 }


### PR DESCRIPTION
## Purpose
Replace the obsolete claim that session derivation cannot be unit-tested with coverage for Local Studio session grouping, parent/child projection, filtering, search, and workspace sorting.

## Verification
- Android unit-test report: `SessionsDerivationTests` — 5 tests, 0 failures, 0 errors.
- `git diff --check`