### PR TITLE
watch: remove unwired voice barge-in control

### DIFF
--- a/apps/ios/Sources/Litter/Models/WatchCompanionBridge.swift
+++ b/apps/ios/Sources/Litter/Models/WatchCompanionBridge.swift
@@ -633,9 +633,6 @@ final class WatchCompanionBridge: NSObject {
         case "voice.toggleMute":
             return await handleVoiceToggleMute()
 
-        case "voice.bargeIn":
-            return await handleVoiceBargeIn()
-
         case "home.hide":
             return handleHomeHide(message)
 
@@ -827,15 +824,6 @@ final class WatchCompanionBridge: NSObject {
         return ["ok": true, "isMuted": controller.isMicrophoneMuted]
     }
 
-    private func handleVoiceBargeIn() async -> [String: Any] {
-        // Same situation as mute: there's no client-side cancel-response
-        // entry point yet. Reply with an error so the watch UI can hide the
-        // affordance.
-        return [
-            "ok": false,
-            "error": "barge-in not yet wired into iOS realtime session",
-        ]
-    }
 }
 
 /// WCSessionDelegate proxy. Declared as a separate class so the bridge can

--- a/apps/ios/Sources/LitterWatch/Models/WatchSessionBridge.swift
+++ b/apps/ios/Sources/LitterWatch/Models/WatchSessionBridge.swift
@@ -127,10 +127,6 @@ final class WatchSessionBridge: NSObject, WCSessionDelegate {
         sendMessage(["kind": "voice.toggleMute"])
     }
 
-    func sendVoiceBargeIn() {
-        sendMessage(["kind": "voice.bargeIn"])
-    }
-
     private func sendMessage(_ payload: [String: Any]) {
         guard WCSession.default.activationState == .activated else { return }
         if WCSession.default.isReachable {

--- a/apps/ios/Sources/LitterWatch/Views/RealtimeVoiceScreen.swift
+++ b/apps/ios/Sources/LitterWatch/Views/RealtimeVoiceScreen.swift
@@ -87,34 +87,20 @@ private struct ActiveBody: View {
 
     private var controls: some View {
         VStack(spacing: 6) {
-            HStack(spacing: 4) {
-                Button {
-                    WKInterfaceDevice.current().play(.failure)
-                    WatchSessionBridge.shared.sendVoiceStop()
-                } label: {
-                    Text("stop")
-                        .font(WatchTheme.mono(11, weight: .bold))
-                        .foregroundStyle(theme.danger)
-                        .frame(maxWidth: .infinity, minHeight: 30)
-                        .background(
-                            Capsule().fill(theme.surfaceLight)
-                                .overlay(Capsule().stroke(theme.danger.opacity(0.4), lineWidth: 1))
-                        )
-                }
-                .buttonStyle(.plain)
-
-                Button {
-                    WKInterfaceDevice.current().play(.click)
-                    WatchSessionBridge.shared.sendVoiceBargeIn()
-                } label: {
-                    Text("barge in")
-                        .font(WatchTheme.mono(11, weight: .bold))
-                        .foregroundStyle(theme.textOnAccent)
-                        .frame(maxWidth: .infinity, minHeight: 30)
-                        .background(Capsule().fill(theme.accent))
-                }
-                .buttonStyle(.plain)
+            Button {
+                WKInterfaceDevice.current().play(.failure)
+                WatchSessionBridge.shared.sendVoiceStop()
+            } label: {
+                Text("stop")
+                    .font(WatchTheme.mono(11, weight: .bold))
+                    .foregroundStyle(theme.danger)
+                    .frame(maxWidth: .infinity, minHeight: 30)
+                    .background(
+                        Capsule().fill(theme.surfaceLight)
+                            .overlay(Capsule().stroke(theme.danger.opacity(0.4), lineWidth: 1))
+                    )
             }
+            .buttonStyle(.plain)
 
             NavigationLink {
                 VoiceScreen()

--- a/docs/REPOSITORY_AUDIT.md
+++ b/docs/REPOSITORY_AUDIT.md
@@ -233,6 +233,9 @@ merging or replaying the pinned lineage into Alleycat first is the safe order.
 - Android lacks the plugin/file `@` autocomplete behavior recorded in its QA
   matrix.
 - Windows SSH/direct fallback remains incomplete.
+- Realtime response cancellation is observable in the bundled Codex runtime,
+  but not exposed by its app-server protocol. Watch therefore offers only the
+  supported stop control; a true barge-in action awaits that upstream request.
 - ACP cannot truthfully implement direct `command/exec`, terminate, stdin, or
   resize without a session-bearing Codex request. Fork currently creates a new
   ACP session projection; it does not clone complete server-side history.


### PR DESCRIPTION
## Purpose
Remove a Watch voice control that cannot succeed with the bundled app-server protocol.

## Changes
- remove the nonfunctional barge-in button and message route
- retain the supported stop control
- document that true response cancellation needs an upstream app-server request

## Verification
- `xcodebuild build -project apps/ios/Litter.xcodeproj -scheme LitterWatch -destination "platform=watchOS Simulator,name=Apple Watch Series 11 (46mm)" CODE_SIGNING_ALLOWED=NO -quiet`