### PR TITLE
Render chat media, modernize composer, and repair iOS cache reuse

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,8 @@ Incremental policy:
 - `make clean-rust` / `make clean-ios` / `make clean-android` — remove platform-specific artifacts.
 
 ### Configuration overrides (env vars)
-- `IOS_SIM_DEVICE` — simulator name (default: `iPhone 17 Pro`)
+- `IOS_SIM_DEVICE` — fallback simulator name when none is booted (default: `iPhone 17 Pro`)
+- `IOS_SIM_DESTINATION` — explicit xcodebuild destination override; local simulator builds otherwise prefer an already-booted iOS simulator
 - `XCODE_CONFIG` — Xcode build configuration (default: `Debug`)
 - `IOS_SCHEME` — Xcode scheme (default: `Litter`)
 - `IOS_DEPLOYMENT_TARGET` — minimum iOS version (default: `18.0`)

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ PATCHES_DIR := $(ROOT)/patches/codex
 
 IOS_DEPLOYMENT_TARGET ?= 18.0
 IOS_SIM_DEVICE ?= iPhone 17 Pro
+comma := ,
+IOS_SIM_UDID ?= $(shell xcrun simctl list devices booted 2>/dev/null | awk '/^-- iOS/{ios=1; next} /^-- /{ios=0} ios && /\(Booted\)/ { if (match($$0, /\([0-9A-F-]+\)/)) { print substr($$0, RSTART + 1, RLENGTH - 2); exit } }')
+IOS_SIM_DESTINATION ?= $(if $(IOS_SIM_UDID),platform=iOS Simulator$(comma)id=$(IOS_SIM_UDID),platform=iOS Simulator$(comma)name=$(IOS_SIM_DEVICE))
 IOS_SCHEME ?= Litter
 XCODE_CONFIG ?= Debug
 CARGO_FEATURES ?=
@@ -168,6 +171,19 @@ STAMP_SYNC := $(STAMPS)/sync
 STAMP_BINDINGS_S := $(STAMPS)/bindings-swift
 STAMP_BINDINGS_K := $(STAMPS)/bindings-kotlin
 STAMP_XCGEN := $(STAMPS)/xcgen
+UNIFFI_BINDINGS_HASH_SCRIPT := $(ROOT)/tools/scripts/uniffi-bindings-input-hash.sh
+
+# Mark generated Swift bindings current only when their content inputs changed
+# (or an input was merely touched). Keeping this stamp stable on true no-op
+# Rust builds prevents xcgen from rewriting the project and invalidating
+# Xcode's incremental build graph on every loop iteration.
+define mark_swift_bindings_current
+current_hash="$$($(UNIFFI_BINDINGS_HASH_SCRIPT))"; \
+recorded_hash="$$(cat "$(STAMP_BINDINGS_S)" 2>/dev/null || true)"; \
+if [ ! -f "$(STAMP_BINDINGS_S)" ] || [ "$$current_hash" != "$$recorded_hash" ] || $(UNIFFI_BINDINGS_HASH_SCRIPT) --newer-than "$(STAMP_BINDINGS_S)"; then \
+	printf '%s\n' "$$current_hash" >"$(STAMP_BINDINGS_S)"; \
+fi
+endef
 
 # Pinned release tag of the prebuilt Alpine rootfs tarball (still hosted
 # on the dnakov/litter-ish releases page). The iSH kernel itself is built
