### PR TITLE
docs: remove duplicate agent guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/shared/rust-bridge/codex-mobile-client/src/ssh/mod.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/ssh/mod.rs
@@ -103,7 +103,7 @@ pub(super) struct ForwardTask {
 }
 
 // Logging helpers — every event goes through `log_rust` so the bridge log
-// file mirror sees it (see CLAUDE.md / `crate::logging`).
+// file mirror sees it (see AGENTS.md / `crate::logging`).
 fn append_bridge_log(level: LogLevelName, line: &str) {
     log_rust(level, "ssh", "bridge", line.to_string(), None);
 }


### PR DESCRIPTION
## Purpose
Remove a byte-for-byte duplicate contributor/agent instruction file so there is one source of truth.

## Changes
- delete `CLAUDE.md`, which exactly duplicated `AGENTS.md`
- update its sole source-comment reference to `AGENTS.md`

## Verification
- confirmed `AGENTS.md` and `CLAUDE.md` had identical SHA-256 content before removal
- `cargo check -p codex-mobile-client`