### PR TITLE
security: forget orphaned Alleycat tokens

### DIFF
--- a/apps/android/app/src/main/java/com/litter/android/state/SavedServerStore.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/SavedServerStore.kt
@@ -310,9 +310,34 @@ object SavedServerStore {
         load(context).filter { it.rememberedByUser }
 
     fun remove(context: Context, serverId: String) {
-        val existing = load(context).toMutableList()
-        existing.removeAll { it.id == serverId }
-        save(context, existing)
+        val existing = load(context)
+        val nodeIdsToForget = orphanedAlleycatNodeIds(removing = serverId, from = existing)
+        val remaining = existing.filter { it.id != serverId }
+        save(context, remaining)
+
+        val credentials = AlleycatCredentialStore(context.applicationContext)
+        nodeIdsToForget.forEach(credentials::deleteToken)
+    }
+
+    /**
+     * Alleycat tokens are keyed by node ID, so retain them while another saved
+     * server still points at the same node. The device-wide identity key stays
+     * outside this server-scoped forget operation.
+     */
+    fun orphanedAlleycatNodeIds(removing: String, from: List<SavedServer>): List<String> {
+        val removedNodeIds =
+            from
+                .filter { it.id == removing }
+                .mapNotNull { it.alleycatNodeId.normalizedAlleycatNodeId() }
+                .toSet()
+        if (removedNodeIds.isEmpty()) return emptyList()
+
+        val retainedNodeIds =
+            from
+                .filter { it.id != removing }
+                .mapNotNull { it.alleycatNodeId.normalizedAlleycatNodeId() }
+                .toSet()
+        return (removedNodeIds - retainedNodeIds).sorted()
     }
 
     fun rename(context: Context, serverId: String, newName: String) {
@@ -352,6 +377,9 @@ object SavedServerStore {
         }
         return withoutScope.lowercase()
     }
+
+    private fun String?.normalizedAlleycatNodeId(): String? =
+        this?.trim()?.lowercase()?.takeIf { it.isNotEmpty() }
 
     private fun migrateDisplayName(server: SavedServer): SavedServer {
         val nodeId = server.alleycatNodeId?.trim()?.takeIf { it.isNotEmpty() } ?: return server

--- a/apps/android/app/src/test/java/com/litter/android/SavedServerTransportTest.kt
+++ b/apps/android/app/src/test/java/com/litter/android/SavedServerTransportTest.kt
@@ -1,6 +1,7 @@
 package com.litter.android
 
 import com.litter.android.state.SavedServer
+import com.litter.android.state.SavedServerStore
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -8,6 +9,28 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SavedServerTransportTest {
+    @Test
+    fun forgettingAlleycatServerReturnsOnlyUnreferencedNodeToken() {
+        val primary = alleycatServer(id = "primary", nodeId = " NODE-A ")
+        val duplicate = alleycatServer(id = "duplicate", nodeId = "node-a")
+        val independent = alleycatServer(id = "independent", nodeId = "node-b")
+
+        assertEquals(
+            emptyList<String>(),
+            SavedServerStore.orphanedAlleycatNodeIds(
+                removing = primary.id,
+                from = listOf(primary, duplicate, independent),
+            ),
+        )
+        assertEquals(
+            listOf("node-b"),
+            SavedServerStore.orphanedAlleycatNodeIds(
+                removing = independent.id,
+                from = listOf(primary, duplicate, independent),
+            ),
+        )
+    }
+
     @Test
     fun codexAndSshDiscoveryRequiresChoiceUntilPreferenceIsSet() {
         val server =
@@ -79,4 +102,13 @@ class SavedServerTransportTest {
         assertFalse(server.prefersSshConnection)
         assertEquals(9234, server.directCodexPort)
     }
+
+    private fun alleycatServer(id: String, nodeId: String) =
+        SavedServer(
+            id = id,
+            name = id,
+            hostname = nodeId,
+            port = 0,
+            alleycatNodeId = nodeId,
+        )
 }

--- a/apps/ios/Sources/Litter/Models/SavedServerStore.swift
+++ b/apps/ios/Sources/Litter/Models/SavedServerStore.swift
@@ -138,9 +138,37 @@ enum SavedServerStore {
     }
 
     static func remove(serverId: String) {
-        var saved = load()
-        saved.removeAll { $0.id == serverId }
-        save(saved)
+        let saved = load()
+        let nodeIdsToForget = orphanedAlleycatNodeIds(removing: serverId, from: saved)
+        let remaining = saved.filter { $0.id != serverId }
+        save(remaining)
+
+        for nodeId in nodeIdsToForget {
+            do {
+                try AlleycatCredentialStore.shared.deleteToken(nodeId: nodeId)
+            } catch {
+                LLog.error("alleycat", "keychain token deletion failed while forgetting server", error: error)
+            }
+        }
+    }
+
+    /// An Alleycat token is keyed by node ID, so retain it when another saved
+    /// server still refers to the same node. The installation-wide device key
+    /// is deliberately not part of this server-scoped cleanup.
+    static func orphanedAlleycatNodeIds(removing serverId: String, from servers: [SavedServer]) -> [String] {
+        let removedNodeIds = Set(
+            servers
+                .filter { $0.id == serverId }
+                .compactMap { normalizedAlleycatNodeId($0.alleycatNodeId) }
+        )
+        guard !removedNodeIds.isEmpty else { return [] }
+
+        let retainedNodeIds = Set(
+            servers
+                .filter { $0.id != serverId }
+                .compactMap { normalizedAlleycatNodeId($0.alleycatNodeId) }
+        )
+        return removedNodeIds.subtracting(retainedNodeIds).sorted()
     }
 
     static func rename(serverId: String, newName: String) {
@@ -249,5 +277,12 @@ enum SavedServerStore {
             return "Alleycat \(nodeId)"
         }
         return "Alleycat \(nodeId.prefix(8))...\(nodeId.suffix(8))"
+    }
+
+    private static func normalizedAlleycatNodeId(_ nodeId: String?) -> String? {
+        let normalized = nodeId?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return normalized?.isEmpty == false ? normalized : nil
     }
 }

--- a/apps/ios/Tests/LitterTests/SavedServerStoreTests.swift
+++ b/apps/ios/Tests/LitterTests/SavedServerStoreTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import Litter
+
+@MainActor
+final class SavedServerStoreTests: XCTestCase {
+    func testForgettingAlleycatServerReturnsOnlyUnreferencedNodeToken() {
+        let primary = alleycatServer(id: "primary", nodeId: " NODE-A ")
+        let duplicate = alleycatServer(id: "duplicate", nodeId: "node-a")
+        let independent = alleycatServer(id: "independent", nodeId: "node-b")
+
+        XCTAssertEqual(
+            SavedServerStore.orphanedAlleycatNodeIds(
+                removing: primary.id,
+                from: [primary, duplicate, independent]
+            ),
+            []
+        )
+        XCTAssertEqual(
+            SavedServerStore.orphanedAlleycatNodeIds(
+                removing: independent.id,
+                from: [primary, duplicate, independent]
+            ),
+            ["node-b"]
+        )
+    }
+
+    private func alleycatServer(id: String, nodeId: String) -> SavedServer {
+        SavedServer(
+            id: id,
+            name: id,
+            hostname: nodeId,
+            port: nil,
+            codexPorts: [],
+            sshPort: nil,
+            source: .manual,
+            hasCodexServer: true,
+            wakeMAC: nil,
+            preferredConnectionMode: nil,
+            preferredCodexPort: nil,
+            sshPortForwardingEnabled: nil,
+            websocketURL: nil,
+            rememberedByUser: true,
+            alleycatNodeId: nodeId
+        )
+    }
+}

--- a/docs/REPOSITORY_AUDIT.md
+++ b/docs/REPOSITORY_AUDIT.md
@@ -93,9 +93,10 @@ The continuation also separated confirmed debt from deletion candidates:
 - PowerShell SSH launch fallback remains explicitly unimplemented.
 - Alleycat's Pi/Claude config and MCP projections still contain synthesized or
   empty success surfaces described under P1 below.
-- Removing a saved Alleycat server does not call either platform's existing
-  secure-token deletion helper. A deliberate forget/reset flow is still needed
-  for associated credentials and installation identity.
+- Removing a saved Alleycat server now deletes its unreferenced secure token on
+  both platforms. The cleanup deliberately retains a token while another saved
+  entry references the same node, and it does not delete the installation-wide
+  identity key.
 - `scripts/pi-bridge-codex-shim.sh` and `scripts/bridge-call.py` have no internal
   callers but are command-line operator tools. Lack of imports is not proof
   they are removable; the latter was repaired and both are retained pending an


### PR DESCRIPTION
## Purpose
Remove secure Alleycat credentials when a user removes the last saved server pointing at that node.

## Changes
- delete only tokens no surviving saved server references
- preserve the installation-wide device identity key
- add iOS and Android focused coverage
- update the repository audit finding

## Verification
- `xcodebuild test -project apps/ios/Litter.xcodeproj -scheme Litter -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing:LitterTests/SavedServerStoreTests CODE_SIGNING_ALLOWED=NO -quiet`
- `JAVA_HOME=... ANDROID_SDK_ROOT=... ./gradlew :app:testDebugUnitTest --tests com.litter.android.SavedServerTransportTest`