### PR TITLE
ios: remove static new-thread suggestions

### DIFF
--- a/apps/ios/Sources/Litter/Views/NewThreadHeroView.swift
+++ b/apps/ios/Sources/Litter/Views/NewThreadHeroView.swift
@@ -5,8 +5,8 @@ import SwiftUI
 ///
 /// Layout is intentionally simple — the composer lives in a flex VStack that
 /// pushes it toward the vertical center pre-send and toward the bottom
-/// post-send. Title, chips, and suggestions fade out on send so the eye
-/// follows the composer's motion.
+/// post-send. The title and chips fade out on send so the eye follows the
+/// composer's motion.
 ///
 /// On iOS 26 the composer's background is already a liquid-glass pill
 /// (courtesy of `ConversationComposerContentView`); when the layout
@@ -75,9 +75,6 @@ struct NewThreadHeroView: View {
 
                 if !isSending {
                     chipRow
-                        .transition(.opacity)
-
-                    suggestionsList
                         .transition(.opacity)
 
                     Spacer(minLength: 0)
@@ -164,40 +161,4 @@ struct NewThreadHeroView: View {
         return launchableServers.first { $0.id == activeServerId }
     }
 
-    // MARK: - Suggestions
-
-    /// Placeholder suggestion rows. Data source TBD — for now these are
-    /// static prompts so the layout can be dialed in. When the real source
-    /// is wired, swap the array contents and make tapping prefill the
-    /// composer with the row's text.
-    private static let placeholderSuggestions: [String] = [
-        "Make local iPhone command failures self-diagnosing",
-        "Fix the real home feed item cap",
-        "Fix subagent metadata across conversation rows",
-        "Connect your favorite apps to Codex"
-    ]
-
-    private var suggestionsList: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            ForEach(Array(Self.placeholderSuggestions.enumerated()), id: \.offset) { idx, text in
-                if idx > 0 {
-                    Divider()
-                        .background(LitterTheme.textMuted.opacity(0.15))
-                }
-                HStack(spacing: 10) {
-                    Image(systemName: "bubble.left.and.text.bubble.right")
-                        .font(.system(size: 12, weight: .regular))
-                        .foregroundStyle(LitterTheme.textMuted)
-                    Text(text)
-                        .litterFont(size: 13)
-                        .foregroundStyle(LitterTheme.textSecondary)
-                    Spacer(minLength: 0)
-                }
-                .padding(.vertical, 10)
-                .padding(.horizontal, 4)
-            }
-        }
-        .frame(maxWidth: 760)
-        .padding(.horizontal, 24)
-    }
 }


### PR DESCRIPTION
## Purpose
Remove an unfinished static suggestion panel from the wide-screen new-thread surface. The rows advertised internal implementation work, were non-interactive, and the source explicitly marked them as placeholders.

## Changes
- keep the working composer and server, project, and model controls
- remove the four inert placeholder prompts and their dead rendering code

## Verification
- `git diff --check`
- `xcodebuild -project apps/ios/Litter.xcodeproj -scheme Litter -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath /tmp/litter-new-thread-suggestions-derived build CODE_SIGNING_ALLOWED=NO -quiet`