### PR TITLE
appearance: make Studio the default theme

### DIFF
--- a/apps/android/app/src/main/java/com/litter/android/ui/LitterThemeManager.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/LitterThemeManager.kt
@@ -19,6 +19,8 @@ private const val APPEARANCE_MODE_KEY = "appearance_mode"
 private const val DARK_MODE_KEY = "dark_mode_enabled"
 private const val FONT_MONO_KEY = "font_family_mono"
 private const val FONT_FAMILY_KEY = "font_family"
+private const val DEFAULT_LIGHT_THEME_SLUG = "studio-light"
+private const val DEFAULT_DARK_THEME_SLUG = "studio-dark"
 
 enum class LitterAppearanceMode(
     val storageValue: String,
@@ -46,7 +48,7 @@ enum class LitterFontFamilyOption(
     val displayName: String,
 ) {
     BERKELEY_MONO("mono", "Berkeley Mono"),
-    CHATGPT("system", "ChatGPT (System)"),
+    CHATGPT("system", "System UI"),
     SYSTEM_MONO("system-mono", "System Mono"),
     SERIF("serif", "Reader Serif");
 
@@ -279,10 +281,10 @@ object LitterThemeManager {
         get() = themeIndex.filter { it.type == LitterColorThemeType.DARK }
 
     val selectedLightSlug: String
-        get() = preferences?.getString(SELECTED_LIGHT_THEME_KEY, null) ?: "kitty-litter-light"
+        get() = preferences?.getString(SELECTED_LIGHT_THEME_KEY, null) ?: DEFAULT_LIGHT_THEME_SLUG
 
     val selectedDarkSlug: String
-        get() = preferences?.getString(SELECTED_DARK_THEME_KEY, null) ?: "kitty-litter-dark"
+        get() = preferences?.getString(SELECTED_DARK_THEME_KEY, null) ?: DEFAULT_DARK_THEME_SLUG
 
     private val preferences
         get() = appContext?.getSharedPreferences(UI_PREFERENCES_NAME, Context.MODE_PRIVATE)

--- a/apps/ios/Sources/Litter/Extensions.swift
+++ b/apps/ios/Sources/Litter/Extensions.swift
@@ -122,7 +122,7 @@ enum FontFamilyOption: String, CaseIterable, Identifiable {
     var displayName: String {
         switch self {
         case .mono: return "Berkeley Mono"
-        case .system: return "ChatGPT (System)"
+        case .system: return "System UI"
         case .systemMono: return "System Mono"
         case .serif: return "Reader Serif"
         }

--- a/apps/ios/Sources/Litter/Models/ThemeManager.swift
+++ b/apps/ios/Sources/Litter/Models/ThemeManager.swift
@@ -68,6 +68,8 @@ final class ThemeManager {
 
     private static let appGroupSuite = LitterPalette.appGroupSuite
     private static let appearanceModeKey = "appearanceMode"
+    private static let defaultLightThemeSlug = "studio-light"
+    private static let defaultDarkThemeSlug = "studio-dark"
 
     private(set) var lightTheme: ResolvedTheme = .defaultLight
     private(set) var darkTheme: ResolvedTheme = .defaultDark
@@ -77,12 +79,12 @@ final class ThemeManager {
     private var systemColorScheme: ColorScheme = .dark
 
     var selectedLightSlug: String {
-        get { UserDefaults.standard.string(forKey: "selectedLightTheme") ?? "kitty-litter-light" }
+        get { UserDefaults.standard.string(forKey: "selectedLightTheme") ?? Self.defaultLightThemeSlug }
         set { UserDefaults.standard.set(newValue, forKey: "selectedLightTheme") }
     }
 
     var selectedDarkSlug: String {
-        get { UserDefaults.standard.string(forKey: "selectedDarkTheme") ?? "kitty-litter-dark" }
+        get { UserDefaults.standard.string(forKey: "selectedDarkTheme") ?? Self.defaultDarkThemeSlug }
         set { UserDefaults.standard.set(newValue, forKey: "selectedDarkTheme") }
     }
 

--- a/apps/ios/Tests/LitterTests/LitterAppearanceModeTests.swift
+++ b/apps/ios/Tests/LitterTests/LitterAppearanceModeTests.swift
@@ -34,12 +34,12 @@ final class FontFamilyOptionTests: XCTestCase {
         ])
     }
 
-    func testChatGPTAndReaderChoicesUseProportionalFamilies() {
+    func testSystemAndReaderChoicesUseProportionalFamilies() {
         XCTAssertFalse(FontFamilyOption.system.isMono)
         XCTAssertFalse(FontFamilyOption.serif.isMono)
         XCTAssertTrue(FontFamilyOption.mono.isMono)
         XCTAssertTrue(FontFamilyOption.systemMono.isMono)
-        XCTAssertEqual(FontFamilyOption.system.displayName, "ChatGPT (System)")
+        XCTAssertEqual(FontFamilyOption.system.displayName, "System UI")
     }
 
     func testFontPreferenceObserverAdvancesRevision() {


### PR DESCRIPTION
## Purpose
Make fresh Litter installs match the requested Local Studio visual language rather than silently starting with Kitty Litter.

## Changes
- use Studio Light and Studio Dark only when no stored theme selection exists
- preserve all existing user-selected theme slugs
- keep iOS and Android defaults identical
- rename the platform-default font option from `ChatGPT (System)` to the accurate `System UI`

## Verification
- `xcodebuild test -project apps/ios/Litter.xcodeproj -scheme Litter -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing:LitterTests/LitterAppearanceModeTests -quiet`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ANDROID_SDK_ROOT=/opt/homebrew/share/android-commandlinetools ANDROID_NDK_HOME=/opt/homebrew/share/android-commandlinetools/ndk/30.0.14904198 ./gradlew :app:testDebugUnitTest --tests com.litter.android.ui.LitterAppearanceModeTest`