### PR TITLE
chat: refine conversation typography

### DIFF
--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/SelectableConversationText.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/SelectableConversationText.kt
@@ -69,12 +69,24 @@ internal fun SelectableMarkdownText(
             LitterFontFamilyOption.SERIF -> android.graphics.Typeface.SERIF
         }
     }
+    val codeTypeface = remember(context, selectedFontFamily) {
+        if (selectedFontFamily == LitterFontFamilyOption.BERKELEY_MONO) {
+            runCatching {
+                androidx.core.content.res.ResourcesCompat.getFont(
+                    context,
+                    com.sigkitten.litter.android.R.font.berkeley_mono_regular,
+                )
+            }.getOrNull() ?: android.graphics.Typeface.MONOSPACE
+        } else {
+            android.graphics.Typeface.MONOSPACE
+        }
+    }
     val markdownTextSizePx = remember(context, resolvedTextSize, usePhysicalDpTextSize) {
         resolvedTextSize.toTextSizePx(context, usePhysicalDpTextSize)
     }
     val markwon = rememberConversationMarkwon(
         context = context,
-        typeface = typeface,
+        codeTypeface = codeTypeface,
         markdownTextSizePx = markdownTextSizePx,
         textColor = textColor,
     )
@@ -110,6 +122,7 @@ internal fun SelectableMarkdownText(
                 textColor = textColor,
                 textSizePx = markdownTextSizePx,
                 typeface = typeface,
+                codeTypeface = codeTypeface,
             )
             if (tv.tag != renderTag) {
                 tv.tag = renderTag
@@ -125,6 +138,7 @@ private data class MarkdownRenderTag(
     val textColor: Int,
     val textSizePx: Float,
     val typeface: android.graphics.Typeface?,
+    val codeTypeface: android.graphics.Typeface?,
 )
 
 internal fun configureSelectableMarkdownTextView(
@@ -148,6 +162,7 @@ internal fun configureSelectableMarkdownTextView(
     textView.movementMethod = LinkMovementMethod.getInstance()
     textView.setLinkTextColor(linkColor)
     textView.setTextIsSelectable(selectable)
+    textView.setLineSpacing(0f, 1.32f)
     textView.customSelectionActionModeCallback = if (selectable) {
         RunInTerminalSelectionMenu(textView)
     } else {
@@ -216,16 +231,20 @@ private class RunInTerminalSelectionMenu(
 @Composable
 private fun rememberConversationMarkwon(
     context: android.content.Context,
-    typeface: android.graphics.Typeface?,
+    codeTypeface: android.graphics.Typeface?,
     markdownTextSizePx: Float,
     textColor: Int,
-): Markwon = remember(context, typeface, markdownTextSizePx, textColor) {
+): Markwon = remember(context, codeTypeface, markdownTextSizePx, textColor) {
     try {
         val prism4j = Prism4j(com.litter.android.ui.Prism4jGrammarLocator())
         Markwon.builder(context)
             .usePlugin(object : AbstractMarkwonPlugin() {
                 override fun configureTheme(builder: MarkwonTheme.Builder) {
-                    typeface?.let { builder.codeTypeface(it) }
+                    codeTypeface?.let { builder.codeTypeface(it) }
+                    codeTypeface?.let { builder.codeBlockTypeface(it) }
+                    val codeTextSize = markdownTextSizePx.times(0.94f).toInt()
+                    builder.codeTextSize(codeTextSize)
+                    builder.codeBlockTextSize(codeTextSize)
                 }
             })
             .usePlugin(

--- a/apps/ios/Sources/Litter/Extensions.swift
+++ b/apps/ios/Sources/Litter/Extensions.swift
@@ -311,6 +311,13 @@ enum LitterFont {
         max(UIFont.preferredFont(forTextStyle: .body).pointSize - 1, 15)
     }
 
+    static var conversationCodePointSize: CGFloat {
+        // Code is supporting material in a conversation. A one-step smaller
+        // monospaced face keeps prose as the primary reading surface without
+        // making commands or snippets hard to inspect.
+        max(UIFont.preferredFont(forTextStyle: .callout).pointSize - 1, 14)
+    }
+
     static var conversationDiffPointSize: CGFloat {
         UIFont.preferredFont(forTextStyle: .caption1).pointSize
     }

--- a/apps/ios/Sources/Litter/Views/CodeBlockView.swift
+++ b/apps/ios/Sources/Litter/Views/CodeBlockView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct CodeBlockView: View {
     let language: String
     let code: String
-    var fontSize: CGFloat = LitterFont.conversationBodyPointSize
+    var fontSize: CGFloat = LitterFont.conversationCodePointSize
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
@@ -20,8 +20,12 @@ struct CodeBlockView: View {
                     .litterMonoFont(size: fontSize)
                     .foregroundColor(LitterTheme.textBody)
                     .textSelection(.enabled)
+                    // Let the text keep its natural width inside the horizontal
+                    // scroller. A max-width frame here asks SwiftUI to squeeze
+                    // long source lines, which produces ellipses instead of a
+                    // scrollable code block.
+                    .fixedSize(horizontal: true, vertical: true)
                     .padding(12)
-                    .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
         .background(LitterTheme.codeBackground.opacity(0.8))

--- a/apps/ios/Sources/Litter/Views/ConversationDisplayUITestHarnessView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationDisplayUITestHarnessView.swift
@@ -115,7 +115,16 @@ struct ConversationDisplayUITestHarnessView: View {
         ConversationItem(
             id: "ui-test-assistant",
             content: .assistant(ConversationAssistantMessageData(
-                text: "UITEST_ASSISTANT_MESSAGE",
+                text: """
+                ## UITEST_ASSISTANT_MESSAGE
+
+                Here is a short answer with `inline code`, readable prose, and a second paragraph so typography and spacing are visible in screenshots.
+
+                ```swift
+                let greeting = "UITEST_CODE_BLOCK"
+                print(greeting)
+                ```
+                """,
                 agentNickname: nil,
                 agentRole: nil,
                 phase: nil

--- a/apps/ios/Sources/Litter/Views/MessageBubbleView.swift
+++ b/apps/ios/Sources/Litter/Views/MessageBubbleView.swift
@@ -46,7 +46,7 @@ struct LitterMarkdownView: View {
     let markdown: String
     var style: LitterMarkdownStyleVariant = .content
     var bodySize: CGFloat = LitterFont.conversationBodyPointSize
-    var codeSize: CGFloat = LitterFont.conversationBodyPointSize
+    var codeSize: CGFloat = LitterFont.conversationCodePointSize
     var selectionEnabled = true
 
     @State private var debugSettings = DebugSettings.shared
@@ -99,7 +99,7 @@ struct InlineSelectableMarkdownMessage<Content: View>: View {
     let markdown: String
     var style: LitterMarkdownStyleVariant = .content
     var bodySize: CGFloat = LitterFont.conversationBodyPointSize
-    var codeSize: CGFloat = LitterFont.conversationBodyPointSize
+    var codeSize: CGFloat = LitterFont.conversationCodePointSize
     @ViewBuilder let content: () -> Content
 
     var body: some View {
@@ -292,7 +292,7 @@ struct AssistantBubble: View, Equatable {
                     markdown: markdownString,
                     style: .content,
                     bodySize: contentFontSize,
-                    codeSize: contentFontSize
+                    codeSize: LitterFont.conversationCodePointSize
                 ) {
                     bubbleContent
                 }
@@ -316,7 +316,7 @@ struct AssistantBubble: View, Equatable {
                 markdown: markdownString,
                 style: .content,
                 bodySize: contentFontSize,
-                codeSize: contentFontSize
+                codeSize: LitterFont.conversationCodePointSize
             )
             .fixedSize(horizontal: false, vertical: true)
             .transaction { $0.animation = nil }
@@ -361,7 +361,7 @@ struct AssistantBlocksBubble: View {
                 markdown: content,
                 style: .content,
                 bodySize: contentFontSize,
-                codeSize: contentFontSize
+                codeSize: LitterFont.conversationCodePointSize
             )
             .frame(maxWidth: .infinity, alignment: .leading)
             .id(identity)
@@ -374,7 +374,7 @@ struct AssistantBlocksBubble: View {
                 CodeBlockView(
                     language: language ?? "",
                     code: code,
-                    fontSize: contentFontSize
+                    fontSize: LitterFont.conversationCodePointSize
                 )
                 .id(identity)
             }
@@ -406,7 +406,7 @@ private struct LitterMathBlockView: View {
     var body: some View {
         ScrollView(.horizontal, showsIndicators: true) {
             LatexBlockView(content: latex)
-                .fixedSize(horizontal: true, vertical: false)
+                    .fixedSize(horizontal: true, vertical: true)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -497,7 +497,7 @@ struct StreamingAssistantBubble: View {
                         .revealGranularity(typingConfig.effectiveGranularity)
                         .litterContentMarkdown(
                             bodySize: contentFontSize,
-                            codeSize: contentFontSize,
+                            codeSize: LitterFont.conversationCodePointSize,
                             selectionEnabled: !isStreaming
                         )
                         .transaction { $0.animation = nil }
@@ -506,7 +506,7 @@ struct StreamingAssistantBubble: View {
                         markdown: text,
                         style: .content,
                         bodySize: contentFontSize,
-                        codeSize: contentFontSize
+                        codeSize: LitterFont.conversationCodePointSize
                     )
                     .fixedSize(horizontal: false, vertical: true)
                     .tokenReveal(.disabled)
@@ -529,8 +529,12 @@ private func litterContentTheme(bodySize: CGFloat, codeSize: CGFloat) -> Markdow
     // primary foreground rather than the muted metadata color so long replies
     // retain contrast on dark themes.
     theme.foregroundColor = LitterTheme.textPrimary
-    theme.paragraphSpacing = 8
-    theme.blockSpacing = 8
+    // Hairball's default 1.6 multiplier reads overly airy in a long mobile
+    // transcript. Keep enough leading for scanning while making consecutive
+    // paragraphs feel like one answer rather than isolated cards.
+    theme.lineSpacing = 1.36
+    theme.paragraphSpacing = 10
+    theme.blockSpacing = 10
 
     theme.headingStyleSet = HeadingStyleSet(
         h1: HeadingStyle(font: LitterFont.markdownHeadingFont(size: bodySize * 1.43, weight: .bold), fontSize: bodySize * 1.43, weight: .bold,
@@ -603,8 +607,9 @@ private func litterSystemTheme(bodySize: CGFloat, codeSize: CGFloat) -> Markdown
     theme.bodyFont = LitterFont.markdownBodyFont(size: bodySize)
     theme.bodyFontSize = bodySize
     theme.foregroundColor = LitterTheme.textSystem
-    theme.paragraphSpacing = 6
-    theme.blockSpacing = 6
+    theme.lineSpacing = 1.32
+    theme.paragraphSpacing = 8
+    theme.blockSpacing = 8
 
     theme.headingStyleSet = HeadingStyleSet(
         h1: HeadingStyle(font: LitterFont.markdownHeadingFont(size: bodySize * 1.31, weight: .bold), fontSize: bodySize * 1.31, weight: .bold,
@@ -704,7 +709,29 @@ struct LitterCodeBlockRenderer: CodeBlockRenderer {
             .modifier(GlassRectModifier(cornerRadius: 8))
             .modifier(CodeBlockTerminalContextMenu(code: configuration.code))
         } else {
-            DefaultCodeBlockRenderer().makeBody(configuration: configuration)
+            VStack(alignment: .leading, spacing: 0) {
+                if configuration.hasLanguage {
+                    HStack {
+                        Text(configuration.languageDisplayName)
+                            .litterMonoFont(size: 11, weight: .semibold)
+                            .foregroundColor(LitterTheme.textSecondary)
+                        Spacer()
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.top, 8)
+                    .padding(.bottom, 4)
+                }
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    Text(configuration.highlightedCode)
+                        .font(configuration.theme.codeBlock.font)
+                        .foregroundColor(configuration.theme.codeBlock.textColor)
+                        .fixedSize(horizontal: true, vertical: true)
+                        .padding(configuration.theme.codeBlock.padding)
+                }
+            }
+            .background(configuration.theme.codeBlock.backgroundColor)
+            .clipShape(RoundedRectangle(cornerRadius: configuration.theme.codeBlock.cornerRadius))
                 .modifier(GlassRectModifier(cornerRadius: 8))
                 .modifier(CodeBlockTerminalContextMenu(code: configuration.code))
         }
@@ -895,7 +922,7 @@ private struct ScaledSystemMarkdownModifier: ViewModifier {
 extension View {
     func litterContentMarkdown(
         bodySize: CGFloat = LitterFont.conversationBodyPointSize,
-        codeSize: CGFloat = LitterFont.conversationBodyPointSize,
+        codeSize: CGFloat = LitterFont.conversationCodePointSize,
         selectionEnabled: Bool = true
     ) -> some View {
         modifier(
@@ -909,7 +936,7 @@ extension View {
 
     func litterSystemMarkdown(
         bodySize: CGFloat = LitterFont.conversationBodyPointSize,
-        codeSize: CGFloat = LitterFont.conversationBodyPointSize,
+        codeSize: CGFloat = LitterFont.conversationCodePointSize,
         selectionEnabled: Bool = true
     ) -> some View {
         modifier(

--- a/apps/ios/Tests/LitterUITests/LitterUITests.swift
+++ b/apps/ios/Tests/LitterUITests/LitterUITests.swift
@@ -25,6 +25,7 @@ final class LitterUITests: XCTestCase {
 
         XCTAssertTrue(app.staticTexts["UITEST_USER_MESSAGE"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.staticTexts["UITEST_ASSISTANT_MESSAGE"].exists)
+        XCTAssertTrue(app.staticTexts["UITEST_CODE_BLOCK"].exists)
         XCTAssertTrue(app.staticTexts["UITEST_REASONING_DETAIL"].exists)
         XCTAssertTrue(app.staticTexts["UITEST_COMMAND_OUTPUT"].exists)
         XCTAssertTrue(app.staticTexts["UITEST_TOOL_DETAIL"].exists)


### PR DESCRIPTION
## Purpose
Make conversation replies materially easier to read without changing session data or behavior.

## Changes
- keep prose prominent, tighten mobile markdown leading, and size code separately
- preserve complete code blocks in horizontally scrollable views rather than ellipsizing them
- apply the same code face/scale and line spacing to Android Markwon
- exercise a prose, inline-code, and fenced-code fixture in the iOS display harness

## Verification
- `xcodebuild test -project apps/ios/Litter.xcodeproj -scheme Litter -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing:LitterUITests/LitterUITests/testConversationDisplayExpandedModeShowsAllDetails -quiet`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ANDROID_SDK_ROOT=/opt/homebrew/share/android-commandlinetools ANDROID_NDK_HOME=/opt/homebrew/share/android-commandlinetools/ndk/30.0.14904198 ./gradlew :app:testDebugUnitTest --tests com.litter.android.ui.LitterAppearanceModeTest`
- Installed the iOS app on an iPhone 17 Pro Max simulator and captured the conversation fixture; the finished fenced block retains both lines without truncation.