@@ -198,9 +214,10 @@ ANDROID_RUST_SOURCES := $(shell find $(RUST_DIR) \
 
 $(shell mkdir -p $(STAMPS))
 
-.PHONY: all ios ios-sim ios-sim-fast ios-sim-run ios-device ios-device-fast ios-device-run ios-device-stop ios-run verify-ios-project catalyst catalyst-run catalyst-fast catalyst-fast-run mac-direct mac-direct-run mac-direct-fast mac-direct-fast-run \
+.PHONY: all ios ios-sim ios-sim-fast ios-sim-run ios-sim-launch ios-device ios-device-fast ios-device-run ios-device-launch ios-device-stop ios-run verify-ios-project catalyst catalyst-run catalyst-fast catalyst-fast-run mac-direct mac-direct-run mac-direct-fast mac-direct-fast-run \
 	android android-fast android-emulator-fast android-emulator-run android-device-run android-release android-debug android-install android-emulator-install \
 	rust-ios rust-ios-package rust-ios-device-release rust-mac-release rust-ios-device-fast rust-ios-sim-fast rust-ios-macabi-fast rust-android rust-check rust-test rust-host-dev \
+	ios-xcode-sim ios-xcode-sim-fast ios-xcode-device ios-xcode-device-fast \
 	android-alpine-fs proot-android \
 	ghostty-ios ghostty-android \
 	alleycat-main \
@@ -215,14 +232,16 @@ $(shell mkdir -p $(STAMPS))
 
 all: ios android
 
-# ios-build-* targets declare their real prerequisites so that `make -j`
-# can run rust-ios-package, alpine-fs download, and xcgen in parallel.
-ios-build-sim: rust-ios-package alpine-fs xcgen
-ios-build-device: rust-ios-package alpine-fs xcgen
+# Rust and the Alpine download may run in parallel. Xcode project generation
+# is deliberately sequenced after Rust: build-rust.sh already emits the Swift
+# bindings, so running `xcgen` in parallel used to launch a second full host
+# Cargo build that sat behind the cross-compile target lock.
+ios-build-sim: rust-ios-package alpine-fs
+ios-build-device: rust-ios-package alpine-fs
 
 # Fast lanes use lightweight raw staticlib outputs instead of full packaging.
-ios-build-sim-fast: rust-ios-sim-fast alpine-fs xcgen
-ios-build-device-fast: rust-ios-device-fast alpine-fs xcgen
+ios-build-sim-fast: rust-ios-sim-fast alpine-fs
+ios-build-device-fast: rust-ios-device-fast alpine-fs
 
 ios: ios-build-sim
 ios-sim: ios-build-sim
@@ -335,6 +354,9 @@ loop-device-run:
 	@$(ROOT)/tools/scripts/loop-ios.sh device-run
 
 ios-sim-run: ios-sim-fast
+	@$(MAKE) ios-sim-launch
+
+ios-sim-launch:
 	@echo "==> Installing and launching on booted simulator with saved logs/profile..."
 	@cd $(ROOT) && \
 	IOS_SIM_PROFILE='$(IOS_SIM_PROFILE)' \
@@ -343,6 +365,9 @@ ios-sim-run: ios-sim-fast
 	$(IOS_SCRIPTS)/run-sim.sh
 
 ios-device-run: ios-device-fast
+	@$(MAKE) ios-device-launch
+
+ios-device-launch:
 	@echo "==> Installing and launching on connected device with saved logs/profile..."
 	@cd $(ROOT) && \
 	IOS_DEVICE_PROFILE='$(IOS_DEVICE_PROFILE)' \
@@ -415,26 +440,32 @@ alleycat-main:
 rust-ios-package: alleycat-main $(STAMP_SYNC) $(STAMP_GHOSTTY_IOS)
 	@echo "==> Packaging Rust for iOS (device + simulator + xcframework)..."
 	@cd $(ROOT) && $(PACKAGE_CARGO_ENV) $(IOS_SCRIPTS)/build-rust.sh --preserve-current $(CARGO_FEATURES)
+	@$(mark_swift_bindings_current)
 
 rust-ios-device-release: alleycat-main $(STAMP_SYNC) $(STAMP_GHOSTTY_IOS)
 	@echo "==> Building Rust for iOS release archive prep (device staticlib + headers)..."
 	@cd $(ROOT) && $(PACKAGE_CARGO_ENV) $(IOS_SCRIPTS)/build-rust.sh --preserve-current --device-only $(CARGO_FEATURES)
+	@$(mark_swift_bindings_current)
 
 rust-mac-release: alleycat-main $(STAMP_SYNC) $(STAMP_GHOSTTY_IOS)
 	@echo "==> Building Rust for Mac Catalyst release archive prep (macabi staticlib + headers)..."
 	@cd $(ROOT) && $(PACKAGE_CARGO_ENV) $(IOS_SCRIPTS)/build-rust.sh --preserve-current --macabi-only $(CARGO_FEATURES)
+	@$(mark_swift_bindings_current)
 
 rust-ios-device-fast: alleycat-main $(STAMP_SYNC) $(STAMP_GHOSTTY_IOS)
 	@echo "==> Building Rust for fast iOS device iteration (raw staticlib + headers)..."
 	@cd $(ROOT) && $(DEV_CARGO_ENV) $(IOS_SCRIPTS)/build-rust.sh --preserve-current --fast-device $(CARGO_FEATURES)
+	@$(mark_swift_bindings_current)
 
 rust-ios-sim-fast: alleycat-main $(STAMP_SYNC) $(STAMP_GHOSTTY_IOS)
 	@echo "==> Building Rust for fast iOS simulator iteration (raw staticlib + headers)..."
 	@cd $(ROOT) && $(DEV_CARGO_ENV) $(IOS_SCRIPTS)/build-rust.sh --preserve-current --fast-sim $(CARGO_FEATURES)
+	@$(mark_swift_bindings_current)
 
 rust-ios-macabi-fast: alleycat-main $(STAMP_SYNC) $(STAMP_GHOSTTY_IOS)
 	@echo "==> Building Rust for fast Mac Catalyst iteration (raw macabi staticlib + headers, host arch only)..."
 	@cd $(ROOT) && $(DEV_CARGO_ENV) $(IOS_SCRIPTS)/build-rust.sh --preserve-current --fast-macabi $(CARGO_FEATURES)
+	@$(mark_swift_bindings_current)
 
 rust-check: alleycat-main $(STAMP_SYNC)
 	@echo "==> cargo check (host, shared crates)..."
@@ -468,31 +499,31 @@ $(STAMP_RUST_ANDROID): $(STAMP_SYNC) $(STAMP_BINDINGS_K) $(STAMP_GHOSTTY_ANDROID
 	@touch $@
 
 sync-ghostty: $(STAMP_SYNC_GHOSTTY)
-$(STAMP_SYNC_GHOSTTY): $(GHOSTTY_PATCH_FILES) apps/ios/scripts/sync-ghostty.sh Makefile
+$(STAMP_SYNC_GHOSTTY): $(GHOSTTY_PATCH_FILES) apps/ios/scripts/sync-ghostty.sh
 	@echo "==> Syncing ghostty submodule + applying Litter patches..."
 	@$(IOS_SCRIPTS)/sync-ghostty.sh --preserve-current
 	@touch $@
 
 ghostty-ios: $(STAMP_GHOSTTY_IOS)
-$(STAMP_GHOSTTY_IOS): $(STAMP_SYNC_GHOSTTY) shared/third_party/ghostty/build.zig apps/ios/scripts/build-ghostty.sh Makefile
+$(STAMP_GHOSTTY_IOS): $(STAMP_SYNC_GHOSTTY) shared/third_party/ghostty/build.zig apps/ios/scripts/build-ghostty.sh
 	@echo "==> Building Ghostty renderer for iOS..."
 	@cd $(ROOT) && $(IOS_SCRIPTS)/build-ghostty.sh
 	@touch $@
 
 ghostty-android: $(STAMP_GHOSTTY_ANDROID)
-$(STAMP_GHOSTTY_ANDROID): $(STAMP_SYNC_GHOSTTY) shared/third_party/ghostty/build.zig tools/scripts/build-ghostty-android.sh Makefile
+$(STAMP_GHOSTTY_ANDROID): $(STAMP_SYNC_GHOSTTY) shared/third_party/ghostty/build.zig tools/scripts/build-ghostty-android.sh
 	@echo "==> Building Ghostty renderer for Android..."
 	@cd $(ROOT) && ANDROID_ABIS="$(ANDROID_ABIS)" ./tools/scripts/build-ghostty-android.sh
 	@touch $@
 
 android-alpine-fs: $(STAMP_ANDROID_ALPINE_FS)
-$(STAMP_ANDROID_ALPINE_FS): apps/android/scripts/download-alpine-fs.sh Makefile
+$(STAMP_ANDROID_ALPINE_FS): apps/android/scripts/download-alpine-fs.sh
 	@echo "==> Fetching Android alpine-fs $(ALPINE_FS_VERSION)..."
 	@ALPINE_FS_VERSION=$(ALPINE_FS_VERSION) $(ANDROID_DIR)/scripts/download-alpine-fs.sh
 	@touch $@
 
 proot-android: $(STAMP_PROOT_ANDROID)
-$(STAMP_PROOT_ANDROID): tools/scripts/build-proot-android.sh Makefile
+$(STAMP_PROOT_ANDROID): tools/scripts/build-proot-android.sh
 	@echo "==> Building Android proot $(PROOT_COMMIT)..."
 	@cd $(ROOT) && $(ANDROID_ENV) ANDROID_ABIS="$(ANDROID_ABIS)" PROOT_COMMIT="$(PROOT_COMMIT)" TALLOC_VERSION="$(TALLOC_VERSION)" ./tools/scripts/build-proot-android.sh
 	@touch $@
@@ -562,18 +593,18 @@ bindings: bindings-swift bindings-kotlin
 bindings-swift: $(STAMP_BINDINGS_S)
 $(STAMP_BINDINGS_S): $(STAMP_SYNC) $(BOUNDARY_SOURCES) | alleycat-main
 	@echo "==> Generating Swift bindings..."
-	@cd $(RUST_DIR) && ./generate-bindings.sh --swift-only
+	@cd $(RUST_DIR) && $(DEV_CARGO_ENV) ./generate-bindings.sh --swift-only
 	@mkdir -p $(IOS_GENERATED)/Headers
 	@cp $(GENERATED_DIR)/swift/codex_mobile_client.swift $(IOS_SOURCES)/Litter/Bridge/UniFFICodexClient.generated.swift
 	@cp $(GENERATED_DIR)/swift/codex_mobile_clientFFI.h $(IOS_GENERATED)/Headers/codex_mobile_clientFFI.h
 	@cp $(GENERATED_DIR)/swift/codex_mobile_clientFFI.modulemap $(IOS_GENERATED)/Headers/codex_mobile_clientFFI.modulemap
 	@cp $(GENERATED_DIR)/swift/module.modulemap $(IOS_GENERATED)/Headers/module.modulemap
-	@touch $@
+	@current_hash="$$($(UNIFFI_BINDINGS_HASH_SCRIPT))"; printf '%s\n' "$$current_hash" >"$@"
 
 bindings-kotlin: $(STAMP_BINDINGS_K)
 $(STAMP_BINDINGS_K): $(STAMP_SYNC) $(BOUNDARY_SOURCES) | alleycat-main
 	@echo "==> Generating Kotlin bindings..."
-	@cd $(RUST_DIR) && ./generate-bindings.sh --kotlin-only
+	@cd $(RUST_DIR) && $(DEV_CARGO_ENV) ./generate-bindings.sh --kotlin-only
 	@touch $@
 
 xcgen: $(STAMP_XCGEN)
@@ -596,25 +627,38 @@ verify-ios-project:
 	@$(IOS_SCRIPTS)/regenerate-project.sh --repair-only
 
 ios-build-sim: verify-ios-project
+	@$(MAKE) xcgen
+	@$(MAKE) ios-xcode-sim
+
+ios-xcode-sim: verify-ios-project
 	@echo "==> Building iOS ($(XCODE_CONFIG), simulator)..."
 	@xcodebuild -project $(IOS_DIR)/Litter.xcodeproj \
 		-scheme $(IOS_SCHEME) \
 		-configuration $(XCODE_CONFIG) \
-		-destination 'platform=iOS Simulator,name=$(IOS_SIM_DEVICE)' \
+		-destination '$(IOS_SIM_DESTINATION)' \
 		COMPILER_INDEX_STORE_ENABLE=NO \
 		build
 
 ios-build-sim-fast: verify-ios-project
-	@echo "==> Building iOS ($(XCODE_CONFIG), fast simulator)..."
+	@$(MAKE) xcgen
+	@$(MAKE) ios-xcode-sim-fast
+
+ios-xcode-sim-fast: verify-ios-project
+	@echo "==> Building iOS ($(XCODE_CONFIG), fast simulator: $(IOS_SIM_DESTINATION))..."
 	@xcodebuild -project $(IOS_DIR)/Litter.xcodeproj \
 		-scheme $(IOS_SCHEME) \
 		-configuration $(XCODE_CONFIG) \
-		-destination 'platform=iOS Simulator,name=$(IOS_SIM_DEVICE)' \
+		-destination '$(IOS_SIM_DESTINATION)' \
 		COMPILER_INDEX_STORE_ENABLE=NO \
 		ONLY_ACTIVE_ARCH=YES \
+		CODE_SIGNING_ALLOWED=NO \
 		build
 
 ios-build-device: verify-ios-project
+	@$(MAKE) xcgen
+	@$(MAKE) ios-xcode-device
+
+ios-xcode-device: verify-ios-project
 	@echo "==> Building iOS ($(XCODE_CONFIG), device)..."
 	@cd $(ROOT) && \
 	XCODE_CONFIG='$(XCODE_CONFIG)' \
@@ -623,6 +667,10 @@ ios-build-device: verify-ios-project
 	$(IOS_SCRIPTS)/build-device.sh
 
 ios-build-device-fast: verify-ios-project
+	@$(MAKE) xcgen
+	@$(MAKE) ios-xcode-device-fast
+
+ios-xcode-device-fast: verify-ios-project
 	@echo "==> Building iOS ($(XCODE_CONFIG), fast device)..."
 	@cd $(ROOT) && \
 	XCODE_CONFIG='$(XCODE_CONFIG)' \

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -165,6 +165,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-service:2.8.6")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
     implementation("io.coil-kt:coil-compose:2.7.0")
+    implementation("io.coil-kt:coil-svg:2.7.0")
     implementation("io.noties.markwon:core:4.6.2")
     implementation("io.noties.markwon:ext-latex:4.6.2")
     implementation("io.noties.markwon:ext-tables:4.6.2")

--- a/apps/android/app/src/main/java/com/litter/android/ui/common/FormattedText.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/common/FormattedText.kt
@@ -1,6 +1,7 @@
 package com.litter.android.ui.common
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -21,6 +22,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -50,12 +58,11 @@ fun FormattedText(
 
     // Fast path: no pills.
     if (segments.size == 1 && segments[0] is TitleSegment.Text) {
-        Text(
+        LinkifiedText(
             text = (segments[0] as TitleSegment.Text).`text`,
             color = color,
             fontSize = fontSize,
             maxLines = maxLines,
-            overflow = TextOverflow.Ellipsis,
             modifier = modifier,
         )
         return
@@ -69,12 +76,11 @@ fun FormattedText(
         ) {
             segments.forEach { segment ->
                 when (segment) {
-                    is TitleSegment.Text -> Text(
+                    is TitleSegment.Text -> LinkifiedText(
                         text = segment.`text`,
                         color = color,
                         fontSize = fontSize,
                         maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
                     )
                     is TitleSegment.PluginRef -> PluginPill(
                         displayName = segment.`displayName`,
@@ -92,7 +98,7 @@ fun FormattedText(
         ) {
             segments.forEach { segment ->
                 when (segment) {
-                    is TitleSegment.Text -> Text(
+                    is TitleSegment.Text -> LinkifiedText(
                         text = segment.`text`,
                         color = color,
                         fontSize = fontSize,
@@ -105,6 +111,69 @@ fun FormattedText(
                 }
             }
         }
+    }
+}
+
+private const val WebLinkAnnotation = "litter-web-link"
+private val WebLinkRegex = Regex("""https?://[^\s<>]+""", RegexOption.IGNORE_CASE)
+private val WebLinkTrailingPunctuation = setOf('.', ',', ';', ':', '!', '?', ']', '}')
+
+@Composable
+private fun LinkifiedText(
+    text: String,
+    color: Color,
+    fontSize: TextUnit,
+    modifier: Modifier = Modifier,
+    maxLines: Int = Int.MAX_VALUE,
+) {
+    val uriHandler = LocalUriHandler.current
+    val linkColor = LitterTheme.accent
+    val annotated = remember(text, linkColor) {
+        linkifiedAnnotatedString(text, linkColor)
+    }
+    ClickableText(
+        text = annotated,
+        style = TextStyle(color = color, fontSize = fontSize),
+        maxLines = maxLines,
+        overflow = TextOverflow.Ellipsis,
+        modifier = modifier,
+        onClick = { offset ->
+            annotated.getStringAnnotations(WebLinkAnnotation, offset, offset)
+                .firstOrNull()
+                ?.item
+                ?.let { url -> runCatching { uriHandler.openUri(url) } }
+        },
+    )
+}
+
+private fun linkifiedAnnotatedString(text: String, linkColor: Color): AnnotatedString {
+    val matches = WebLinkRegex.findAll(text).mapNotNull { match ->
+        var endExclusive = match.range.last + 1
+        while (endExclusive > match.range.first && text[endExclusive - 1] in WebLinkTrailingPunctuation) {
+            endExclusive -= 1
+        }
+        if (endExclusive == match.range.first) null else match.range.first until endExclusive
+    }.toList()
+    if (matches.isEmpty()) return AnnotatedString(text)
+
+    return buildAnnotatedString {
+        var cursor = 0
+        matches.forEach { range ->
+            append(text.substring(cursor, range.first))
+            val url = text.substring(range)
+            pushStringAnnotation(WebLinkAnnotation, url)
+            withStyle(
+                SpanStyle(
+                    color = linkColor,
+                    textDecoration = TextDecoration.None,
+                ),
+            ) {
+                append(url)
+            }
+            pop()
+            cursor = range.last + 1
+        }
+        append(text.substring(cursor))
     }
 }
 

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ComposerBar.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ComposerBar.kt
@@ -827,13 +827,17 @@ fun ComposerBar(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 12.dp, vertical = 8.dp),
+                .padding(horizontal = 12.dp, vertical = 8.dp)
+                .background(LitterTheme.codeBackground, RoundedCornerShape(26.dp))
+                .padding(horizontal = 6.dp, vertical = 4.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             if (!isRecording && !isTranscribing && !isThinking) {
                 IconButton(
                     onClick = { showAttachMenu = true },
-                    modifier = Modifier.size(36.dp),
+                    modifier = Modifier
+                        .size(40.dp)
+                        .background(LitterTheme.surface.copy(alpha = 0.78f), CircleShape),
                 ) {
                     Icon(
                         Icons.Default.Add,
@@ -847,9 +851,8 @@ fun ComposerBar(
             Row(
                 modifier = Modifier
                     .weight(1f)
-                    .heightIn(min = 36.dp, max = 120.dp)
-                    .background(LitterTheme.codeBackground, RoundedCornerShape(18.dp))
-                    .padding(horizontal = 14.dp, vertical = 8.dp),
+                    .heightIn(min = 44.dp, max = 120.dp)
+                    .padding(start = 8.dp, end = 2.dp, top = 8.dp, bottom = 8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Box(modifier = Modifier.weight(1f)) {
@@ -990,7 +993,7 @@ fun ComposerBar(
                         )
                     }
 
-                    else -> {
+                    !canSend && !isThinking -> {
                         val realtimeAvailable = remember {
                             com.litter.android.ui.ExperimentalFeatures.isEnabled(
                                 com.litter.android.ui.LitterFeature.REALTIME_VOICE,
@@ -1041,58 +1044,59 @@ fun ComposerBar(
                         }
                     }
                 }
-            }
-
-            Spacer(Modifier.width(4.dp))
-
-            if (canSend) {
-                IconButton(
-                    onClick = sendCurrent,
-                    enabled = !isRecording && !isTranscribing,
-                    modifier = Modifier
-                        .size(36.dp)
-                        .clip(CircleShape)
-                        .background(
-                            if (!isRecording && !isTranscribing) {
-                                LitterTheme.accent
-                            } else {
-                                LitterTheme.accent.copy(alpha = 0.45f)
-                            },
-                            CircleShape,
-                        ),
-                ) {
-                    Icon(
-                        Icons.AutoMirrored.Filled.Send,
-                        contentDescription = "Send",
-                        tint = Color.Black,
-                        modifier = Modifier.size(17.dp),
-                    )
-                }
-                Spacer(Modifier.width(4.dp))
-            }
-
-            if (isThinking && !canSend) {
-                Text(
-                    text = "Cancel",
-                    color = LitterTheme.textPrimary,
-                    fontSize = LitterTextStyle.caption.scaled,
-                    fontWeight = FontWeight.Medium,
-                    modifier = Modifier
-                        .clip(RoundedCornerShape(18.dp))
-                        .background(LitterTheme.surface)
-                        .clickable {
-                            val turnId = activeTurnId ?: return@clickable
+                if (canSend) {
+                    Spacer(Modifier.width(6.dp))
+                    IconButton(
+                        onClick = sendCurrent,
+                        enabled = !isRecording && !isTranscribing,
+                        modifier = Modifier
+                            .size(40.dp)
+                            .clip(CircleShape)
+                            .background(
+                                if (!isRecording && !isTranscribing) {
+                                    LitterTheme.accent
+                                } else {
+                                    LitterTheme.accent.copy(alpha = 0.45f)
+                                },
+                                CircleShape,
+                            ),
+                    ) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.Send,
+                            contentDescription = "Send",
+                            tint = Color.Black,
+                            modifier = Modifier.size(17.dp),
+                        )
+                    }
+                } else if (isThinking) {
+                    Spacer(Modifier.width(6.dp))
+                    IconButton(
+                        onClick = {
+                            val turnId = activeTurnId ?: return@IconButton
                             scope.launch {
-                                try {
+                                runCatching {
                                     appModel.client.interruptTurn(
                                         threadKey.serverId,
-                                        AppInterruptTurnRequest(threadId = threadKey.threadId, turnId = turnId),
+                                        AppInterruptTurnRequest(
+                                            threadId = threadKey.threadId,
+                                            turnId = turnId,
+                                        ),
                                     )
-                                } catch (_: Exception) {}
+                                }
                             }
-                        }
-                        .padding(horizontal = 14.dp, vertical = 10.dp),
-                )
+                        },
+                        modifier = Modifier
+                            .size(40.dp)
+                            .background(LitterTheme.textPrimary, CircleShape),
+                    ) {
+                        Icon(
+                            Icons.Default.Stop,
+                            contentDescription = "Cancel response",
+                            tint = LitterTheme.surface,
+                            modifier = Modifier.size(15.dp),
+                        )
+                    }
+                }
             }
         }
 

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationScreen.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationScreen.kt
@@ -558,6 +558,7 @@ fun ConversationScreen(
                                                     item = entry.item,
                                                     serverId = threadKey.serverId,
                                                     threadId = threadKey.threadId,
+                                                    threadCwd = thread?.info?.cwd,
                                                     agentDirectoryVersion = agentDirectoryVersion,
                                                     latestCommandExecutionItemId = latestCommandExecutionItemId,
                                                     isLiveTurn = turn.isActiveTurn,

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationTimeline.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationTimeline.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import com.sigkitten.litter.android.R
 import androidx.compose.foundation.ExperimentalFoundationApi
-import android.graphics.BitmapFactory
 import android.net.Uri
 import android.util.Base64
 import coil.compose.AsyncImage
@@ -58,7 +57,6 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.LaunchedEffect
@@ -71,7 +69,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
@@ -90,7 +87,6 @@ import com.litter.android.ui.LitterTextStyle
 import com.litter.android.ui.LitterTheme
 import com.litter.android.ui.LocalTextScale
 import com.litter.android.ui.scaled
-import com.litter.android.state.AppModel
 import androidx.compose.runtime.rememberCoroutineScope
 import kotlinx.coroutines.launch
 import org.json.JSONArray
@@ -101,9 +97,7 @@ import uniffi.codex_mobile_client.HydratedConversationItem
 import uniffi.codex_mobile_client.HydratedConversationItemContent
 import uniffi.codex_mobile_client.HydratedPlanStepStatus
 import kotlin.math.roundToInt
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.withContext
 
 private const val ToolCallTextPreviewLimit = 2_000
 private const val UserMessageTextPreviewLimit = 1_000
@@ -117,6 +111,7 @@ fun ConversationTimelineItem(
     item: HydratedConversationItem,
     serverId: String,
     threadId: String,
+    threadCwd: String? = null,
     agentDirectoryVersion: ULong,
     latestCommandExecutionItemId: String? = null,
     isLiveTurn: Boolean = false,
@@ -149,6 +144,7 @@ fun ConversationTimelineItem(
             itemId = item.id,
             data = content.v1,
             serverId = serverId,
+            threadCwd = threadCwd,
             agentDirectoryVersion = agentDirectoryVersion,
             isStreamingMessage = isStreamingMessage,
             onStreamingSnapshotRendered = onStreamingSnapshotRendered,
@@ -388,6 +384,7 @@ private fun AssistantMessageRow(
     itemId: String,
     data: uniffi.codex_mobile_client.HydratedAssistantMessageData,
     serverId: String,
+    threadCwd: String?,
     agentDirectoryVersion: ULong,
     isStreamingMessage: Boolean,
     onStreamingSnapshotRendered: (() -> Unit)?,
@@ -470,12 +467,16 @@ private fun AssistantMessageRow(
             StreamingMarkdownView(
                 text = renderedText,
                 itemId = itemId,
+                serverId = serverId,
+                cwd = threadCwd,
                 onRendered = onStreamingSnapshotRendered,
             )
         } else {
             AssistantRenderBlocks(
                 blocks = renderBlocks,
                 fallbackText = renderedText,
+                serverId = serverId,
+                cwd = threadCwd,
             )
         }
     }
@@ -485,13 +486,14 @@ private fun AssistantMessageRow(
 private fun AssistantRenderBlocks(
     blocks: List<AppMessageRenderBlock>,
     fallbackText: String,
+    serverId: String,
+    cwd: String?,
 ) {
     if (blocks.isEmpty()) {
         MarkdownText(text = fallbackText)
         return
     }
 
-    val context = LocalContext.current
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         blocks.forEachIndexed { index, block ->
             when (block) {
@@ -507,16 +509,17 @@ private fun AssistantRenderBlocks(
                     }
                 }
                 is AppMessageRenderBlock.InlineImage -> {
-                    AsyncImage(
-                        model = ImageRequest.Builder(context)
-                            .data(block.data)
-                            .crossfade(false)
-                            .build(),
+                    InlineChatImage(
+                        data = block.data,
                         contentDescription = "Assistant image ${index + 1}",
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .heightIn(max = 300.dp)
-                            .clip(RoundedCornerShape(10.dp)),
+                        maxHeight = 300.dp,
+                    )
+                }
+                is AppMessageRenderBlock.LocalImage -> {
+                    ResolvedChatImage(
+                        path = block.path,
+                        serverId = serverId,
+                        cwd = cwd,
                     )
                 }
             }
@@ -1293,27 +1296,11 @@ private fun RevisedPromptSection(prompt: String) {
     }
 }
 
-private sealed interface ToolImageLoadState {
-    data object Loading : ToolImageLoadState
-    data class Loaded(val bitmap: android.graphics.Bitmap) : ToolImageLoadState
-    data class Failed(val message: String) : ToolImageLoadState
-}
-
 @Composable
 private fun ImageResultSection(
     path: String,
     serverId: String,
 ) {
-    val appModel = LocalAppModel.current
-    val loadState by produceState<ToolImageLoadState>(
-        initialValue = ToolImageLoadState.Loading,
-        path,
-        serverId,
-    ) {
-        value = ToolImageLoadState.Loading
-        value = loadToolImage(appModel, path, serverId)
-    }
-
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
         SectionLabel("Image")
         Box(
@@ -1323,60 +1310,12 @@ private fun ImageResultSection(
                 .padding(horizontal = 10.dp, vertical = 8.dp),
             contentAlignment = Alignment.Center,
         ) {
-            when (val state = loadState) {
-                ToolImageLoadState.Loading -> {
-                    CircularProgressIndicator(
-                        color = LitterTheme.accent,
-                        strokeWidth = 2.dp,
-                        modifier = Modifier.padding(vertical = 24.dp),
-                    )
-                }
-
-                is ToolImageLoadState.Loaded -> {
-                    Image(
-                        bitmap = state.bitmap.asImageBitmap(),
-                        contentDescription = workspaceTitle(path),
-                        contentScale = ContentScale.Fit,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .heightIn(max = 320.dp)
-                            .clip(RoundedCornerShape(8.dp)),
-                    )
-                }
-
-                is ToolImageLoadState.Failed -> {
-                    Text(
-                        text = state.message,
-                        color = LitterTheme.danger,
-                        fontSize = LitterTextStyle.caption.scaled,
-                        modifier = Modifier.padding(vertical = 20.dp),
-                    )
-                }
-            }
+            ResolvedChatImage(
+                path = path,
+                serverId = serverId,
+                cwd = null,
+            )
         }
-    }
-}
-
-private suspend fun loadToolImage(
-    appModel: AppModel,
-    path: String,
-    serverId: String,
-): ToolImageLoadState {
-    return try {
-        val resolved = withContext(Dispatchers.IO) {
-            appModel.client.resolveImageView(serverId, path)
-        }
-        val bitmap = BitmapFactory.decodeByteArray(resolved.bytes, 0, resolved.bytes.size)
-        if (bitmap != null) {
-            ToolImageLoadState.Loaded(bitmap)
-        } else {
-            ToolImageLoadState.Failed("Could not decode the image.")
-        }
-    } catch (error: Exception) {
-        val message = error.message?.trim().orEmpty()
-        ToolImageLoadState.Failed(
-            if (message.isNotEmpty()) message else "Image unavailable",
-        )
     }
 }
 

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ResolvedChatImage.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ResolvedChatImage.kt
@@ -1,0 +1,113 @@
+package com.litter.android.ui.conversation
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.litter.android.ui.LitterTextStyle
+import com.litter.android.ui.LitterTheme
+import com.litter.android.ui.LocalAppModel
+import com.litter.android.ui.scaled
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private sealed interface ResolvedChatImageState {
+    data object Loading : ResolvedChatImageState
+    data class Loaded(val data: ByteArray) : ResolvedChatImageState
+    data class Failed(val message: String) : ResolvedChatImageState
+}
+
+@Composable
+internal fun InlineChatImage(
+    data: ByteArray,
+    contentDescription: String,
+    modifier: Modifier = Modifier,
+    maxHeight: Dp = 320.dp,
+) {
+    val context = LocalContext.current
+    AsyncImage(
+        model = ImageRequest.Builder(context)
+            .data(data)
+            .crossfade(false)
+            .build(),
+        contentDescription = contentDescription,
+        contentScale = ContentScale.Fit,
+        modifier = modifier
+            .fillMaxWidth()
+            .heightIn(max = maxHeight)
+            .clip(RoundedCornerShape(10.dp)),
+    )
+}
+
+@Composable
+internal fun ResolvedChatImage(
+    path: String,
+    serverId: String,
+    cwd: String?,
+    modifier: Modifier = Modifier,
+    maxHeight: Dp = 320.dp,
+) {
+    val appModel = LocalAppModel.current
+    val state by produceState<ResolvedChatImageState>(
+        initialValue = ResolvedChatImageState.Loading,
+        path,
+        serverId,
+        cwd,
+    ) {
+        value = try {
+            val resolved = withContext(Dispatchers.IO) {
+                appModel.client.resolveImageViewAt(serverId, path, cwd)
+            }
+            if (resolved.bytes.isEmpty()) {
+                ResolvedChatImageState.Failed("Image data was empty.")
+            } else {
+                ResolvedChatImageState.Loaded(resolved.bytes)
+            }
+        } catch (error: Exception) {
+            ResolvedChatImageState.Failed(
+                error.message?.trim()?.takeIf(String::isNotEmpty) ?: "Image unavailable",
+            )
+        }
+    }
+
+    Box(
+        modifier = modifier.fillMaxWidth(),
+        contentAlignment = Alignment.Center,
+    ) {
+        when (val current = state) {
+            ResolvedChatImageState.Loading -> CircularProgressIndicator(
+                color = LitterTheme.accent,
+                strokeWidth = 2.dp,
+                modifier = Modifier.padding(vertical = 28.dp),
+            )
+
+            is ResolvedChatImageState.Loaded -> InlineChatImage(
+                data = current.data,
+                contentDescription = "Assistant image ${path.substringAfterLast('/')}",
+                maxHeight = maxHeight,
+            )
+
+            is ResolvedChatImageState.Failed -> Text(
+                text = current.message,
+                color = LitterTheme.danger,
+                fontSize = LitterTextStyle.caption.scaled,
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 24.dp),
+            )
+        }
+    }
+}

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/StreamingMarkdownView.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/StreamingMarkdownView.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -15,11 +14,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -39,6 +33,8 @@ import uniffi.codex_mobile_client.AppMessageRenderBlock
 fun StreamingMarkdownView(
     text: String,
     itemId: String,
+    serverId: String = "",
+    cwd: String? = null,
     onRendered: (() -> Unit)? = null,
     bodySize: Float = LitterTextStyle.body,
 ) {
@@ -66,6 +62,8 @@ fun StreamingMarkdownView(
             StreamingRenderBlocks(
                 blocks = streamState.stableBlocks,
                 bodySize = bodySize,
+                serverId = serverId,
+                cwd = cwd,
             )
         }
 
@@ -76,6 +74,8 @@ fun StreamingMarkdownView(
             StreamingRenderBlocks(
                 blocks = streamState.frontierBlocks,
                 bodySize = bodySize,
+                serverId = serverId,
+                cwd = cwd,
             )
         }
     }
@@ -85,6 +85,8 @@ fun StreamingMarkdownView(
 private fun StreamingRenderBlocks(
     blocks: List<AppMessageRenderBlock>,
     bodySize: Float,
+    serverId: String,
+    cwd: String?,
 ) {
     blocks.forEach { block ->
         when (block) {
@@ -111,17 +113,17 @@ private fun StreamingRenderBlocks(
                 }
             }
             is AppMessageRenderBlock.InlineImage -> {
-                val context = LocalContext.current
-                AsyncImage(
-                    model = ImageRequest.Builder(context)
-                        .data(block.data)
-                        .crossfade(false)
-                        .build(),
+                InlineChatImage(
+                    data = block.data,
                     contentDescription = "Assistant image",
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .heightIn(max = 300.dp)
-                        .clip(RoundedCornerShape(10.dp)),
+                    maxHeight = 300.dp,
+                )
+            }
+            is AppMessageRenderBlock.LocalImage -> {
+                ResolvedChatImage(
+                    path = block.path,
+                    serverId = serverId,
+                    cwd = cwd,
                 )
             }
         }

--- a/apps/android/app/src/main/java/com/litter/android/ui/home/HomeComposerBar.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/home/HomeComposerBar.kt
@@ -344,13 +344,17 @@ fun HomeComposerBar(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 12.dp, vertical = 8.dp),
+                .padding(horizontal = 12.dp, vertical = 8.dp)
+                .background(LitterTheme.codeBackground, RoundedCornerShape(26.dp))
+                .padding(horizontal = 6.dp, vertical = 4.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             if (!isRecording && !isTranscribing && !isSubmitting) {
                 IconButton(
                     onClick = { showAttachMenu = true },
-                    modifier = Modifier.size(36.dp),
+                    modifier = Modifier
+                        .size(40.dp)
+                        .background(LitterTheme.surface.copy(alpha = 0.78f), CircleShape),
                 ) {
                     Icon(
                         imageVector = Icons.Default.Add,
@@ -363,9 +367,8 @@ fun HomeComposerBar(
             Row(
                 modifier = Modifier
                     .weight(1f)
-                    .heightIn(min = 36.dp, max = 120.dp)
-                    .background(LitterTheme.codeBackground, RoundedCornerShape(18.dp))
-                    .padding(horizontal = 14.dp, vertical = 8.dp),
+                    .heightIn(min = 44.dp, max = 120.dp)
+                    .padding(start = 8.dp, end = 2.dp, top = 8.dp, bottom = 8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Box(modifier = Modifier.weight(1f)) {
@@ -458,7 +461,7 @@ fun HomeComposerBar(
                         )
                     }
 
-                    else -> {
+                    !hasSendContent -> {
                         Spacer(Modifier.width(8.dp))
                         IconButton(
                             onClick = {
@@ -475,31 +478,30 @@ fun HomeComposerBar(
                         }
                     }
                 }
-            }
-
-            if (hasSendContent) {
-                Spacer(Modifier.width(8.dp))
-                IconButton(
-                    onClick = sendCurrent,
-                    enabled = canSend && !isRecording && !isTranscribing,
-                    modifier = Modifier
-                        .size(36.dp)
-                        .clip(CircleShape)
-                        .background(
-                            if (canSend && !isRecording && !isTranscribing) {
-                                LitterTheme.accent
-                            } else {
-                                LitterTheme.accent.copy(alpha = 0.45f)
-                            },
-                            CircleShape,
-                        ),
-                ) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.Send,
-                        contentDescription = "Send",
-                        tint = Color.Black,
-                        modifier = Modifier.size(17.dp),
-                    )
+                if (hasSendContent) {
+                    Spacer(Modifier.width(6.dp))
+                    IconButton(
+                        onClick = sendCurrent,
+                        enabled = canSend && !isRecording && !isTranscribing,
+                        modifier = Modifier
+                            .size(40.dp)
+                            .clip(CircleShape)
+                            .background(
+                                if (canSend && !isRecording && !isTranscribing) {
+                                    LitterTheme.accent
+                                } else {
+                                    LitterTheme.accent.copy(alpha = 0.45f)
+                                },
+                                CircleShape,
+                            ),
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.Send,
+                            contentDescription = "Send",
+                            tint = Color.Black,
+                            modifier = Modifier.size(17.dp),
+                        )
+                    }
                 }
             }
         }

--- a/apps/ios/Litter.xcodeproj/project.pbxproj
+++ b/apps/ios/Litter.xcodeproj/project.pbxproj
@@ -392,6 +392,7 @@
 		909A0CDCE6D9729A20D0DA43 /* OpenAIApiKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3374916FC10F81E9D1C0FCE5 /* OpenAIApiKeyStore.swift */; };
 		9106629F6ABA8F5D30DBA0F2 /* AppSnapshotRecord+Runtime.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B233BBDF2CFAC604E4A1DD /* AppSnapshotRecord+Runtime.swift */; };
 		93979DE896F5A50F73AB4736 /* AppThreadSnapshot+Runtime.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC23186BC2EA0520D9532ED3 /* AppThreadSnapshot+Runtime.swift */; };
+		93B3EB3539CC3B10ACF54DFD /* ResolvedChatImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762B817C31B305D06E8B2667 /* ResolvedChatImageView.swift */; };
 		93C87EABAC0D427BD6089349 /* ChatWallpaperBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4754654D5240E850C98AB85D /* ChatWallpaperBackground.swift */; };
 		95D40AC0FE018DE2B9740DA3 /* usgc-themes-LICENSE.txt in Resources */ = {isa = PBXBuildFile; fileRef = B7160E74B034DD87D77CCDDC /* usgc-themes-LICENSE.txt */; };
 		9661EB7632A00EB0B261D7B9 /* temple-dark.json in Resources */ = {isa = PBXBuildFile; fileRef = 885259DDCC6E448B237FAA61 /* temple-dark.json */; };
@@ -476,6 +477,7 @@
 		B695362B90173465944AF204 /* TranscriptTurn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41B0E2A4F7ED660B3B053076 /* TranscriptTurn.swift */; };
 		B696926BA0B2FD5CB3374502 /* PathDisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66961A8B9B89E5B34B6C5A93 /* PathDisplay.swift */; };
 		B697B660D9D3648B06FF1F00 /* usgc-themes-LICENSE.txt in Resources */ = {isa = PBXBuildFile; fileRef = B7160E74B034DD87D77CCDDC /* usgc-themes-LICENSE.txt */; };
+		B6AC036DC2BC32DBAA27FB68 /* ResolvedChatImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762B817C31B305D06E8B2667 /* ResolvedChatImageView.swift */; };
 		B6F805201F93AF9AD6AAC48D /* SavedServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F4C10A9AB37FCCDDA975381 /* SavedServer.swift */; };
 		B758D24D236CAFE9B5BABE2C /* cat_transmission_03.png in Resources */ = {isa = PBXBuildFile; fileRef = AE86DDCDD1BEC770EAE330A9 /* cat_transmission_03.png */; };
 		B7952C904D305D8E0CA73E9A /* MountedFoldersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52698C6E7E0EC0CCEC716DFD /* MountedFoldersView.swift */; };
@@ -925,6 +927,7 @@
 		75448098987C0B15698C8456 /* monokai.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = monokai.json; sourceTree = "<group>"; };
 		75F91259F006987853B6929F /* ConversationComposerTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationComposerTextView.swift; sourceTree = "<group>"; };
 		760BBA087DD7F86B27829E23 /* github-light.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "github-light.json"; sourceTree = "<group>"; };
+		762B817C31B305D06E8B2667 /* ResolvedChatImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolvedChatImageView.swift; sourceTree = "<group>"; };
 		76B9969D2D4C7AA23FC9DB93 /* material-theme-lighter.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "material-theme-lighter.json"; sourceTree = "<group>"; };
 		7705BE9E4D681844D5FB6C20 /* RealtimeWebRtcSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeWebRtcSession.swift; sourceTree = "<group>"; };
 		7779BD02F3B304F9C3AD32A1 /* DiscoveredServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveredServer.swift; sourceTree = "<group>"; };
@@ -1684,6 +1687,7 @@
 				B6C41CA257D0C3F206C36F81 /* ProximityPairView.swift */,
 				2A7F3CC664EDAC7714BA817B /* QuickReplySheet.swift */,
 				4215329CF98636F31978500E /* RealtimeVoiceScreen.swift */,
+				762B817C31B305D06E8B2667 /* ResolvedChatImageView.swift */,
 				1D8203E9494F06515FC30E3D /* RollingMetricText.swift */,
 				6058552E839CA44F15DA3186 /* SavedAppDetailView.swift */,
 				A58307B7673850139031D023 /* SavedAppUpdateOverlay.swift */,
@@ -2410,6 +2414,7 @@
 				D416C8F96EC0ED100EC5F9FA /* RealtimeVoiceScreen.swift in Sources */,
 				44638D758B4155F7F8FF8A72 /* RealtimeWebRtcSession.swift in Sources */,
 				D512CAC21DF746FA702B10EF /* RecentDirectoryStore.swift in Sources */,
+				93B3EB3539CC3B10ACF54DFD /* ResolvedChatImageView.swift in Sources */,
 				DD0C22B502190804EC15BFE7 /* RollingMetricText.swift in Sources */,
 				6DE00D539BF6F92533A4D8C4 /* RustAlleycatBridge.swift in Sources */,
 				3AEBEBB2C0A6483A4E7D62F0 /* RustVoiceHandoff.swift in Sources */,
@@ -2595,6 +2600,7 @@
 				9FCDDF2CEBF27362F1026DC6 /* PushProxyClient.swift in Sources */,
 				5D69BA5B719D472AC1374842 /* QuickReplySheet.swift in Sources */,
 				ACDDA0682624D4EB1F24618E /* RecentDirectoryStore.swift in Sources */,
+				B6AC036DC2BC32DBAA27FB68 /* ResolvedChatImageView.swift in Sources */,
 				E2D03F494483EBB561B47785 /* RollingMetricText.swift in Sources */,
 				A91B73BD99881AF4EF7388BE /* RustAlleycatBridge.swift in Sources */,
 				9F41A81BE23B68CA2F74BFE4 /* RustVoiceHandoff.swift in Sources */,

--- a/apps/ios/Sources/Litter/Bridge/MessageContentBridge.swift
+++ b/apps/ios/Sources/Litter/Bridge/MessageContentBridge.swift
@@ -5,6 +5,7 @@ enum MessageContentBridge {
         case markdown(String)
         case codeBlock(language: String?, code: String)
         case inlineImage(Data)
+        case localImage(path: String)
     }
 
     enum AssistantContentSegment {
@@ -63,6 +64,8 @@ enum MessageContentBridge {
                 return .codeBlock(language: language, code: code)
             case .inlineImage(data: let data, mimeType: _):
                 return .inlineImage(data)
+            case .localImage(path: let path):
+                return .localImage(path: path)
             }
         }
     }
@@ -79,6 +82,8 @@ enum MessageContentBridge {
                 segments.append(.markdown(fencedMarkdown(code: code, language: language)))
             case .inlineImage(let data):
                 segments.append(.inlineImage(data))
+            case .localImage:
+                break
             }
         }
 

--- a/apps/ios/Sources/Litter/Views/ConversationComposerEntryRowView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationComposerEntryRowView.swift
@@ -17,9 +17,9 @@ struct ConversationComposerEntryRowView: View {
     let onInterrupt: () -> Void
 
     private enum Metrics {
-        static let controlSize: CGFloat = 44
-        static let inputCornerRadius: CGFloat = controlSize / 2
-        static let trailingControlSize: CGFloat = 44
+        static let controlSize: CGFloat = 40
+        static let inputCornerRadius: CGFloat = 26
+        static let trailingControlSize: CGFloat = 40
         static let horizontalPadding: CGFloat = 10
         static let verticalPadding: CGFloat = 6
     }
@@ -73,7 +73,7 @@ struct ConversationComposerEntryRowView: View {
     }
 
     var body: some View {
-        HStack(alignment: .center, spacing: 8) {
+        HStack(alignment: .center, spacing: 4) {
             if !voiceManager.isRecording && !voiceManager.isTranscribing && !isTurnActive {
                 Button {
                     showAttachMenu = true
@@ -82,74 +82,40 @@ struct ConversationComposerEntryRowView: View {
                         .font(LitterFont.styled(size: 20, weight: .semibold))
                         .foregroundColor(LitterTheme.textPrimary)
                         .frame(width: Metrics.controlSize, height: Metrics.controlSize)
-                        .modifier(GlassCircleModifier())
+                        .background(
+                            Circle()
+                                .fill(LitterTheme.surfaceLight.opacity(0.72))
+                        )
                 }
-                .padding(4)
-                .contentShape(Rectangle())
-                .padding(-4)
                 .buttonStyle(.plain)
                 .hoverEffect(.highlight)
                 .transition(.scale.combined(with: .opacity))
                 .accessibilityLabel("Attach")
-                .zIndex(1)
             }
 
-            HStack(spacing: 0) {
-                ZStack(alignment: .topLeading) {
-                    ConversationComposerTextView(
-                        text: $inputText,
-                        isFocused: $isComposerFocused,
-                        selectedRange: $composerSelectionRange,
-                        onPasteImage: onPasteImage,
-                        onHardwareSubmit: {
-                            if canSend { onSendText() }
-                        }
-                    )
+            ZStack(alignment: .topLeading) {
+                ConversationComposerTextView(
+                    text: $inputText,
+                    isFocused: $isComposerFocused,
+                    selectedRange: $composerSelectionRange,
+                    onPasteImage: onPasteImage,
+                    onHardwareSubmit: {
+                        if canSend { onSendText() }
+                    },
+                    horizontalInset: 5,
+                    verticalInset: 12
+                )
 
-                    if inputText.isEmpty {
-                        Text("Message litter...")
-                            .font(LitterFont.styled(size: 17))
-                            .foregroundColor(LitterTheme.textMuted)
-                            .padding(.leading, 16)
-                            .padding(.top, 11)
-                            .allowsHitTesting(false)
-                    }
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-                if voiceManager.isRecording {
-                    AudioWaveformView(level: voiceManager.audioLevel)
-                        .frame(width: 48, height: 20)
-
-                    Button(action: onStopRecording) {
-                        Image(systemName: "stop.circle.fill")
-                            .font(LitterFont.styled(size: 28))
-                            .foregroundColor(LitterTheme.accentStrong)
-                            .frame(width: Metrics.trailingControlSize, height: Metrics.trailingControlSize)
-                            .contentShape(Circle())
-                    }
-                    .buttonStyle(.plain)
-                    .hoverEffect(.highlight)
-                    .accessibilityLabel("Stop recording")
-                } else if voiceManager.isTranscribing {
-                    ProgressView()
-                        .tint(LitterTheme.accent)
-                        .frame(width: Metrics.trailingControlSize, height: Metrics.trailingControlSize)
-                } else if allowsVoiceInput {
-                    Button(action: onStartRecording) {
-                        Image(systemName: "mic.fill")
-                            .font(LitterFont.styled(size: 18))
-                            .foregroundColor(LitterTheme.textSecondary)
-                            .frame(width: Metrics.trailingControlSize, height: Metrics.trailingControlSize)
-                            .contentShape(Circle())
-                    }
-                    .buttonStyle(.plain)
-                    .hoverEffect(.highlight)
-                    .accessibilityLabel("Dictate")
+                if inputText.isEmpty {
+                    Text("Message litter...")
+                        .font(LitterFont.styled(size: 17))
+                        .foregroundColor(LitterTheme.textMuted)
+                        .padding(.leading, 5)
+                        .padding(.top, 12)
+                        .allowsHitTesting(false)
                 }
             }
-            .frame(maxWidth: .infinity, minHeight: Metrics.controlSize)
-            .modifier(GlassRoundedRectModifier(cornerRadius: Metrics.inputCornerRadius))
+            .frame(maxWidth: .infinity, alignment: .leading)
             .overlay(alignment: .topTrailing) {
                 if shouldShowExpand {
                     Button {
@@ -170,12 +136,32 @@ struct ConversationComposerEntryRowView: View {
             }
             .animation(.easeInOut(duration: 0.15), value: shouldShowExpand)
 
-            if canSend {
-                Button(action: onSendText) {
-                    Image(systemName: "arrow.up.circle.fill")
-                        .font(LitterFont.styled(size: 30))
-                        .foregroundColor(LitterTheme.accent)
+            if voiceManager.isRecording {
+                AudioWaveformView(level: voiceManager.audioLevel)
+                    .frame(width: 42, height: 20)
+
+                Button(action: onStopRecording) {
+                    Image(systemName: "stop.fill")
+                        .font(LitterFont.styled(size: 13, weight: .bold))
+                        .foregroundColor(.black)
                         .frame(width: Metrics.trailingControlSize, height: Metrics.trailingControlSize)
+                        .background(Circle().fill(LitterTheme.accentStrong))
+                        .contentShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .hoverEffect(.highlight)
+                .accessibilityLabel("Stop recording")
+            } else if voiceManager.isTranscribing {
+                ProgressView()
+                    .tint(LitterTheme.accent)
+                    .frame(width: Metrics.trailingControlSize, height: Metrics.trailingControlSize)
+            } else if canSend {
+                Button(action: onSendText) {
+                    Image(systemName: "arrow.up")
+                        .font(LitterFont.styled(size: 17, weight: .bold))
+                        .foregroundColor(.black)
+                        .frame(width: Metrics.trailingControlSize, height: Metrics.trailingControlSize)
+                        .background(Circle().fill(LitterTheme.accent))
                         .contentShape(Circle())
                 }
                 .buttonStyle(.plain)
@@ -184,21 +170,35 @@ struct ConversationComposerEntryRowView: View {
                 .opacity(voiceManager.isRecording || voiceManager.isTranscribing ? 0.45 : 1)
                 .accessibilityLabel("Send")
                 .transition(.move(edge: .trailing).combined(with: .opacity))
-            }
-
-            if isTurnActive && !canSend {
+            } else if isTurnActive {
                 Button(action: onInterrupt) {
-                    Text("Cancel")
-                        .font(LitterFont.styled(size: 15, weight: .medium))
-                        .foregroundColor(LitterTheme.textPrimary)
-                        .padding(.horizontal, 14)
-                        .frame(height: Metrics.controlSize)
-                        .modifier(GlassCapsuleModifier())
+                    Image(systemName: "stop.fill")
+                        .font(LitterFont.styled(size: 12, weight: .bold))
+                        .foregroundColor(LitterTheme.surface)
+                        .frame(width: Metrics.trailingControlSize, height: Metrics.trailingControlSize)
+                        .background(Circle().fill(LitterTheme.textPrimary))
+                        .contentShape(Circle())
                 }
                 .buttonStyle(.plain)
+                .hoverEffect(.highlight)
+                .accessibilityLabel("Cancel response")
                 .transition(.move(edge: .trailing).combined(with: .opacity))
+            } else if allowsVoiceInput {
+                Button(action: onStartRecording) {
+                    Image(systemName: "mic.fill")
+                        .font(LitterFont.styled(size: 18))
+                        .foregroundColor(LitterTheme.textSecondary)
+                        .frame(width: Metrics.trailingControlSize, height: Metrics.trailingControlSize)
+                        .contentShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .hoverEffect(.highlight)
+                .accessibilityLabel("Dictate")
             }
         }
+        .padding(.horizontal, 6)
+        .frame(maxWidth: .infinity, minHeight: 52)
+        .modifier(GlassRoundedRectModifier(cornerRadius: Metrics.inputCornerRadius))
         .frame(maxWidth: .infinity, alignment: .leading)
         .animation(.spring(response: 0.3, dampingFraction: 0.86), value: isTurnActive)
         .animation(.spring(response: 0.3, dampingFraction: 0.86), value: canSend)

--- a/apps/ios/Sources/Litter/Views/ConversationComposerTextView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationComposerTextView.swift
@@ -9,6 +9,11 @@ struct ConversationComposerTextView: UIViewRepresentable {
     /// Invoked when the user presses hardware Return with no modifiers. Shift+Return
     /// still inserts a newline via the standard text-view behavior.
     var onHardwareSubmit: (() -> Void)? = nil
+    /// Insets are presentation-only. Keeping them on the existing UIKit text
+    /// view lets the composer chrome change without replacing its text state,
+    /// selection, marked-text, or autocorrection path.
+    var horizontalInset: CGFloat = 16
+    var verticalInset: CGFloat = 11
     /// When true, the view returns no preferred size from `sizeThatFits`, letting
     /// SwiftUI fill the parent frame. Scrolling kicks in against the actual
     /// bounds instead of the 5-line clamp.
@@ -20,6 +25,8 @@ struct ConversationComposerTextView: UIViewRepresentable {
         selectedRange: Binding<NSRange> = .constant(NSRange(location: 0, length: 0)),
         onPasteImage: @escaping (UIImage) -> Void,
         onHardwareSubmit: (() -> Void)? = nil,
+        horizontalInset: CGFloat = 16,
+        verticalInset: CGFloat = 11,
         unboundedHeight: Bool = false
     ) {
         _text = text
@@ -27,6 +34,8 @@ struct ConversationComposerTextView: UIViewRepresentable {
         _selectedRange = selectedRange
         self.onPasteImage = onPasteImage
         self.onHardwareSubmit = onHardwareSubmit
+        self.horizontalInset = horizontalInset
+        self.verticalInset = verticalInset
         self.unboundedHeight = unboundedHeight
     }
 
@@ -39,7 +48,12 @@ struct ConversationComposerTextView: UIViewRepresentable {
         textView.delegate = context.coordinator
         textView.backgroundColor = .clear
         textView.tintColor = UIColor(LitterTheme.accent)
-        textView.textContainerInset = UIEdgeInsets(top: 11, left: 16, bottom: 11, right: 12)
+        textView.textContainerInset = UIEdgeInsets(
+            top: verticalInset,
+            left: horizontalInset,
+            bottom: verticalInset,
+            right: horizontalInset
+        )
         textView.textContainer.lineFragmentPadding = 0
         textView.autocorrectionType = .default
         textView.autocapitalizationType = .sentences
@@ -64,6 +78,12 @@ struct ConversationComposerTextView: UIViewRepresentable {
         context.coordinator.parent = self
         uiView.onPasteImage = onPasteImage
         uiView.onHardwareSubmit = onHardwareSubmit
+        uiView.textContainerInset = UIEdgeInsets(
+            top: verticalInset,
+            left: horizontalInset,
+            bottom: verticalInset,
+            right: horizontalInset
+        )
         context.coordinator.applyStyling(to: uiView)
 
         if uiView.text != text, uiView.markedTextRange == nil {

--- a/apps/ios/Sources/Litter/Views/FormattedText.swift
+++ b/apps/ios/Sources/Litter/Views/FormattedText.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 /// Drop-in replacement for `Text` that applies inline formatting such as
 /// plugin-reference pills (`[@Name](plugin://plugin-name@marketplace)`).
@@ -14,9 +15,15 @@ struct FormattedText: View {
     var lineLimit: Int? = nil
 
     var body: some View {
+        content
+            .environment(\.openURL, externalBrowserAction)
+    }
+
+    @ViewBuilder
+    private var content: some View {
         let segments = parsePluginRefs(input: text)
         if segments.count == 1, case .text(let t) = segments.first {
-            Text(t)
+            Text(linkifiedText(t))
                 .lineLimit(lineLimit)
         } else if lineLimit == 1 {
             singleLine(segments)
@@ -32,7 +39,7 @@ struct FormattedText: View {
             ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
                 switch segment {
                 case .text(let text):
-                    Text(text)
+                    Text(linkifiedText(text))
                         .lineLimit(1)
                         .truncationMode(.tail)
                 case .pluginRef(let displayName, let pluginName, _):
@@ -52,7 +59,7 @@ struct FormattedText: View {
                 case .text(let text):
                     let pieces = splitPreservingWhitespace(text)
                     ForEach(Array(pieces.enumerated()), id: \.offset) { _, piece in
-                        Text(piece)
+                        Text(linkifiedText(piece))
                             .fixedSize()
                     }
                 case .pluginRef(let displayName, let pluginName, _):
@@ -83,6 +90,41 @@ struct FormattedText: View {
         if !current.isEmpty { pieces.append(current) }
         return pieces
     }
+
+    private func linkifiedText(_ value: String) -> AttributedString {
+        var attributed = AttributedString(value)
+        guard let linkDetector = Self.linkDetector else { return attributed }
+        let fullRange = NSRange(value.startIndex..<value.endIndex, in: value)
+        for match in linkDetector.matches(in: value, options: [], range: fullRange) {
+            guard let url = match.url,
+                  let scheme = url.scheme?.lowercased(),
+                  scheme == "http" || scheme == "https",
+                  let stringRange = Range(match.range, in: value),
+                  let lowerBound = AttributedString.Index(stringRange.lowerBound, within: attributed),
+                  let upperBound = AttributedString.Index(stringRange.upperBound, within: attributed) else {
+                continue
+            }
+            attributed[lowerBound..<upperBound].link = url
+        }
+        return attributed
+    }
+
+    private var externalBrowserAction: OpenURLAction {
+        OpenURLAction { url in
+            guard let scheme = url.scheme?.lowercased(),
+                  scheme == "http" || scheme == "https" else {
+                return .systemAction
+            }
+            UIApplication.shared.open(url)
+            return .handled
+        }
+    }
+
+    private static let linkDetector: NSDataDetector? = {
+        // The detector is immutable after construction and reused across
+        // message rows so long transcripts don't repeatedly compile URL rules.
+        try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+    }()
 }
 
 struct PluginPill: View {

--- a/apps/ios/Sources/Litter/Views/MessageBubbleView.swift
+++ b/apps/ios/Sources/Litter/Views/MessageBubbleView.swift
@@ -71,11 +71,24 @@ struct LitterMarkdownView: View {
                 bodySize: bodySize, codeSize: codeSize,
                 selectionEnabled: selectionEnabled
             )
+            .environment(\.openURL, externalBrowserAction)
         case .system:
             view.litterSystemMarkdown(
                 bodySize: bodySize, codeSize: codeSize,
                 selectionEnabled: selectionEnabled
             )
+            .environment(\.openURL, externalBrowserAction)
+        }
+    }
+
+    private var externalBrowserAction: OpenURLAction {
+        OpenURLAction { url in
+            guard let scheme = url.scheme?.lowercased(),
+                  scheme == "http" || scheme == "https" else {
+                return .systemAction
+            }
+            UIApplication.shared.open(url)
+            return .handled
         }
     }
 }
@@ -364,41 +377,17 @@ struct AssistantBlocksBubble: View {
                 .id(identity)
             }
         case .image(let data, let cacheKey):
-            LazyImage(
-                request: ImageRequest(
-                    id: cacheKey,
-                    data: { data },
-                    processors: [
-                        ImageProcessors.Resize(
-                            size: CGSize(width: 1200, height: 300),
-                            unit: .points,
-                            contentMode: .aspectFit
-                        )
-                    ]
-                )
-            ) { state in
-                if let image = state.image {
-                    if let ui = state.imageContainer?.image {
-                        image
-                            .resizable()
-                            .scaledToFit()
-                            .frame(maxHeight: 300)
-                            .clipShape(RoundedRectangle(cornerRadius: 8))
-                            .draggable(Image(uiImage: ui)) {
-                                Image(uiImage: ui)
-                                    .resizable()
-                                    .scaledToFit()
-                                    .frame(width: 120)
-                            }
-                    } else {
-                        image
-                            .resizable()
-                            .scaledToFit()
-                            .frame(maxHeight: 300)
-                            .clipShape(RoundedRectangle(cornerRadius: 8))
-                    }
-                }
-            }
+            ResolvedChatImageView(
+                source: .data(data),
+                maxHeight: 300
+            )
+            .id(cacheKey)
+        case .localImage(let path, let cacheKey):
+            ResolvedChatImageView(
+                source: .path(path),
+                maxHeight: 320
+            )
+            .id(cacheKey)
         }
     }
 

--- a/apps/ios/Sources/Litter/Views/MessageRenderCache.swift
+++ b/apps/ios/Sources/Litter/Views/MessageRenderCache.swift
@@ -7,6 +7,7 @@ final class MessageRenderCache {
             case markdown(String, Int)
             case codeBlock(language: String?, code: String, Int)
             case image(data: Data, cacheKey: String)
+            case localImage(path: String, cacheKey: String)
         }
 
         let id: String
@@ -204,6 +205,15 @@ final class MessageRenderCache {
                     AssistantSegment(
                         id: "image-\(index)-\(data.count)-\(contentHash)",
                         kind: .image(data: data, cacheKey: cacheKey)
+                    )
+                )
+            case .localImage(let path):
+                let contentHash = path.hashValue
+                let cacheKey = "assistant-\(messageId)-path-\(index)-\(contentHash)"
+                segments.append(
+                    AssistantSegment(
+                        id: cacheKey,
+                        kind: .localImage(path: path, cacheKey: cacheKey)
                     )
                 )
             }

--- a/apps/ios/Sources/Litter/Views/ResolvedChatImageView.swift
+++ b/apps/ios/Sources/Litter/Views/ResolvedChatImageView.swift
@@ -1,0 +1,239 @@
+import SwiftUI
+import UIKit
+import WebKit
+
+enum ResolvedChatImageSource: Equatable {
+    case data(Data)
+    case path(String)
+
+    var cacheKey: String {
+        switch self {
+        case .data(let data):
+            return "data-\(data.count)-\(data.hashValue)"
+        case .path(let path):
+            return "path-\(path)"
+        }
+    }
+}
+
+/// Renders chat images from either inline bytes or a path on the connected
+/// Codex host. PNGs use UIKit; SVGs are displayed in a script-disabled WebKit
+/// image context so vector artwork remains sharp without allowing document
+/// scripts or external subresources to run.
+struct ResolvedChatImageView: View {
+    @Environment(AppModel.self) private var appModel
+    @Environment(\.activeThreadKey) private var activeThreadKey
+
+    let source: ResolvedChatImageSource
+    var serverId: String? = nil
+    var cwd: String? = nil
+    var maxHeight: CGFloat = 320
+
+    @State private var imageData: Data?
+    @State private var loadError: String?
+    @State private var isLoading = false
+
+    private static let dataCache = NSCache<NSString, NSData>()
+
+    var body: some View {
+        Group {
+            if let imageData {
+                if Self.isSVG(imageData, source: source) {
+                    SafeSVGImageView(data: imageData)
+                        .aspectRatio(Self.svgAspectRatio(imageData), contentMode: .fit)
+                } else if let image = UIImage(data: imageData) {
+                    Image(uiImage: image)
+                        .resizable()
+                        .scaledToFit()
+                        .draggable(Image(uiImage: image)) {
+                            Image(uiImage: image)
+                                .resizable()
+                                .scaledToFit()
+                                .frame(width: 120)
+                        }
+                } else {
+                    imageError("Could not decode the image.")
+                }
+            } else if isLoading {
+                ProgressView()
+                    .tint(LitterTheme.accent)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 28)
+            } else {
+                imageError(loadError ?? "Image unavailable")
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: maxHeight, alignment: .center)
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .task(id: taskKey) {
+            await loadImage()
+        }
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var resolvedServerId: String {
+        serverId ?? activeThreadKey?.serverId ?? ""
+    }
+
+    private var resolvedCwd: String? {
+        if let cwd, !cwd.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return cwd
+        }
+        guard let activeThreadKey else { return nil }
+        return appModel.threadSnapshot(for: activeThreadKey)?.info.cwd
+    }
+
+    private var taskKey: String {
+        "\(source.cacheKey)|\(resolvedServerId)|\(resolvedCwd ?? "<none>")"
+    }
+
+    private var accessibilityLabel: String {
+        switch source {
+        case .data:
+            return "Assistant image"
+        case .path(let path):
+            return "Assistant image \((path as NSString).lastPathComponent)"
+        }
+    }
+
+    @ViewBuilder
+    private func imageError(_ message: String) -> some View {
+        Text(message)
+            .litterFont(.caption)
+            .foregroundColor(LitterTheme.danger)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 24)
+    }
+
+    private func loadImage() async {
+        if let cached = Self.dataCache.object(forKey: taskKey as NSString) {
+            imageData = cached as Data
+            loadError = nil
+            isLoading = false
+            return
+        }
+
+        isLoading = true
+        loadError = nil
+        defer { isLoading = false }
+
+        do {
+            let data: Data
+            switch source {
+            case .data(let inlineData):
+                data = inlineData
+            case .path(let path):
+                let resolved = try await appModel.client.resolveImageViewAt(
+                    serverId: resolvedServerId,
+                    path: path,
+                    cwd: resolvedCwd
+                )
+                data = Data(resolved.bytes)
+            }
+
+            guard !data.isEmpty else {
+                throw ResolvedChatImageError.emptyImage
+            }
+            Self.dataCache.setObject(data as NSData, forKey: taskKey as NSString)
+            imageData = data
+        } catch {
+            imageData = nil
+            let message = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+            loadError = message.isEmpty ? "Image unavailable" : message
+        }
+    }
+
+    private static func isSVG(_ data: Data, source: ResolvedChatImageSource) -> Bool {
+        if case .path(let path) = source {
+            var normalizedPath = path.lowercased()
+            if let fragmentIndex = normalizedPath.firstIndex(of: "#") {
+                normalizedPath = String(normalizedPath[..<fragmentIndex])
+            }
+            if let queryIndex = normalizedPath.firstIndex(of: "?") {
+                normalizedPath = String(normalizedPath[..<queryIndex])
+            }
+            if normalizedPath.hasSuffix(".svg") {
+                return true
+            }
+        }
+        guard let prefix = String(data: data.prefix(2048), encoding: .utf8)?.lowercased() else {
+            return false
+        }
+        return prefix.contains("<svg")
+    }
+
+    private static func svgAspectRatio(_ data: Data) -> CGFloat {
+        guard let source = String(data: data.prefix(8192), encoding: .utf8) else {
+            return 16 / 9
+        }
+        let pattern = #"viewBox\s*=\s*[\"']\s*[-+0-9.eE]+[\s,]+[-+0-9.eE]+[\s,]+([-+0-9.eE]+)[\s,]+([-+0-9.eE]+)\s*[\"']"#
+        guard let expression = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]),
+              let match = expression.firstMatch(
+                in: source,
+                range: NSRange(source.startIndex..<source.endIndex, in: source)
+              ),
+              let widthRange = Range(match.range(at: 1), in: source),
+              let heightRange = Range(match.range(at: 2), in: source),
+              let width = Double(source[widthRange]),
+              let height = Double(source[heightRange]),
+              width > 0,
+              height > 0 else {
+            return 16 / 9
+        }
+        return CGFloat(width / height)
+    }
+}
+
+private enum ResolvedChatImageError: LocalizedError {
+    case emptyImage
+
+    var errorDescription: String? {
+        "Image data was empty."
+    }
+}
+
+private struct SafeSVGImageView: UIViewRepresentable {
+    let data: Data
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeUIView(context: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = .nonPersistent()
+        let preferences = WKWebpagePreferences()
+        preferences.allowsContentJavaScript = false
+        configuration.defaultWebpagePreferences = preferences
+
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.isOpaque = false
+        webView.backgroundColor = .clear
+        webView.scrollView.backgroundColor = .clear
+        webView.scrollView.isScrollEnabled = false
+        webView.isUserInteractionEnabled = false
+        return webView
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        let fingerprint = "\(data.count)-\(data.hashValue)"
+        guard context.coordinator.fingerprint != fingerprint else { return }
+        context.coordinator.fingerprint = fingerprint
+
+        let payload = data.base64EncodedString()
+        let html = """
+        <!doctype html>
+        <html><head>
+        <meta name="viewport" content="width=device-width,initial-scale=1">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data:; style-src 'unsafe-inline'">
+        <style>html,body{margin:0;width:100%;height:100%;background:transparent}img{display:block;width:100%;height:100%;object-fit:contain}</style>
+        </head><body><img alt="" src="data:image/svg+xml;base64,\(payload)"></body></html>
+        """
+        webView.loadHTMLString(html, baseURL: nil)
+    }
+
+    final class Coordinator {
+        var fingerprint: String?
+    }
+}

--- a/apps/ios/Sources/Litter/Views/StreamingAssistantRenderCache.swift
+++ b/apps/ios/Sources/Litter/Views/StreamingAssistantRenderCache.swift
@@ -220,6 +220,16 @@ final class StreamingAssistantRenderCache {
                     )
                 )
                 blockIndex += 1
+            case .localImage(let path):
+                let contentHash = path.hashValue
+                let cacheKey = "\(itemId)-\(namespace)-path-\(blockIndex)-\(contentHash)"
+                segments.append(
+                    MessageRenderCache.AssistantSegment(
+                        id: cacheKey,
+                        kind: .localImage(path: path, cacheKey: cacheKey)
+                    )
+                )
+                blockIndex += 1
             }
         }
 

--- a/apps/ios/Sources/Litter/Views/ToolCallCardView.swift
+++ b/apps/ios/Sources/Litter/Views/ToolCallCardView.swift
@@ -533,27 +533,19 @@ private enum ToolCallImageDescriptor: Equatable {
     case inlineData(Data)
     case filePath(String)
 
-    var cacheKey: String {
+    var resolvedSource: ResolvedChatImageSource {
         switch self {
         case .inlineData(let data):
-            return "inline-\(data.hashValue)"
+            return .data(data)
         case .filePath(let path):
-            return "path-\(path)"
+            return .path(path)
         }
     }
 }
 
 private struct ToolCallImagePreview: View {
-    @Environment(AppModel.self) private var appModel
-
     let descriptor: ToolCallImageDescriptor
     let serverId: String?
-
-    @State private var renderedImage: UIImage?
-    @State private var isLoading = false
-    @State private var loadError: String?
-
-    private static let imageCache = NSCache<NSString, UIImage>()
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -565,104 +557,16 @@ private struct ToolCallImagePreview: View {
                 RoundedRectangle(cornerRadius: 10, style: .continuous)
                     .fill(LitterTheme.codeBackground.opacity(0.82))
 
-                if let renderedImage {
-                    Image(uiImage: renderedImage)
-                        .resizable()
-                        .scaledToFit()
-                        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-                        .draggable(Image(uiImage: renderedImage)) {
-                            Image(uiImage: renderedImage)
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: 120)
-                        }
-                } else if isLoading {
-                    ProgressView()
-                        .tint(LitterTheme.accent)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 32)
-                } else {
-                    Text(loadError ?? "Image unavailable")
-                        .litterFont(.caption)
-                        .foregroundColor(loadError == nil ? LitterTheme.textSecondary : LitterTheme.danger)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 24)
-                }
+                ResolvedChatImageView(
+                    source: descriptor.resolvedSource,
+                    serverId: serverId,
+                    maxHeight: 320
+                )
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
             }
             .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
         }
-        .task(id: taskKey) {
-            await loadImage()
-        }
-    }
-
-    private var taskKey: String {
-        "\(descriptor.cacheKey)|\(serverId ?? "<none>")"
-    }
-
-    private func loadImage() async {
-        if let cached = Self.imageCache.object(forKey: taskKey as NSString) {
-            renderedImage = cached
-            loadError = nil
-            isLoading = false
-            return
-        }
-
-        isLoading = true
-        loadError = nil
-
-        defer {
-            isLoading = false
-        }
-
-        do {
-            let image: UIImage
-            switch descriptor {
-            case .inlineData(let data):
-                guard let decoded = UIImage(data: data) else {
-                    throw ToolCallImageError.invalidImageData
-                }
-                image = decoded
-            case .filePath(let path):
-                let data = try await fetchImageData(path: path)
-                guard let decoded = UIImage(data: data) else {
-                    throw ToolCallImageError.invalidImageData
-                }
-                image = decoded
-            }
-
-            Self.imageCache.setObject(image, forKey: taskKey as NSString)
-            renderedImage = image
-            loadError = nil
-        } catch {
-            renderedImage = nil
-            loadError = ToolCallImageError.message(for: error)
-        }
-    }
-
-    private func fetchImageData(path: String) async throws -> Data {
-        let resolved = try await appModel.client.resolveImageView(
-            serverId: serverId ?? "",
-            path: path
-        )
-        return Data(resolved.bytes)
-    }
-}
-
-private enum ToolCallImageError: LocalizedError {
-    case invalidImageData
-
-    var errorDescription: String? {
-        switch self {
-        case .invalidImageData:
-            return "Could not decode the image."
-        }
-    }
-
-    static func message(for error: Error) -> String {
-        let message = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
-        return message.isEmpty ? "Image unavailable" : message
     }
 }
 

--- a/apps/ios/Tests/LitterTests/MessageContentBridgeTests.swift
+++ b/apps/ios/Tests/LitterTests/MessageContentBridgeTests.swift
@@ -81,6 +81,31 @@ final class MessageContentBridgeTests: XCTestCase {
         XCTAssertEqual(code, "c+d")
     }
 
+    func testAssistantRenderBlocksPromoteLocalPNGAndSVGPaths() {
+        let blocks = MessageContentBridge.assistantRenderBlocks(
+            "Preview ![chart](/tmp/chart.png) and `docs/system map.svg`."
+        )
+
+        XCTAssertEqual(blocks.count, 5)
+        guard case .localImage(path: let pngPath) = blocks[1] else {
+            return XCTFail("Expected PNG path image block")
+        }
+        XCTAssertEqual(pngPath, "/tmp/chart.png")
+
+        guard case .localImage(path: let svgPath) = blocks[3] else {
+            return XCTFail("Expected SVG path image block")
+        }
+        XCTAssertEqual(svgPath, "docs/system map.svg")
+    }
+
+    func testAssistantRenderBlocksLinkifyBareWebURL() {
+        let blocks = MessageContentBridge.assistantRenderBlocks("Open https://openai.com now.")
+        guard case .markdown(let markdown) = blocks.first else {
+            return XCTFail("Expected markdown block")
+        }
+        XCTAssertEqual(markdown, "Open <https://openai.com> now.")
+    }
+
     func testNormalizedAssistantMarkdownConvertsBackslashMathDelimiters() {
         let text = """
         Hello, LaTeX.

--- a/apps/ios/scripts/build-rust.sh
+++ b/apps/ios/scripts/build-rust.sh
@@ -16,6 +16,7 @@ GENERATED_DEVICE_DIR="$GENERATED_RUST_DIR/ios-device"
 GENERATED_SIM_DIR="$GENERATED_RUST_DIR/ios-sim"
 GENERATED_MACABI_DIR="$GENERATED_RUST_DIR/ios-macabi"
 BINDINGS_HASH_FILE="$GENERATED_RUST_DIR/.swift-bindings.hash"
+BINDINGS_HASH_SCRIPT="$REPO_DIR/tools/scripts/uniffi-bindings-input-hash.sh"
 IOS_DEPLOYMENT_TARGET="${IOS_DEPLOYMENT_TARGET:-18.0}"
 MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-14.0}"
 SUBMODULE_DIR="$REPO_DIR/shared/third_party/codex"
@@ -221,41 +222,36 @@ if [ -n "$IPHONESIM_SDK" ]; then
   export BINDGEN_EXTRA_CLANG_ARGS_aarch64_apple_ios_sim="--target=arm64-apple-ios${IOS_DEPLOYMENT_TARGET}-simulator -isysroot ${IPHONESIM_SDK}"
 fi
 
-bindings_inputs() {
-  cat <<EOF
-$RUST_BRIDGE_DIR/codex-mobile-client/src/lib.rs
-$RUST_BRIDGE_DIR/codex-mobile-client/src/conversation_uniffi.rs
-$RUST_BRIDGE_DIR/codex-mobile-client/src/discovery_uniffi.rs
-$RUST_BRIDGE_DIR/codex-mobile-client/src/uniffi_shared.rs
-$RUST_BRIDGE_DIR/codex-mobile-client/Cargo.toml
-$RUST_BRIDGE_DIR/Cargo.lock
-$RUST_BRIDGE_DIR/../third_party/codex/codex-rs/app-server-protocol/src/protocol/common.rs
-$RUST_BRIDGE_DIR/../third_party/codex/codex-rs/app-server-protocol/src/protocol/v1.rs
-$RUST_BRIDGE_DIR/../third_party/codex/codex-rs/app-server-protocol/src/protocol/v2.rs
-$RUST_BRIDGE_DIR/../third_party/codex/codex-rs/protocol/src/account.rs
-$RUST_BRIDGE_DIR/../third_party/codex/codex-rs/protocol/src/config_types.rs
-$RUST_BRIDGE_DIR/../third_party/codex/codex-rs/protocol/src/models.rs
-$RUST_BRIDGE_DIR/../third_party/codex/codex-rs/protocol/src/openai_models.rs
-$RUST_BRIDGE_DIR/../third_party/codex/codex-rs/protocol/src/parse_command.rs
-$RUST_BRIDGE_DIR/../third_party/codex/codex-rs/protocol/src/protocol.rs
-EOF
-  find "$RUST_BRIDGE_DIR/codex-mobile-client/src" -type f -name '*.rs' | sort
+compute_bindings_hash() {
+  "$BINDINGS_HASH_SCRIPT"
 }
 
-compute_bindings_hash() {
-  local file
-  {
-    while IFS= read -r file; do
-      [ -f "$file" ] || continue
-      shasum -a 256 "$file"
-    done < <(bindings_inputs | sort)
-  } | shasum -a 256 | awk '{print $1}'
+copy_if_changed() {
+  local source="$1"
+  local destination="$2"
+  if [ -f "$destination" ]; then
+    local source_size destination_size source_mtime destination_mtime
+    source_size="$(stat -f '%z' "$source")"
+    destination_size="$(stat -f '%z' "$destination")"
+    source_mtime="$(stat -f '%m' "$source")"
+    destination_mtime="$(stat -f '%m' "$destination")"
+    if [ "$source_size" = "$destination_size" ] && [ "$source_mtime" = "$destination_mtime" ]; then
+      return
+    fi
+    # One-time migration for artifacts copied before timestamps were
+    # preserved. Subsequent no-op builds take the metadata fast path above.
+    if cmp -s "$source" "$destination"; then
+      touch -r "$source" "$destination"
+      return
+    fi
+  fi
+  cp -p "$source" "$destination"
 }
 
 sync_generated_headers() {
-  cp "$GENERATED_SWIFT_DIR/codex_mobile_clientFFI.h" "$GENERATED_HEADERS_DIR/codex_mobile_clientFFI.h"
-  cp "$GENERATED_SWIFT_DIR/codex_mobile_clientFFI.modulemap" "$GENERATED_HEADERS_DIR/codex_mobile_clientFFI.modulemap"
-  cp "$GENERATED_SWIFT_DIR/module.modulemap" "$GENERATED_HEADERS_DIR/module.modulemap"
+  copy_if_changed "$GENERATED_SWIFT_DIR/codex_mobile_clientFFI.h" "$GENERATED_HEADERS_DIR/codex_mobile_clientFFI.h"
+  copy_if_changed "$GENERATED_SWIFT_DIR/codex_mobile_clientFFI.modulemap" "$GENERATED_HEADERS_DIR/codex_mobile_clientFFI.modulemap"
+  copy_if_changed "$GENERATED_SWIFT_DIR/module.modulemap" "$GENERATED_HEADERS_DIR/module.modulemap"
 }
 
 maybe_generate_swift_bindings() {
@@ -284,19 +280,19 @@ maybe_generate_swift_bindings() {
   echo "==> Regenerating UniFFI Swift bindings -> $UNIFFI_OUT"
   cd "$RUST_BRIDGE_DIR"
   "$RUST_BRIDGE_DIR/generate-bindings.sh" --swift-only
-  cp "$GENERATED_SWIFT_DIR/codex_mobile_client.swift" "$UNIFFI_OUT"
+  copy_if_changed "$GENERATED_SWIFT_DIR/codex_mobile_client.swift" "$UNIFFI_OUT"
   sync_generated_headers
   printf '%s\n' "$current_hash" >"$BINDINGS_HASH_FILE"
 }
 
 copy_device_artifact() {
-  cp "$CARGO_TARGET_DIR_EFFECTIVE/aarch64-apple-ios/$PROFILE/libcodex_mobile_client.a" \
+  copy_if_changed "$CARGO_TARGET_DIR_EFFECTIVE/aarch64-apple-ios/$PROFILE/libcodex_mobile_client.a" \
     "$GENERATED_DEVICE_DIR/libcodex_mobile_client.a"
 }
 
 copy_sim_artifact() {
   local sim_lib="$1"
-  cp "$sim_lib" "$GENERATED_SIM_DIR/libcodex_mobile_client.a"
+  copy_if_changed "$sim_lib" "$GENERATED_SIM_DIR/libcodex_mobile_client.a"
 }
 
 copy_macabi_artifact() {
@@ -342,7 +338,7 @@ elif [ "$MACABI_ONLY" -eq 1 ]; then
   if [ "$FAST_MACABI" -eq 1 ]; then
     echo "==> Building codex-mobile-client for $MACABI_HOST_TARGET ($PROFILE)..."
     cargo rustc --manifest-path "$RUST_BRIDGE_DIR/Cargo.toml" -p codex-mobile-client $CARGO_PROFILE_FLAG --target "$MACABI_HOST_TARGET" --crate-type staticlib $CARGO_FEATURES
-    cp "$CARGO_TARGET_DIR_EFFECTIVE/$MACABI_HOST_TARGET/$PROFILE/libcodex_mobile_client.a" \
+    copy_if_changed "$CARGO_TARGET_DIR_EFFECTIVE/$MACABI_HOST_TARGET/$PROFILE/libcodex_mobile_client.a" \
       "$GENERATED_MACABI_DIR/libcodex_mobile_client.a"
   else
     echo "==> Building codex-mobile-client for Mac Catalyst macabi targets ($PROFILE) in parallel..."

--- a/docs/ios/quickstart.md
+++ b/docs/ios/quickstart.md
@@ -63,5 +63,6 @@ generation, and Xcode builds. Stamp files make repeated runs incremental.
 
 Override via environment variables:
 
-- `IOS_SIM_DEVICE="iPhone 17 Pro"` — change simulator target
+- `IOS_SIM_DEVICE="iPhone 17 Pro"` — fallback simulator name when none is booted
+- `IOS_SIM_DESTINATION="platform=iOS Simulator,id=<UDID>"` — override the destination; local builds prefer an already-booted iOS simulator automatically
 - `XCODE_CONFIG=Release` — release build

--- a/shared/rust-bridge/codex-mobile-client/src/ffi/client.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/ffi/client.rs
@@ -1280,7 +1280,22 @@ impl AppClient {
         path: String,
     ) -> Result<types::ResolvedImageViewResult, ClientError> {
         blocking_async!(self.rt, self.inner, |c| {
-            resolve_image_view_bytes(c.as_ref(), &server_id, &path).await
+            resolve_image_view_bytes(c.as_ref(), &server_id, &path, None).await
+        })
+    }
+
+    /// Resolve an image path relative to a thread working directory when the
+    /// message referenced `./foo.png`, `art/foo.svg`, or another relative
+    /// path. The original `resolve_image_view` remains available for
+    /// absolute/tool-provided paths.
+    pub async fn resolve_image_view_at(
+        &self,
+        server_id: String,
+        path: String,
+        cwd: Option<String>,
+    ) -> Result<types::ResolvedImageViewResult, ClientError> {
+        blocking_async!(self.rt, self.inner, |c| {
+            resolve_image_view_bytes(c.as_ref(), &server_id, &path, cwd.as_deref()).await
         })
     }
 
@@ -1846,6 +1861,7 @@ async fn resolve_image_view_bytes(
     client: &MobileClient,
     server_id: &str,
     raw_path: &str,
+    cwd: Option<&str>,
 ) -> Result<types::ResolvedImageViewResult, ClientError> {
     let source = ImageViewSource::parse(raw_path)
         .ok_or_else(|| ClientError::InvalidParams("image_view path is empty".to_string()))?;
@@ -1856,8 +1872,17 @@ async fn resolve_image_view_bytes(
             bytes,
         }),
         ImageViewSource::FilePath(path) => {
-            if let Ok(bytes) = std::fs::read(&path) {
-                return Ok(types::ResolvedImageViewResult { path, bytes });
+            let local_path = if std::path::Path::new(&path).is_relative() {
+                cwd.map(|base| std::path::Path::new(base).join(&path))
+                    .unwrap_or_else(|| std::path::PathBuf::from(&path))
+            } else {
+                std::path::PathBuf::from(&path)
+            };
+            if let Ok(bytes) = std::fs::read(&local_path) {
+                return Ok(types::ResolvedImageViewResult {
+                    path: local_path.to_string_lossy().into_owned(),
+                    bytes,
+                });
             }
 
             if server_id.trim().is_empty() {
@@ -1866,9 +1891,13 @@ async fn resolve_image_view_bytes(
                 ));
             }
 
-            let response =
-                exec_command_simple_owned(client, server_id, image_read_command(&path), None)
-                    .await?;
+            let response = exec_command_simple_owned(
+                client,
+                server_id,
+                image_read_command(&path),
+                cwd.map(str::to_owned),
+            )
+            .await?;
 
             if response.exit_code != 0 {
                 let stderr = response.stderr.trim();
@@ -2152,6 +2181,10 @@ fn normalized_image_path(raw: &str) -> Option<String> {
         || raw.starts_with("\\\\")
         || is_windows_path(raw)
     {
+        return Some(raw.to_string());
+    }
+
+    if !raw.contains("://") && !raw.starts_with("data:") {
         return Some(raw.to_string());
     }
 

--- a/shared/rust-bridge/codex-mobile-client/src/hydration.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/hydration.rs
@@ -4,6 +4,7 @@
 //! with revision-keyed entries, and inline base64 image extraction.
 
 use base64::Engine;
+use linkify::{LinkFinder, LinkKind};
 use lru::LruCache;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -93,6 +94,9 @@ pub enum MessageSegment {
         data: Vec<u8>,
         mime_type: String,
     },
+    LocalImage {
+        path: String,
+    },
     InlineMath {
         latex: String,
     },
@@ -114,6 +118,9 @@ pub enum AppMessageSegment {
         data: Vec<u8>,
         mime_type: String,
     },
+    LocalImage {
+        path: String,
+    },
     InlineMath {
         latex: String,
     },
@@ -133,6 +140,7 @@ impl From<MessageSegment> for AppMessageSegment {
             MessageSegment::InlineImage { data, mime_type } => {
                 Self::InlineImage { data, mime_type }
             }
+            MessageSegment::LocalImage { path } => Self::LocalImage { path },
             MessageSegment::InlineMath { latex } => Self::InlineMath { latex },
             MessageSegment::DisplayMath { latex } => Self::DisplayMath { latex },
             MessageSegment::CodeBlock { language, code } => Self::CodeBlock { language, code },
@@ -154,6 +162,9 @@ pub enum MessageRenderBlock {
         data: Vec<u8>,
         mime_type: String,
     },
+    LocalImage {
+        path: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, uniffi::Enum)]
@@ -169,6 +180,9 @@ pub enum AppMessageRenderBlock {
         data: Vec<u8>,
         mime_type: String,
     },
+    LocalImage {
+        path: String,
+    },
 }
 
 impl From<MessageRenderBlock> for AppMessageRenderBlock {
@@ -179,6 +193,7 @@ impl From<MessageRenderBlock> for AppMessageRenderBlock {
             MessageRenderBlock::InlineImage { data, mime_type } => {
                 Self::InlineImage { data, mime_type }
             }
+            MessageRenderBlock::LocalImage { path } => Self::LocalImage { path },
         }
     }
 }
@@ -300,6 +315,26 @@ static BARE_DATA_URI_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"data:image/([^;]+);base64,([A-Za-z0-9+/=]+)").expect("invalid bare data URI regex")
 });
 
+/// Matches Markdown image or ordinary link destinations. Local PNG/SVG
+/// destinations are promoted into typed image blocks so the platform can
+/// resolve them against the connected Codex host instead of treating them as
+/// web links.
+static MARKDOWN_LINK_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"!?\[[^\]]*\]\(\s*(?:<([^>]+)>|([^\s)]+))(?:\s+[\"'][^\"']*[\"'])?\s*\)"#)
+        .expect("invalid markdown link regex")
+});
+
+/// Conservative bare-path matcher. The candidate is validated again by
+/// `local_image_path`, which rejects network/data URLs and anything other than
+/// PNG/SVG. Spaces are supported by Markdown's `<...>` destination form or by
+/// wrapping the path in inline code.
+static BARE_LOCAL_IMAGE_PATH_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(?i)(?:file://)?(?:[A-Za-z]:[\\/]|(?:~|\.{1,2})?/)?[^\s`<>()\[\]{}\"']+\.(?:png|svg)"#,
+    )
+    .expect("invalid local image path regex")
+});
+
 // ---------------------------------------------------------------------------
 // Segment extraction
 // ---------------------------------------------------------------------------
@@ -312,6 +347,92 @@ fn decode_image_capture(cap: &regex::Captures<'_>) -> Option<(String, Vec<u8>)> 
     let engine = base64::engine::general_purpose::STANDARD;
     let bytes = engine.decode(&cleaned).ok()?;
     Some((format!("image/{}", mime_suffix), bytes))
+}
+
+fn local_image_path(raw: &str) -> Option<String> {
+    let candidate = raw
+        .trim()
+        .trim_matches(|character| character == '<' || character == '>');
+    if candidate.is_empty() || candidate.contains('\n') || candidate.contains('\r') {
+        return None;
+    }
+
+    let lowercase = candidate.to_ascii_lowercase();
+    if lowercase.starts_with("http://")
+        || lowercase.starts_with("https://")
+        || lowercase.starts_with("data:")
+        || lowercase.contains("://") && !lowercase.starts_with("file://")
+    {
+        return None;
+    }
+
+    let extension_source = lowercase
+        .split(['?', '#'])
+        .next()
+        .unwrap_or(lowercase.as_str());
+    if !extension_source.ends_with(".png") && !extension_source.ends_with(".svg") {
+        return None;
+    }
+
+    Some(candidate.to_owned())
+}
+
+fn inline_code_value<'a>(text: &'a str, start: usize, end: usize) -> Option<&'a str> {
+    let span = text.get(start..end)?;
+    let opener_len = span
+        .as_bytes()
+        .iter()
+        .take_while(|&&byte| byte == b'`')
+        .count();
+    if opener_len == 0 || span.len() < opener_len * 2 {
+        return None;
+    }
+    span.get(opener_len..span.len() - opener_len).map(str::trim)
+}
+
+fn linkify_bare_web_urls(markdown: &str) -> String {
+    let mut finder = LinkFinder::new();
+    finder.kinds(&[LinkKind::Url]);
+
+    let inline_code_ranges = find_inline_code_spans(markdown, &[]);
+    let markdown_link_ranges: Vec<(usize, usize)> = MARKDOWN_LINK_RE
+        .find_iter(markdown)
+        .map(|matched| (matched.start(), matched.end()))
+        .collect();
+
+    let links: Vec<_> = finder
+        .links(markdown)
+        .filter(|link| {
+            let value = link.as_str().to_ascii_lowercase();
+            if !value.starts_with("http://") && !value.starts_with("https://") {
+                return false;
+            }
+            if overlaps_range(link.start(), link.end(), &inline_code_ranges)
+                || overlaps_range(link.start(), link.end(), &markdown_link_ranges)
+            {
+                return false;
+            }
+            let already_autolinked =
+                markdown[..link.start()].ends_with('<') && markdown[link.end()..].starts_with('>');
+            !already_autolinked
+        })
+        .collect();
+
+    if links.is_empty() {
+        return markdown.to_owned();
+    }
+
+    let mut output = String::with_capacity(markdown.len() + links.len() * 2);
+    let mut cursor = 0usize;
+    for link in links {
+        output.push_str(&markdown[cursor..link.start()]);
+        output.push('<');
+        output.push_str(link.as_str());
+        output.push('>');
+        cursor = link.end();
+    }
+    output.push_str(&markdown[cursor..]);
+    output
 }
 
 /// Find all code fence spans in `text` using a line-based scan.
@@ -615,7 +736,7 @@ fn find_math_spans(
     spans
 }
 
-/// Extract inline base64 images and code blocks from message text,
+/// Extract inline images, local PNG/SVG paths, and code blocks from message text,
 /// splitting into typed segments.
 ///
 /// Processing order:
@@ -675,6 +796,62 @@ pub fn extract_message_segments(text: &str) -> Vec<MessageSegment> {
                     data: bytes,
                     mime_type,
                 },
+            ));
+        }
+    }
+
+    // Markdown image/link destinations that reference a local PNG or SVG.
+    for cap in MARKDOWN_LINK_RE.captures_iter(text) {
+        let matched = cap.get(0).expect("markdown link has whole match");
+        if overlaps_range(matched.start(), matched.end(), &opaque_ranges)
+            || spans
+                .iter()
+                .any(|(start, end, _)| matched.start() < *end && matched.end() > *start)
+        {
+            continue;
+        }
+        let raw_path = cap
+            .get(1)
+            .or_else(|| cap.get(2))
+            .map(|value| value.as_str());
+        if let Some(path) = raw_path.and_then(local_image_path) {
+            spans.push((
+                matched.start(),
+                matched.end(),
+                MessageSegment::LocalImage { path },
+            ));
+        }
+    }
+
+    // Inline-code image paths are common in Codex answers. Promote the whole
+    // code token only when its entire content is a PNG/SVG path.
+    for (start, end) in &inline_code_ranges {
+        if spans
+            .iter()
+            .any(|(span_start, span_end, _)| *start < *span_end && *end > *span_start)
+        {
+            continue;
+        }
+        if let Some(path) = inline_code_value(text, *start, *end).and_then(local_image_path) {
+            spans.push((*start, *end, MessageSegment::LocalImage { path }));
+        }
+    }
+
+    // Finally collect bare path references outside fenced/inline code and
+    // outside the richer Markdown matches above.
+    for matched in BARE_LOCAL_IMAGE_PATH_RE.find_iter(text) {
+        let overlaps = overlaps_range(matched.start(), matched.end(), &opaque_ranges)
+            || spans
+                .iter()
+                .any(|(start, end, _)| matched.start() < *end && matched.end() > *start);
+        if overlaps {
+            continue;
+        }
+        if let Some(path) = local_image_path(matched.as_str()) {
+            spans.push((
+                matched.start(),
+                matched.end(),
+                MessageSegment::LocalImage { path },
             ));
         }
     }
@@ -765,6 +942,10 @@ pub fn extract_message_render_blocks(text: &str) -> Vec<MessageRenderBlock> {
                 flush_markdown_buffer(&mut blocks, &mut markdown_buffer);
                 blocks.push(MessageRenderBlock::InlineImage { data, mime_type });
             }
+            MessageSegment::LocalImage { path } => {
+                flush_markdown_buffer(&mut blocks, &mut markdown_buffer);
+                blocks.push(MessageRenderBlock::LocalImage { path });
+            }
         }
     }
 
@@ -784,7 +965,8 @@ fn flush_markdown_buffer(blocks: &mut Vec<MessageRenderBlock>, markdown_buffer: 
         return;
     }
 
-    for markdown in crate::markdown_blocks::render_markdown_blocks(markdown_buffer) {
+    let linked_markdown = linkify_bare_web_urls(markdown_buffer);
+    for markdown in crate::markdown_blocks::render_markdown_blocks(&linked_markdown) {
         match markdown {
             crate::markdown_blocks::MarkdownBlock::Markdown(markdown) => {
                 if !markdown.is_empty() {
@@ -1463,6 +1645,88 @@ mod tests {
                 MessageRenderBlock::Markdown { .. }
             ] if mime_type == "image/png"
         ));
+    }
+
+    #[test]
+    fn test_render_blocks_promote_markdown_local_png_and_svg_links() {
+        let blocks = extract_message_render_blocks(
+            "Before ![chart](/tmp/chart.png) and [diagram](<docs/system map.svg>) after",
+        );
+
+        assert_eq!(
+            blocks,
+            vec![
+                MessageRenderBlock::Markdown {
+                    markdown: "Before".to_owned(),
+                },
+                MessageRenderBlock::LocalImage {
+                    path: "/tmp/chart.png".to_owned(),
+                },
+                MessageRenderBlock::Markdown {
+                    markdown: "and".to_owned(),
+                },
+                MessageRenderBlock::LocalImage {
+                    path: "docs/system map.svg".to_owned(),
+                },
+                MessageRenderBlock::Markdown {
+                    markdown: "after".to_owned(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_render_blocks_promote_bare_and_inline_code_image_paths() {
+        let blocks = extract_message_render_blocks(
+            "Bare ./art/chart.svg and spaced `/Users/example/My Chart.png`.",
+        );
+
+        assert!(matches!(
+            blocks.as_slice(),
+            [
+                MessageRenderBlock::Markdown { .. },
+                MessageRenderBlock::LocalImage { path: first },
+                MessageRenderBlock::Markdown { .. },
+                MessageRenderBlock::LocalImage { path: second },
+                MessageRenderBlock::Markdown { .. },
+            ] if first == "./art/chart.svg" && second == "/Users/example/My Chart.png"
+        ));
+    }
+
+    #[test]
+    fn test_render_blocks_leave_remote_image_urls_as_clickable_links() {
+        let blocks = extract_message_render_blocks(
+            "See https://example.com/chart.png and [the SVG](https://example.com/map.svg).",
+        );
+
+        assert_eq!(blocks.len(), 1);
+        let MessageRenderBlock::Markdown { markdown } = &blocks[0] else {
+            panic!("expected markdown");
+        };
+        assert!(markdown.contains("<https://example.com/chart.png>"));
+        assert!(markdown.contains("[the SVG](https://example.com/map.svg)"));
+    }
+
+    #[test]
+    fn test_linkify_bare_urls_skips_inline_code_and_existing_links() {
+        assert_eq!(
+            linkify_bare_web_urls(
+                "Open https://openai.com, keep `https://example.com`, and [docs](https://example.org).",
+            ),
+            "Open <https://openai.com>, keep `https://example.com`, and [docs](https://example.org)."
+        );
+    }
+
+    #[test]
+    fn test_local_image_paths_inside_fenced_code_remain_code() {
+        let blocks = extract_message_render_blocks("```text\n/tmp/chart.png\n```");
+        assert_eq!(
+            blocks,
+            vec![MessageRenderBlock::CodeBlock {
+                language: Some("text".to_owned()),
+                code: "/tmp/chart.png".to_owned(),
+            }]
+        );
     }
 
     // -- FollowScrollTracker --

--- a/shared/rust-bridge/generate-bindings.sh
+++ b/shared/rust-bridge/generate-bindings.sh
@@ -15,6 +15,8 @@ WORKSPACE_DIR="$SCRIPT_DIR"
 source "$WORKSPACE_DIR/../../tools/scripts/load-sccache-aws-creds.sh"
 OUT_SWIFT="$WORKSPACE_DIR/generated/swift"
 OUT_KOTLIN="$WORKSPACE_DIR/generated/kotlin"
+SWIFT_BINDINGS_HASH_FILE="$WORKSPACE_DIR/../../apps/ios/GeneratedRust/.swift-bindings.hash"
+BINDINGS_HASH_SCRIPT="$WORKSPACE_DIR/../../tools/scripts/uniffi-bindings-input-hash.sh"
 
 cd "$WORKSPACE_DIR"
 
@@ -92,6 +94,8 @@ if [[ "$GENERATE_SWIFT" -eq 1 ]]; then
         --language swift \
         --out-dir "$OUT_SWIFT"
     cp "$OUT_SWIFT/codex_mobile_clientFFI.modulemap" "$OUT_SWIFT/module.modulemap"
+    mkdir -p "$(dirname "$SWIFT_BINDINGS_HASH_FILE")"
+    "$BINDINGS_HASH_SCRIPT" >"$SWIFT_BINDINGS_HASH_FILE"
 fi
 
 if [[ "$GENERATE_KOTLIN" -eq 1 ]]; then

--- a/tools/scripts/loop-ios.sh
+++ b/tools/scripts/loop-ios.sh
@@ -8,10 +8,10 @@ set -euo pipefail
 
 MODE="${1:-sim}"
 case "$MODE" in
-  sim)        RUST_TARGET=rust-ios-sim-fast    ; BUILD_TARGET=ios-build-sim-fast    ; RUN_TARGET="" ;;
-  sim-run)    RUST_TARGET=rust-ios-sim-fast    ; BUILD_TARGET=ios-build-sim-fast    ; RUN_TARGET=ios-sim-run ;;
-  device)     RUST_TARGET=rust-ios-device-fast ; BUILD_TARGET=ios-build-device-fast ; RUN_TARGET="" ;;
-  device-run) RUST_TARGET=rust-ios-device-fast ; BUILD_TARGET=ios-build-device-fast ; RUN_TARGET=ios-device-run ;;
+  sim)        BUILD_TARGET=ios-build-sim-fast    ; SWIFT_TARGET=ios-xcode-sim-fast    ; RUN_TARGET="" ;;
+  sim-run)    BUILD_TARGET=ios-build-sim-fast    ; SWIFT_TARGET=ios-xcode-sim-fast    ; RUN_TARGET=ios-sim-launch ;;
+  device)     BUILD_TARGET=ios-build-device-fast ; SWIFT_TARGET=ios-xcode-device-fast ; RUN_TARGET="" ;;
+  device-run) BUILD_TARGET=ios-build-device-fast ; SWIFT_TARGET=ios-xcode-device-fast ; RUN_TARGET=ios-device-launch ;;
   *)
     echo "usage: $0 [sim|sim-run|device|device-run]" >&2
     exit 1
@@ -50,8 +50,8 @@ run_target() {
 }
 
 echo "==> [loop] watching for changes (MODE=$MODE)"
-echo "    rust changes → make $RUST_TARGET + $BUILD_TARGET"
-echo "    swift changes → make $BUILD_TARGET"
+echo "    rust changes → make $BUILD_TARGET"
+echo "    swift changes → make $SWIFT_TARGET (Rust skipped)"
 [ -n "$RUN_TARGET" ] && echo "    after each build → make $RUN_TARGET"
 echo "    Ctrl+C to stop"
 
@@ -72,12 +72,20 @@ fswatch -0 -r --latency 1 \
     case "$path" in
       *.rs|*/Cargo.toml|*/Cargo.lock)
         run_target "$BUILD_TARGET" "rust+swift ($(basename "$path"))"
-        # BUILD_TARGET depends on RUST_TARGET via the Makefile, so this picks
-        # up the Rust rebuild automatically. We don't run RUST_TARGET first
-        # because BUILD_TARGET's dep chain handles it.
+        ;;
+      */project.yml)
+        (
+          flock -n 9 || { echo "[loop] build in progress — skipping (project.yml)"; exit 0; }
+          echo
+          echo "==> [loop] $(date +%H:%M:%S) project.yml → make xcgen + $SWIFT_TARGET"
+          cd "$ROOT" && make xcgen && make "$SWIFT_TARGET"
+          if [ -n "$RUN_TARGET" ]; then
+            cd "$ROOT" && make "$RUN_TARGET"
+          fi
+        ) 9>"$LOCK"
         ;;
       *.swift|*.yml|*.plist|*.xcassets/*|*.storyboard|*.xib)
-        run_target "$BUILD_TARGET" "swift ($(basename "$path"))"
+        run_target "$SWIFT_TARGET" "swift ($(basename "$path"))"
         ;;
       *)
         # Ignore other change types (editor swap files, etc.)

--- a/tools/scripts/uniffi-bindings-input-hash.sh
+++ b/tools/scripts/uniffi-bindings-input-hash.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+RUST_BRIDGE_DIR="$REPO_DIR/shared/rust-bridge"
+
+bindings_inputs() {
+  {
+  printf '%s\n' \
+    "$RUST_BRIDGE_DIR/codex-mobile-client/src/lib.rs" \
+    "$RUST_BRIDGE_DIR/codex-mobile-client/src/conversation_uniffi.rs" \
+    "$RUST_BRIDGE_DIR/codex-mobile-client/src/discovery_uniffi.rs" \
+    "$RUST_BRIDGE_DIR/codex-mobile-client/src/uniffi_shared.rs" \
+    "$RUST_BRIDGE_DIR/codex-mobile-client/Cargo.toml" \
+    "$RUST_BRIDGE_DIR/Cargo.lock" \
+    "$REPO_DIR/shared/third_party/codex/codex-rs/app-server-protocol/src/protocol/common.rs" \
+    "$REPO_DIR/shared/third_party/codex/codex-rs/app-server-protocol/src/protocol/v1.rs" \
+    "$REPO_DIR/shared/third_party/codex/codex-rs/app-server-protocol/src/protocol/v2.rs" \
+    "$REPO_DIR/shared/third_party/codex/codex-rs/protocol/src/account.rs" \
+    "$REPO_DIR/shared/third_party/codex/codex-rs/protocol/src/config_types.rs" \
+    "$REPO_DIR/shared/third_party/codex/codex-rs/protocol/src/models.rs" \
+    "$REPO_DIR/shared/third_party/codex/codex-rs/protocol/src/openai_models.rs" \
+    "$REPO_DIR/shared/third_party/codex/codex-rs/protocol/src/parse_command.rs" \
+    "$REPO_DIR/shared/third_party/codex/codex-rs/protocol/src/protocol.rs"
+    find "$RUST_BRIDGE_DIR/codex-mobile-client/src" -type f -name '*.rs'
+  } | sort -u
+}
+
+if [ "${1:-}" = "--newer-than" ]; then
+  stamp="${2:?usage: $(basename "$0") [--newer-than STAMP]}"
+  while IFS= read -r file; do
+    if [ -f "$file" ] && { [ ! -e "$stamp" ] || [ "$file" -nt "$stamp" ]; }; then
+      exit 0
+    fi
+  done < <(bindings_inputs)
+  exit 1
+fi
+
+bindings_inputs | while IFS= read -r file; do
+  [ -f "$file" ] || continue
+  shasum -a 256 "$file"
+done | shasum -a 256 | awk '{print $1}'


### PR DESCRIPTION
## Purpose

Render local PNG/SVG references directly in chat, place composer controls inside the input surface, make HTTP(S) links open externally, and stop warm iOS iteration from repeatedly rebuilding expensive Rust/Ghostty work.

## Key changes

- parse PNG/SVG Markdown links and path references in the shared Rust conversation renderer
- resolve local and remote-thread image paths on both iOS and Android
- linkify bare HTTP(S) URLs and route clicks to the platform browser
- move add, voice, send, and stop controls inside the composer surface on both platforms
- sequence Rust and UniFFI generation, preserve unchanged artifact mtimes, and remove broad Makefile-driven invalidation
- make the Swift-only watcher use an Xcode-only target and prefer the already-booted simulator

## Verification

- focused Rust hydration tests: 49 passed
- Android `:app:compileDebugKotlin`: passed
- Android `:app:testDebugUnitTest`: passed
- `make ios-sim-fast`: passed
- measured warm `make ios-sim-fast`: 24.12 seconds
- shell syntax checks and `git diff --check`: passed
