### PR TITLE
docs: clarify TestFlight release lane

### DIFF
--- a/docs/releases/ios-testflight-checklist.md
+++ b/docs/releases/ios-testflight-checklist.md
@@ -19,15 +19,14 @@ credentials therefore fail before the expensive iOS build.
 ## Release Checklist
 
 1. Confirm `apps/ios/project.yml` bundle ID/version/build settings are correct.
-2. Build/archive in Xcode from `apps/ios/Litter.xcodeproj`.
-3. Update `docs/releases/testflight-whats-new.md` with changelog bullets for this build.
-4. Keep `docs/releases/testflight-beta-description.txt` populated with the evergreen Beta App Description.
-5. Upload via `./apps/ios/scripts/testflight-upload.sh` (script auto-applies the Beta App Description and What to Test notes, assigns internal and external beta groups, submits Beta App Review by default, and auto-bumps to the next patch version if the committed repo version has already shipped live).
-6. Validate processing in App Store Connect.
-7. Confirm the build is attached to both internal and external TestFlight groups.
-8. Confirm Beta App Review submission/approval state for the external build, then verify release notes and tester instructions.
-9. If the workflow advanced to a new beta patch version, confirm `apps/ios/project.yml` and `docs/releases/testflight-whats-new.md` were updated for the next cycle.
-10. Smoke test install + login/session/message flow.
+2. Update `docs/releases/testflight-whats-new.md` with changelog bullets for this build.
+3. Keep `docs/releases/testflight-beta-description.txt` populated with the evergreen Beta App Description.
+4. Upload via `./apps/ios/scripts/testflight-upload.sh`. The script regenerates the project, archives, exports, and uploads the IPA; it also applies the Beta App Description and What to Test notes, assigns internal and external beta groups, submits Beta App Review by default, and auto-bumps to the next patch version if the committed repo version has already shipped live.
+5. Validate processing in App Store Connect.
+6. Confirm the build is attached to both internal and external TestFlight groups.
+7. Confirm Beta App Review submission/approval state for the external build, then verify release notes and tester instructions.
+8. If the workflow advanced to a new beta patch version, confirm `apps/ios/project.yml` and `docs/releases/testflight-whats-new.md` were updated for the next cycle.
+9. Smoke test install + login/session/message flow.
 
 If upload succeeds but metadata or review submission fails, rerun only the
 finalization stage with the `iOS TestFlight Finalize` workflow and the existing


### PR DESCRIPTION
## Purpose
Correct the iOS TestFlight checklist so it matches the release script that actually builds, archives, exports, and uploads the IPA.

## Changes
- remove the redundant manual Xcode archive instruction
- name the release script as the single build/archive/upload lane

## Verification
- `git diff --check`
- `bash apps/ios/scripts/tests/testflight-finalize.test.sh`