### PR TITLE
Fix mobile tool rendering and move controls into composer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,15 @@ ANDROID_EMULATOR_ABIS ?= $(if $(filter arm64 aarch64,$(HOST_ARCH)),arm64-v8a,x86
 # This must precede cache setup and path auto-detection.
 -include .env
 
-LITTER_SHARED_CACHE_ROOT ?= $(HOME)/Library/Caches/litter-build
-LITTER_SHARED_RUST_TARGET ?= 0
+# All linked worktrees share the primary checkout's Cargo target. Cargo still
+# fingerprints each source revision, but registry/git dependencies are built
+# once instead of silently growing a multi-gigabyte target per worktree.
+GIT_COMMON_DIR := $(shell git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+LITTER_PRIMARY_WORKTREE_ROOT := $(if $(GIT_COMMON_DIR),$(abspath $(GIT_COMMON_DIR)/..),$(ROOT))
+LITTER_SHARED_CACHE_ROOT ?= $(LITTER_PRIMARY_WORKTREE_ROOT)/shared/rust-bridge
+LITTER_SHARED_RUST_TARGET ?= 1
 ifeq ($(LITTER_SHARED_RUST_TARGET),1)
-  export CARGO_TARGET_DIR ?= $(LITTER_SHARED_CACHE_ROOT)/cargo-target
+  export CARGO_TARGET_DIR ?= $(LITTER_SHARED_CACHE_ROOT)/target
 endif
 RUST_TARGET := $(if $(CARGO_TARGET_DIR),$(CARGO_TARGET_DIR),$(RUST_DIR)/target)
 

--- a/apps/android/app/src/main/java/com/litter/android/ui/LitterThemeManager.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/LitterThemeManager.kt
@@ -254,7 +254,7 @@ object LitterThemeManager {
     var appearanceMode by mutableStateOf(LitterAppearanceMode.SYSTEM)
         private set
 
-    var selectedFontFamily by mutableStateOf(LitterFontFamilyOption.BERKELEY_MONO)
+    var selectedFontFamily by mutableStateOf(LitterFontFamilyOption.CHATGPT)
         private set
 
     var lightTheme by mutableStateOf(LitterResolvedTheme.defaultLight)
@@ -279,10 +279,10 @@ object LitterThemeManager {
         get() = themeIndex.filter { it.type == LitterColorThemeType.DARK }
 
     val selectedLightSlug: String
-        get() = preferences?.getString(SELECTED_LIGHT_THEME_KEY, null) ?: "kitty-litter-light"
+        get() = preferences?.getString(SELECTED_LIGHT_THEME_KEY, null) ?: "codex-light"
 
     val selectedDarkSlug: String
-        get() = preferences?.getString(SELECTED_DARK_THEME_KEY, null) ?: "kitty-litter-dark"
+        get() = preferences?.getString(SELECTED_DARK_THEME_KEY, null) ?: "chatgpt-dark"
 
     private val preferences
         get() = appContext?.getSharedPreferences(UI_PREFERENCES_NAME, Context.MODE_PRIVATE)
@@ -367,15 +367,11 @@ object LitterThemeManager {
     }
 
     private fun loadFontFamily(): LitterFontFamilyOption {
-        val prefs = preferences ?: return LitterFontFamilyOption.BERKELEY_MONO
+        val prefs = preferences ?: return LitterFontFamilyOption.CHATGPT
         LitterFontFamilyOption.fromStorageValue(prefs.getString(FONT_FAMILY_KEY, null))?.let {
             return it
         }
-        return if (prefs.contains(FONT_MONO_KEY) && !prefs.getBoolean(FONT_MONO_KEY, true)) {
-            LitterFontFamilyOption.CHATGPT
-        } else {
-            LitterFontFamilyOption.BERKELEY_MONO
-        }
+        return LitterFontFamilyOption.CHATGPT
     }
 
     private fun usesDarkTheme(mode: LitterAppearanceMode = appearanceMode): Boolean =

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ComposerBar.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ComposerBar.kt
@@ -435,11 +435,25 @@ fun ComposerBar(
             val launchState = appModel.launchState.snapshot.value
             val pendingModel = launchState.selectedModel.trim().ifEmpty { null }
             val thread = appModel.snapshot.value?.threads?.find { it.key == threadKey }
+            val selectedModel = appModel.snapshot.value?.servers
+                ?.firstOrNull { it.serverId == threadKey.serverId }
+                ?.availableModels
+                ?.firstOrNull {
+                    it.matchesModelSelection(pendingModel.orEmpty(), launchState.selectedAgentRuntimeKind)
+                }
             val effort = if (thread?.ampReasoningEffortLocked == true) {
                 null
             } else {
-                launchState.reasoningEffort.trim().ifEmpty { null }
-                    ?.let(::reasoningEffortFromServerValue)
+                val pending = launchState.reasoningEffort.trim()
+                val requested = reasoningEffortFromServerValue(pending)
+                val supported = selectedModel?.supportedReasoningEfforts.orEmpty()
+                    .map { it.reasoningEffort }
+                when {
+                    pending.isEmpty() -> null
+                    selectedModel == null -> requested
+                    requested != null && supported.contains(requested) -> requested
+                    else -> selectedModel.defaultReasoningEffort
+                }
             }
             val tier = if (HeaderOverrides.pendingFastMode) ServiceTier.FAST else null
             val attachmentToSend = attachedImage

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ComposerBar.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ComposerBar.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -107,6 +108,8 @@ import com.litter.android.ui.BerkeleyMono
 import com.litter.android.ui.LitterTextStyle
 import com.litter.android.ui.LitterTheme
 import com.litter.android.ui.common.hasFixedFullAccess
+import com.litter.android.ui.common.matchesModelSelection
+import com.litter.android.ui.common.modelPickerDisplayName
 import com.litter.android.ui.scaled
 import java.io.ByteArrayOutputStream
 import kotlinx.coroutines.launch
@@ -469,6 +472,20 @@ fun ComposerBar(
         }
     }
     val canSend = text.isNotBlank() || attachedImage != null || attachedFiles.isNotEmpty()
+    val composerThread = appSnapshot?.threads?.firstOrNull { it.key == threadKey }
+    val composerServer = appSnapshot?.servers?.firstOrNull { it.serverId == threadKey.serverId }
+    val launchSelection by appModel.launchState.snapshot.collectAsState()
+    val composerModelSelection = launchSelection.selectedModel.trim().ifBlank {
+        (composerThread?.model ?: composerThread?.info?.model ?: "").trim()
+    }
+    val composerRuntime = launchSelection.selectedAgentRuntimeKind ?: composerThread?.agentRuntimeKind
+    val composerModelLabel = composerServer?.availableModels
+        ?.firstOrNull { it.matchesModelSelection(composerModelSelection, composerRuntime) }
+        ?.modelPickerDisplayName()
+        ?: composerModelSelection.ifBlank { "litter" }
+    val composerReasoningLabel = launchSelection.reasoningEffort.trim().ifBlank {
+        composerThread?.reasoningEffort?.trim().orEmpty()
+    }
 
     Column(
         modifier = Modifier
@@ -823,34 +840,18 @@ fun ComposerBar(
             )
         }
 
-        // Input row
-        Row(
+        // ChatGPT-style composer: writing surface first, then one compact row
+        // for attachments, model/mode selection, voice, and send/stop.
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 12.dp, vertical = 8.dp)
                 .background(LitterTheme.codeBackground, RoundedCornerShape(26.dp))
                 .padding(horizontal = 6.dp, vertical = 4.dp),
-            verticalAlignment = Alignment.CenterVertically,
         ) {
-            if (!isRecording && !isTranscribing && !isThinking) {
-                IconButton(
-                    onClick = { showAttachMenu = true },
-                    modifier = Modifier
-                        .size(40.dp)
-                        .background(LitterTheme.surface.copy(alpha = 0.78f), CircleShape),
-                ) {
-                    Icon(
-                        Icons.Default.Add,
-                        contentDescription = "Attach",
-                        tint = LitterTheme.textPrimary,
-                    )
-                }
-            }
-
-            // Text field
             Row(
                 modifier = Modifier
-                    .weight(1f)
+                    .fillMaxWidth()
                     .heightIn(min = 44.dp, max = 120.dp)
                     .padding(start = 8.dp, end = 2.dp, top = 8.dp, bottom = 8.dp),
                 verticalAlignment = Alignment.CenterVertically,
@@ -869,7 +870,7 @@ fun ComposerBar(
                         textStyle = TextStyle(
                             color = LitterTheme.textPrimary,
                             fontSize = LitterTextStyle.body.scaled,
-                            fontFamily = LitterTheme.monoFont,
+                            fontFamily = LitterTheme.bodyFont,
                         ),
                         cursorBrush = SolidColor(LitterTheme.accent),
                         // Always reserve trailing space for the expand icon so
@@ -950,116 +951,93 @@ fun ComposerBar(
                     }
                 }
 
-                when {
-                    isRecording -> {
-                        Spacer(Modifier.width(8.dp))
-                        IconButton(
-                            onClick = {
-                                scope.launch {
-                                    val auth = runCatching {
-                                        appModel.client.authStatus(
-                                            threadKey.serverId,
-                                            AuthStatusRequest(
-                                                includeToken = true,
-                                                refreshToken = false,
-                                            ),
-                                        )
-                                    }.getOrNull()
-                                    val transcript = transcriptionManager.stopAndTranscribe(
-                                        authMethod = auth?.authMethod,
-                                        authToken = auth?.authToken,
-                                    )
-                                    transcript?.let {
-                                        textFieldValue = insertComposerTranscript(textFieldValue, it)
-                                    }
-                                }
-                            },
-                            modifier = Modifier.size(32.dp),
-                        ) {
-                            Icon(
-                                Icons.Default.Stop,
-                                contentDescription = "Stop recording",
-                                tint = LitterTheme.accentStrong,
-                            )
-                        }
-                    }
+            }
 
-                    isTranscribing -> {
-                        Spacer(Modifier.width(8.dp))
-                        LinearProgressIndicator(
-                            modifier = Modifier.width(24.dp),
-                            color = LitterTheme.accent,
-                            trackColor = Color.Transparent,
-                        )
-                    }
-
-                    !canSend && !isThinking -> {
-                        val realtimeAvailable = remember {
-                            com.litter.android.ui.ExperimentalFeatures.isEnabled(
-                                com.litter.android.ui.LitterFeature.REALTIME_VOICE,
-                            )
-                        }
-                        val voiceController = remember { com.litter.android.state.VoiceRuntimeController.shared }
-                        val voiceSession by voiceController.activeVoiceSession.collectAsState()
-                        val voiceSnapshot by appModel.snapshot.collectAsState()
-                        val voicePhase = voiceSnapshot?.voiceSession?.phase
-                        val voiceInputLevel = voiceSession?.inputLevel ?: 0f
-
-                        if (realtimeAvailable && text.isEmpty() && attachedImage == null && attachedFiles.isEmpty()) {
-                            Spacer(Modifier.width(8.dp))
-                            com.litter.android.ui.voice.InlineVoiceButton(
-                                phase = voicePhase,
-                                inputLevel = voiceInputLevel,
-                                isAvailable = true,
-                                onStart = {
-                                    scope.launch {
-                                        voiceController.startVoiceOnThread(appModel, threadKey)
-                                    }
-                                },
-                                onStop = {
-                                    scope.launch {
-                                        voiceController.stopActiveVoiceSession(appModel)
-                                    }
-                                },
-                                modifier = Modifier.size(32.dp),
-                            )
-                        } else {
-                            Spacer(Modifier.width(8.dp))
-                            IconButton(
-                                onClick = {
-                                    if (transcriptionManager.hasMicPermission(context)) {
-                                        transcriptionManager.startRecording(context)
-                                    } else {
-                                        micPermissionLauncher.launch(android.Manifest.permission.RECORD_AUDIO)
-                                    }
-                                },
-                                modifier = Modifier.size(32.dp),
-                            ) {
-                                Icon(
-                                    Icons.Default.Mic,
-                                    contentDescription = "Voice",
-                                    tint = LitterTheme.textSecondary,
-                                )
-                            }
-                        }
-                    }
-                }
-                if (canSend) {
-                    Spacer(Modifier.width(6.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 6.dp, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (!isRecording && !isTranscribing && !isThinking) {
                     IconButton(
+                        onClick = { showAttachMenu = true },
+                        modifier = Modifier
+                            .size(40.dp)
+                            .background(LitterTheme.surface.copy(alpha = 0.78f), CircleShape),
+                    ) {
+                        Icon(Icons.Default.Add, contentDescription = "Attach", tint = LitterTheme.textPrimary)
+                    }
+                    Spacer(Modifier.width(6.dp))
+                }
+
+                Text(
+                    text = buildString {
+                        append(composerModelLabel)
+                        if (composerReasoningLabel.isNotBlank() && composerReasoningLabel != "default") {
+                            append("  ")
+                            append(composerReasoningLabel)
+                        }
+                        append("  ⌄")
+                    },
+                    color = LitterTheme.textPrimary,
+                    fontSize = LitterTextStyle.caption.scaled,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier
+                        .widthIn(max = 176.dp)
+                        .clickable { onToggleModelSelector?.invoke() }
+                        .background(LitterTheme.surface.copy(alpha = 0.78f), RoundedCornerShape(999.dp))
+                        .padding(horizontal = 10.dp, vertical = 8.dp),
+                )
+
+                if (showCollaborationModeChip) {
+                    Spacer(Modifier.width(6.dp))
+                    CollaborationModeChip(
+                        mode = collaborationMode,
+                        onClick = { onOpenCollaborationModePicker?.invoke() },
+                    )
+                }
+
+                Spacer(Modifier.weight(1f))
+                when {
+                    isRecording -> IconButton(
+                        onClick = {
+                            scope.launch {
+                                val auth = runCatching {
+                                    appModel.client.authStatus(
+                                        threadKey.serverId,
+                                        AuthStatusRequest(includeToken = true, refreshToken = false),
+                                    )
+                                }.getOrNull()
+                                val transcript = transcriptionManager.stopAndTranscribe(
+                                    authMethod = auth?.authMethod,
+                                    authToken = auth?.authToken,
+                                )
+                                transcript?.let {
+                                    textFieldValue = insertComposerTranscript(textFieldValue, it)
+                                }
+                            }
+                        },
+                        modifier = Modifier.size(40.dp),
+                    ) {
+                        Icon(Icons.Default.Stop, contentDescription = "Stop recording", tint = LitterTheme.accentStrong)
+                    }
+
+                    isTranscribing -> LinearProgressIndicator(
+                        modifier = Modifier.width(32.dp),
+                        color = LitterTheme.accent,
+                        trackColor = Color.Transparent,
+                    )
+
+                    canSend -> IconButton(
                         onClick = sendCurrent,
-                        enabled = !isRecording && !isTranscribing,
+                        enabled = !isTranscribing,
                         modifier = Modifier
                             .size(40.dp)
                             .clip(CircleShape)
-                            .background(
-                                if (!isRecording && !isTranscribing) {
-                                    LitterTheme.accent
-                                } else {
-                                    LitterTheme.accent.copy(alpha = 0.45f)
-                                },
-                                CircleShape,
-                            ),
+                            .background(LitterTheme.accent),
                     ) {
                         Icon(
                             Icons.AutoMirrored.Filled.Send,
@@ -1068,19 +1046,15 @@ fun ComposerBar(
                             modifier = Modifier.size(17.dp),
                         )
                     }
-                } else if (isThinking) {
-                    Spacer(Modifier.width(6.dp))
-                    IconButton(
+
+                    isThinking -> IconButton(
                         onClick = {
                             val turnId = activeTurnId ?: return@IconButton
                             scope.launch {
                                 runCatching {
                                     appModel.client.interruptTurn(
                                         threadKey.serverId,
-                                        AppInterruptTurnRequest(
-                                            threadId = threadKey.threadId,
-                                            turnId = turnId,
-                                        ),
+                                        AppInterruptTurnRequest(threadId = threadKey.threadId, turnId = turnId),
                                     )
                                 }
                             }
@@ -1095,6 +1069,47 @@ fun ComposerBar(
                             tint = LitterTheme.surface,
                             modifier = Modifier.size(15.dp),
                         )
+                    }
+
+                    else -> {
+                        val realtimeAvailable = remember {
+                            com.litter.android.ui.ExperimentalFeatures.isEnabled(
+                                com.litter.android.ui.LitterFeature.REALTIME_VOICE,
+                            )
+                        }
+                        val voiceController = remember { com.litter.android.state.VoiceRuntimeController.shared }
+                        val voiceSession by voiceController.activeVoiceSession.collectAsState()
+                        val voiceSnapshot by appModel.snapshot.collectAsState()
+                        val voicePhase = voiceSnapshot?.voiceSession?.phase
+                        val voiceInputLevel = voiceSession?.inputLevel ?: 0f
+
+                        if (realtimeAvailable && text.isEmpty() && attachedImage == null && attachedFiles.isEmpty()) {
+                            com.litter.android.ui.voice.InlineVoiceButton(
+                                phase = voicePhase,
+                                inputLevel = voiceInputLevel,
+                                isAvailable = true,
+                                onStart = {
+                                    scope.launch { voiceController.startVoiceOnThread(appModel, threadKey) }
+                                },
+                                onStop = {
+                                    scope.launch { voiceController.stopActiveVoiceSession(appModel) }
+                                },
+                                modifier = Modifier.size(40.dp),
+                            )
+                        } else {
+                            IconButton(
+                                onClick = {
+                                    if (transcriptionManager.hasMicPermission(context)) {
+                                        transcriptionManager.startRecording(context)
+                                    } else {
+                                        micPermissionLauncher.launch(android.Manifest.permission.RECORD_AUDIO)
+                                    }
+                                },
+                                modifier = Modifier.size(40.dp),
+                            ) {
+                                Icon(Icons.Default.Mic, contentDescription = "Voice", tint = LitterTheme.textSecondary)
+                            }
+                        }
                     }
                 }
             }

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ComposerBar.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ComposerBar.kt
@@ -451,6 +451,7 @@ fun ComposerBar(
                 when {
                     pending.isEmpty() -> null
                     selectedModel == null -> requested
+                    supported.isEmpty() -> null
                     requested != null && supported.contains(requested) -> requested
                     else -> selectedModel.defaultReasoningEffort
                 }

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ComposerExpandedDialog.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ComposerExpandedDialog.kt
@@ -130,7 +130,7 @@ fun ComposerExpandedDialog(
                         textStyle = TextStyle(
                             color = LitterTheme.textPrimary,
                             fontSize = LitterTextStyle.body.scaled,
-                            fontFamily = LitterTheme.monoFont,
+                            fontFamily = LitterTheme.bodyFont,
                         ),
                         cursorBrush = SolidColor(LitterTheme.accent),
                         modifier = Modifier

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationScreen.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/ConversationScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -398,33 +399,12 @@ fun ConversationScreen(
     val hasWallpaper = remember(threadKey, wallpaperVersion) {
         WallpaperManager.resolvedConfig(threadKey)?.type?.let { it != WallpaperType.NONE } == true
     }
-    val headerScrimColor = if (hasWallpaper) LitterTheme.surface.copy(alpha = 0.75f) else LitterTheme.surface
-
+    val composerScrimColor = if (hasWallpaper) LitterTheme.surface.copy(alpha = 0.75f) else LitterTheme.surface
     Box(modifier = Modifier.fillMaxSize()) {
         // Wallpaper fills the entire screen edge-to-edge (behind status + nav bars)
         ChatWallpaperBackground(threadKey = threadKey)
 
-        Column(
-            modifier = Modifier.fillMaxSize(),
-        ) {
-            // Header with status bar inset built-in — extends behind status bar with scrim
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(headerScrimColor),
-            ) {
-                Spacer(Modifier.statusBarsPadding())
-                HeaderBar(
-                    thread = thread,
-                    onBack = onBack,
-                    onInfo = onInfo,
-                    showModelSelector = showModelSelector,
-                    onToggleModelSelector = { showModelSelector = !showModelSelector },
-                    onReloadError = { reloadErrorMessage = it },
-                    transparentBackground = hasWallpaper,
-                )
-            }
-
+        Column(modifier = Modifier.fillMaxSize()) {
             // Message list with gradient fade and scroll FAB
             Box(modifier = Modifier.weight(1f)) {
                 if (thread == null) {
@@ -437,6 +417,7 @@ fun ConversationScreen(
 
                     LazyColumn(
                         state = listState,
+                        contentPadding = PaddingValues(top = 68.dp),
                         modifier = Modifier
                             .fillMaxSize()
                             .padding(horizontal = 16.dp)
@@ -455,8 +436,6 @@ fun ConversationScreen(
                                 } else Modifier.drawWithContent { drawContent() }
                             ),
                     ) {
-                        item { Spacer(Modifier.height(12.dp)) }
-
                         if (isWaitingForData || isInitialTurnsLoading) {
                             item {
                                 Box(
@@ -741,7 +720,7 @@ fun ConversationScreen(
                             .height(24.dp)
                             .background(
                                 Brush.verticalGradient(
-                                    colors = listOf(Color.Transparent, headerScrimColor),
+                                    colors = listOf(Color.Transparent, composerScrimColor),
                                 ),
                             ),
                     )
@@ -751,7 +730,7 @@ fun ConversationScreen(
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .background(headerScrimColor),
+                        .background(composerScrimColor),
                 ) {
                     // Pinned context strip
                     if (pinnedContext != null) {
@@ -854,6 +833,19 @@ fun ConversationScreen(
             }
         }
 
+        // Only the navigation controls float over the transcript; the full-width
+        // title/model bar is gone so messages can scroll through the freed space.
+        Column(modifier = Modifier.align(Alignment.TopCenter)) {
+            Spacer(Modifier.statusBarsPadding())
+            HeaderBar(
+                thread = thread,
+                onBack = onBack,
+                onInfo = onInfo,
+                onReloadError = { reloadErrorMessage = it },
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+            )
+        }
+
         // Thinking-indicator minigame overlay: bottom 40% of the screen.
         // Slides up from the bottom when appearing and slides back out on
         // dismiss, mirroring iOS ConversationView.swift:148
@@ -895,6 +887,34 @@ fun ConversationScreen(
                 ComposerPermissionsSheet(
                     threadKey = threadKey,
                     onDismiss = { showPermissionsSheet = false },
+                )
+            }
+        }
+
+        if (showModelSelector) {
+            ModalBottomSheet(
+                onDismissRequest = { showModelSelector = false },
+                sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+                containerColor = LitterTheme.background,
+            ) {
+                com.litter.android.ui.common.ModelSelectorPanel(
+                    thread = thread,
+                    availableModels = server?.availableModels ?: emptyList(),
+                    catalogLoaded = server?.availableModels != null,
+                    catalogError = server?.serverId?.let(appModel::modelCatalogError),
+                    onRetryModels = {
+                        scope.launch {
+                            appModel.loadAvailableModelsIfNeeded(threadKey.serverId, force = true)
+                        }
+                    },
+                    onToggleMode = { mode ->
+                        scope.launch {
+                            runCatching { appModel.store.setThreadCollaborationMode(threadKey, mode) }
+                        }
+                    },
+                    fastMode = HeaderOverrides.pendingFastMode,
+                    onFastModeChange = { HeaderOverrides.pendingFastMode = it },
+                    showBackground = false,
                 )
             }
         }

--- a/apps/android/app/src/main/java/com/litter/android/ui/conversation/HeaderBar.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/conversation/HeaderBar.kt
@@ -2,48 +2,21 @@ package com.litter.android.ui.conversation
 
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.Lock
-import androidx.compose.material.icons.filled.LockOpen
-import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.Switch
-import androidx.compose.material3.SwitchDefaults
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -52,340 +25,116 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import com.litter.android.state.accentColor
-import com.litter.android.state.displayModelLabel
-import com.litter.android.state.resolvedModel
-import com.litter.android.state.statusColor
-import com.litter.android.ui.LitterTextStyle
-import com.litter.android.ui.LocalAppModel
 import com.litter.android.ui.LitterTheme
-import com.litter.android.ui.common.modelPickerDisplayName
-import com.litter.android.ui.common.matchesModelSelection
-import com.litter.android.ui.common.reportsEffectiveThreadPermissions
-import com.litter.android.ui.scaled
+import com.litter.android.ui.LocalAppModel
 import kotlinx.coroutines.launch
-import uniffi.codex_mobile_client.AppModeKind
-import uniffi.codex_mobile_client.AppServerHealth
 import uniffi.codex_mobile_client.AppThreadSnapshot
-import uniffi.codex_mobile_client.ThreadKey
 
-/**
- * Top bar showing model, reasoning, status dot, cwd.
- * Inline model selector expands on tap.
- */
+/** Floating conversation navigation; model and mode controls live in the composer. */
 @Composable
 fun HeaderBar(
     thread: AppThreadSnapshot?,
     onBack: () -> Unit,
     onInfo: (() -> Unit)? = null,
-    showModelSelector: Boolean,
-    onToggleModelSelector: () -> Unit,
     onReloadError: ((String) -> Unit)? = null,
-    transparentBackground: Boolean = false,
+    modifier: Modifier = Modifier,
 ) {
     val appModel = LocalAppModel.current
     val context = LocalContext.current
     val snapshot by appModel.snapshot.collectAsState()
-    val launchState by appModel.launchState.snapshot.collectAsState()
     val scope = rememberCoroutineScope()
     val server = remember(snapshot, thread) {
-        thread?.let { t -> snapshot?.servers?.find { it.serverId == t.key.serverId } }
+        thread?.let { current -> snapshot?.servers?.find { it.serverId == current.key.serverId } }
     }
-    val pendingModelId = launchState.selectedModel.trim()
-    val pendingRuntime = launchState.selectedAgentRuntimeKind
-    val pendingModelLabel = server?.availableModels
-        ?.firstOrNull { it.matchesModelSelection(pendingModelId, pendingRuntime) }
-        ?.modelPickerDisplayName()
-        ?.ifBlank { pendingModelId }
-        ?: pendingModelId.ifBlank { null }
-    val currentModelId = pendingModelId.ifBlank {
-        (thread?.model ?: thread?.info?.model ?: "").trim()
-    }
-    val currentRuntime = pendingRuntime ?: thread?.agentRuntimeKind
-    val selectedModelDefinition = remember(server?.availableModels, currentModelId, currentRuntime) {
-        server?.availableModels?.firstOrNull { it.matchesModelSelection(currentModelId, currentRuntime) }
-            ?: server?.availableModels?.firstOrNull { it.isDefault }
-            ?: server?.availableModels?.firstOrNull()
-    }
-    val reasoningLabel = remember(launchState.reasoningEffort, thread?.reasoningEffort, selectedModelDefinition) {
-        val pendingReasoning = launchState.reasoningEffort.trim()
-        if (pendingReasoning.isNotEmpty()) {
-            pendingReasoning
-        } else {
-            val threadReasoning = thread?.reasoningEffort?.trim().orEmpty()
-            if (threadReasoning.isNotEmpty()) {
-                threadReasoning
-            } else if (selectedModelDefinition?.supportedReasoningEfforts?.isEmpty() == true) {
-                ""
-            } else {
-                selectedModelDefinition?.defaultReasoningEffort?.let(::effortLabelLocal) ?: "default"
-            }
-        }
-    }
-    val modelLabel = remember(pendingModelLabel, thread?.displayModelLabel) {
-        (pendingModelLabel ?: thread?.displayModelLabel).orEmpty().ifBlank { "litter" }
-    }
+    var isReloading by remember { mutableStateOf(false) }
 
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .then(if (!transparentBackground) Modifier.background(LitterTheme.surface) else Modifier),
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 8.dp, vertical = 6.dp),
+        FloatingHeaderButton(onClick = onBack) {
+            Icon(
+                Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = "Back",
+                tint = LitterTheme.textPrimary,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+
+        Spacer(Modifier.weight(1f))
+
+        FloatingHeaderButton(
+            enabled = !isReloading && thread != null,
+            onClick = {
+                val currentThread = thread ?: return@FloatingHeaderButton
+                scope.launch {
+                    isReloading = true
+                    try {
+                        if (server?.requiresOpenaiAuth == true && server.account == null) {
+                            val authUrl = appModel.client.startRemoteSshOauthLogin(currentThread.key.serverId)
+                            CustomTabsIntent.Builder().setShowTitle(true).build()
+                                .launchUrl(context, Uri.parse(authUrl))
+                        } else {
+                            val nextKey = appModel.refreshThreadIncludingTurns(currentThread.key)
+                            appModel.store.setActiveThread(nextKey)
+                        }
+                    } catch (error: Exception) {
+                        onReloadError?.invoke(error.message ?: "Failed to reload conversation")
+                    } finally {
+                        isReloading = false
+                    }
+                }
+            },
         ) {
-            IconButton(onClick = onBack, modifier = Modifier.size(32.dp)) {
+            if (isReloading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(18.dp),
+                    strokeWidth = 2.dp,
+                    color = LitterTheme.accent,
+                )
+            } else {
                 Icon(
-                    Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = "Back",
-                    tint = LitterTheme.textPrimary,
-                    modifier = Modifier.size(20.dp),
+                    Icons.Default.Refresh,
+                    contentDescription = "Reload",
+                    tint = LitterTheme.textSecondary,
+                    modifier = Modifier.size(18.dp),
                 )
             }
-
-            // Status dot
-            val health = server?.health ?: AppServerHealth.UNKNOWN
-            val statusColor = server?.statusColor ?: health.accentColor
-            val shouldPulse = health == AppServerHealth.CONNECTING || health == AppServerHealth.UNRESPONSIVE
-            val dotAlpha = if (shouldPulse) {
-                val infiniteTransition = rememberInfiniteTransition(label = "statusDotPulse")
-                infiniteTransition.animateFloat(
-                    initialValue = 0.3f,
-                    targetValue = 1.0f,
-                    animationSpec = infiniteRepeatable(
-                        animation = tween(durationMillis = 1000),
-                        repeatMode = RepeatMode.Reverse,
-                    ),
-                    label = "statusDotAlpha",
-                ).value
-            } else {
-                1.0f
-            }
-            Box(
-                modifier = Modifier
-                    .size(8.dp)
-                    .clip(CircleShape)
-                    .background(statusColor.copy(alpha = dotAlpha)),
-            )
-            Spacer(Modifier.width(8.dp))
-
-            // Model + reasoning label (tappable)
-            Column(
-                modifier = Modifier
-                    .weight(1f)
-                    .clickable { onToggleModelSelector() },
-            ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text(
-                        text = modelLabel,
-                        color = LitterTheme.textPrimary,
-                        fontSize = LitterTextStyle.footnote.scaled,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                    if (HeaderOverrides.pendingFastMode) {
-                        Spacer(Modifier.width(4.dp))
-                        Text(
-                            text = "\u26A1",
-                            color = LitterTheme.warning,
-                            fontSize = LitterTextStyle.caption2.scaled,
-                        )
-                    }
-                    if (reasoningLabel.isNotBlank()) {
-                        Spacer(Modifier.width(6.dp))
-                        Text(
-                            text = reasoningLabel,
-                            color = LitterTheme.textSecondary,
-                            fontSize = LitterTextStyle.caption.scaled,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    }
-                    Spacer(Modifier.width(2.dp))
-                    Icon(
-                        Icons.Default.KeyboardArrowDown,
-                        contentDescription = "Open model selector",
-                        tint = LitterTheme.textSecondary,
-                        modifier = Modifier.size(14.dp),
-                    )
-                }
-                val cwd = thread?.info?.cwd
-                if (cwd != null) {
-                    val abbreviated = cwd.replace(Regex("^/home/[^/]+"), "~")
-                        .replace(Regex("^/Users/[^/]+"), "~")
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text(
-                            text = abbreviated,
-                            color = LitterTheme.textMuted,
-                            fontSize = 10f.scaled,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier.weight(1f, fill = false),
-                        )
-                        if (thread?.collaborationMode == AppModeKind.PLAN) {
-                            Spacer(Modifier.width(6.dp))
-                            Text(
-                                text = "plan",
-                                color = Color.Black,
-                                fontSize = 10f.scaled,
-                                fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
-                                modifier = Modifier
-                                    .background(
-                                        LitterTheme.accent,
-                                        RoundedCornerShape(999.dp),
-                                    )
-                                    .padding(horizontal = 6.dp, vertical = 2.dp),
-                            )
-                        }
-                        // Permission-preset chip: show a danger-tinted `lock.open`
-                        // when this thread is running at full-access (approval =
-                        // never + sandbox = danger-full-access). Mirrors iOS
-                        // HeaderView.swift:74-78 `headerPermissionPreset == .fullAccess`.
-                        val permissionPreset = thread
-                            ?.takeIf { it.agentRuntimeKind.reportsEffectiveThreadPermissions }
-                            ?.let { t ->
-                                val approval = appModel.launchState.approvalPolicyValue(t.key)
-                                    ?: t.effectiveApprovalPolicy
-                                val sandbox = appModel.launchState.turnSandboxPolicy(t.key)
-                                    ?: t.effectiveSandboxPolicy
-                                uniffi.codex_mobile_client.threadPermissionPreset(approval, sandbox)
-                            }
-                        if (permissionPreset ==
-                            uniffi.codex_mobile_client.AppThreadPermissionPreset.FULL_ACCESS) {
-                            Spacer(Modifier.width(6.dp))
-                            Icon(
-                                imageVector = Icons.Default.LockOpen,
-                                contentDescription = "Full access permissions",
-                                tint = LitterTheme.danger,
-                                modifier = Modifier.size(10.dp),
-                            )
-                        }
-                    }
-                }
-            }
-
-            // Reload button
-            var isReloading by remember { mutableStateOf(false) }
-            IconButton(
-                onClick = {
-                    if (thread == null || isReloading) return@IconButton
-                    scope.launch {
-                        isReloading = true
-                        try {
-                            if (server?.requiresOpenaiAuth == true && server.account == null) {
-                                val authUrl = appModel.client.startRemoteSshOauthLogin(
-                                    thread.key.serverId,
-                                )
-                                CustomTabsIntent.Builder()
-                                    .setShowTitle(true)
-                                    .build()
-                                    .launchUrl(context, Uri.parse(authUrl))
-                                return@launch
-                            }
-                            val nextKey = appModel.refreshThreadIncludingTurns(thread.key)
-                            appModel.store.setActiveThread(nextKey)
-                        } catch (e: Exception) {
-                            onReloadError?.invoke(e.message ?: "Failed to reload conversation")
-                        } finally {
-                            isReloading = false
-                        }
-                    }
-                },
-                enabled = !isReloading,
-                modifier = Modifier.size(32.dp),
-            ) {
-                if (isReloading) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(18.dp),
-                        strokeWidth = 2.dp,
-                        color = LitterTheme.accent,
-                    )
-                } else {
-                    Icon(
-                        Icons.Default.Refresh,
-                        contentDescription = "Reload",
-                        tint = LitterTheme.textSecondary,
-                        modifier = Modifier.size(18.dp),
-                    )
-                }
-            }
-
-            // Info button
-            if (onInfo != null) {
-                IconButton(
-                    onClick = onInfo,
-                    modifier = Modifier.size(32.dp),
-                ) {
-                    Icon(
-                        Icons.Outlined.Info,
-                        contentDescription = "Info",
-                        tint = LitterTheme.textSecondary,
-                        modifier = Modifier.size(18.dp),
-                    )
-                }
-            }
         }
 
-        // Inline model selector — shared panel lives in
-        // `com.litter.android.ui.common.ModelSelectorPanel`; the home
-        // composer's HomeModelChip uses the same panel inside a
-        // ModalBottomSheet.
-        AnimatedVisibility(
-            visible = showModelSelector,
-            enter = expandVertically(),
-            exit = shrinkVertically(),
-        ) {
-            com.litter.android.ui.common.ModelSelectorPanel(
-                thread = thread,
-                availableModels = server?.availableModels ?: emptyList(),
-                catalogLoaded = server?.availableModels != null,
-                catalogError = server?.serverId?.let(appModel::modelCatalogError),
-                onRetryModels = {
-                    server?.serverId?.let { serverId ->
-                        scope.launch { appModel.loadAvailableModelsIfNeeded(serverId, force = true) }
-                    }
-                },
-                onToggleMode = { mode ->
-                    thread?.let { t ->
-                        scope.launch {
-                            try {
-                                appModel.store.setThreadCollaborationMode(t.key, mode)
-                            } catch (_: Exception) {}
-                        }
-                    }
-                },
-                fastMode = HeaderOverrides.pendingFastMode,
-                onFastModeChange = { HeaderOverrides.pendingFastMode = it },
-                showBackground = false,
-            )
+        if (onInfo != null) {
+            FloatingHeaderButton(onClick = onInfo) {
+                Icon(
+                    Icons.Outlined.Info,
+                    contentDescription = "Info",
+                    tint = LitterTheme.textSecondary,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
         }
     }
 }
 
-/**
- * Holds the fast-mode override selected in the header.
- * Launch model/effort state lives in [AppLaunchState].
- */
+@Composable
+private fun FloatingHeaderButton(
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+    content: @Composable () -> Unit,
+) {
+    IconButton(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = Modifier
+            .size(40.dp)
+            .clip(CircleShape)
+            .background(LitterTheme.surface.copy(alpha = 0.86f)),
+        content = content,
+    )
+}
+
+/** Shared fast-tier override selected from the model options sheet. */
 object HeaderOverrides {
     var pendingFastMode by mutableStateOf(false)
 }
-
-private fun effortLabelLocal(value: uniffi.codex_mobile_client.ReasoningEffort): String =
-    when (value) {
-        uniffi.codex_mobile_client.ReasoningEffort.NONE -> "none"
-        uniffi.codex_mobile_client.ReasoningEffort.MINIMAL -> "minimal"
-        uniffi.codex_mobile_client.ReasoningEffort.LOW -> "low"
-        uniffi.codex_mobile_client.ReasoningEffort.MEDIUM -> "medium"
-        uniffi.codex_mobile_client.ReasoningEffort.HIGH -> "high"
-        uniffi.codex_mobile_client.ReasoningEffort.X_HIGH -> "xhigh"
-        uniffi.codex_mobile_client.ReasoningEffort.MAX -> "max"
-        uniffi.codex_mobile_client.ReasoningEffort.ULTRA -> "ultra"
-    }

--- a/apps/android/app/src/main/java/com/litter/android/ui/home/HomeComposerBar.kt
+++ b/apps/android/app/src/main/java/com/litter/android/ui/home/HomeComposerBar.kt
@@ -385,7 +385,7 @@ fun HomeComposerBar(
                         textStyle = TextStyle(
                             color = LitterTheme.textPrimary,
                             fontSize = LitterTextStyle.body.scaled,
-                            fontFamily = LitterTheme.monoFont,
+                            fontFamily = LitterTheme.bodyFont,
                         ),
                         cursorBrush = SolidColor(LitterTheme.accent),
                         modifier = Modifier

--- a/apps/ios/Sources/Litter/LitterApp.swift
+++ b/apps/ios/Sources/Litter/LitterApp.swift
@@ -1881,6 +1881,7 @@ private struct HomeNavigationView: View {
 }
 
 private struct ConversationDestinationScreen: View {
+    @Environment(\.dismiss) private var dismiss
     @Environment(AppModel.self) private var appModel
     @Environment(AppState.self) private var appState
     @AppStorage("workDir") private var workDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?.path ?? "/"
@@ -1936,7 +1937,7 @@ private struct ConversationDestinationScreen: View {
                     composer: screenModel.composer,
                     composerInputText: $bindableScreenModel.composerInputText,
                     composerAttachedImage: $bindableScreenModel.composerAttachedImage,
-                    topInset: 0,
+                    topInset: 12,
                     bottomInset: bottomInset,
                     onOpenConversation: onOpenConversation,
                     onResumeSessions: onResumeSessions,
@@ -1980,30 +1981,37 @@ private struct ConversationDestinationScreen: View {
                 .background(LitterTheme.backgroundGradient.ignoresSafeArea())
             }
         }
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(LitterTheme.surface, for: .navigationBar)
-        .toolbarBackground(.visible, for: .navigationBar)
-        .toolbar {
-            if let conversationThread {
-                ToolbarItem(placement: .principal) {
-                    HeaderView(thread: conversationThread)
-                }
-                ToolbarItem(placement: .topBarTrailing) {
-                    ConversationToolbarControls(
-                        thread: conversationThread,
-                        control: .reload
-                    )
-                }
-                if onInfo != nil {
-                    ToolbarItem(placement: .topBarTrailing) {
-                        ConversationToolbarControls(
-                            thread: conversationThread,
-                            control: .info,
-                            onInfo: onInfo
-                        )
+        .navigationBarBackButtonHidden(true)
+        .toolbar(.hidden, for: .navigationBar)
+        .overlay(alignment: .top) {
+            GlassMorphContainer(spacing: 8) {
+                HStack(spacing: 8) {
+                    Button { dismiss() } label: {
+                        Image(systemName: "chevron.left")
+                            .font(LitterFont.styled(size: 17, weight: .semibold))
+                            .foregroundColor(LitterTheme.textPrimary)
+                            .frame(width: 40, height: 40)
+                    }
+                    .buttonStyle(.plain)
+                    .modifier(GlassCircleModifier())
+                    .accessibilityLabel("Back")
+
+                    Spacer(minLength: 0)
+
+                    if let conversationThread {
+                        ConversationToolbarControls(thread: conversationThread, control: .reload)
+                        if onInfo != nil {
+                            ConversationToolbarControls(
+                                thread: conversationThread,
+                                control: .info,
+                                onInfo: onInfo
+                            )
+                        }
                     }
                 }
             }
+            .padding(.horizontal, 12)
+            .padding(.top, 6)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .ignoresSafeArea(.container, edges: .bottom)

--- a/apps/ios/Sources/Litter/Models/ThemeManager.swift
+++ b/apps/ios/Sources/Litter/Models/ThemeManager.swift
@@ -77,12 +77,12 @@ final class ThemeManager {
     private var systemColorScheme: ColorScheme = .dark
 
     var selectedLightSlug: String {
-        get { UserDefaults.standard.string(forKey: "selectedLightTheme") ?? "kitty-litter-light" }
+        get { UserDefaults.standard.string(forKey: "selectedLightTheme") ?? "codex-light" }
         set { UserDefaults.standard.set(newValue, forKey: "selectedLightTheme") }
     }
 
     var selectedDarkSlug: String {
-        get { UserDefaults.standard.string(forKey: "selectedDarkTheme") ?? "kitty-litter-dark" }
+        get { UserDefaults.standard.string(forKey: "selectedDarkTheme") ?? "chatgpt-dark" }
         set { UserDefaults.standard.set(newValue, forKey: "selectedDarkTheme") }
     }
 

--- a/apps/ios/Sources/Litter/Views/ConversationComposerContentView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationComposerContentView.swift
@@ -18,6 +18,8 @@ struct ConversationComposerContentView: View {
     let contextPercent: Int64?
     let isTurnActive: Bool
     let showModeChip: Bool
+    let modelLabel: String?
+    let reasoningLabel: String?
     let voiceManager: VoiceTranscriptionManager
     let allowsVoiceInput: Bool
     @Binding var showAttachMenu: Bool
@@ -32,6 +34,7 @@ struct ConversationComposerContentView: View {
     let onRemovePluginMention: (PluginMentionSelection) -> Void
     let onPasteImage: (UIImage) -> Void
     let onOpenModePicker: () -> Void
+    let onOpenModelPicker: () -> Void
     let onSendText: () -> Void
     let onStopRecording: () -> Void
     let onStartRecording: () -> Void
@@ -56,6 +59,8 @@ struct ConversationComposerContentView: View {
         contextPercent: Int64?,
         isTurnActive: Bool,
         showModeChip: Bool = true,
+        modelLabel: String? = nil,
+        reasoningLabel: String? = nil,
         voiceManager: VoiceTranscriptionManager,
         allowsVoiceInput: Bool = true,
         showAttachMenu: Binding<Bool>,
@@ -70,6 +75,7 @@ struct ConversationComposerContentView: View {
         onRemovePluginMention: @escaping (PluginMentionSelection) -> Void = { _ in },
         onPasteImage: @escaping (UIImage) -> Void,
         onOpenModePicker: @escaping () -> Void,
+        onOpenModelPicker: @escaping () -> Void = {},
         onSendText: @escaping () -> Void,
         onStopRecording: @escaping () -> Void,
         onStartRecording: @escaping () -> Void,
@@ -93,6 +99,8 @@ struct ConversationComposerContentView: View {
         self.contextPercent = contextPercent
         self.isTurnActive = isTurnActive
         self.showModeChip = showModeChip
+        self.modelLabel = modelLabel
+        self.reasoningLabel = reasoningLabel
         self.voiceManager = voiceManager
         self.allowsVoiceInput = allowsVoiceInput
         _showAttachMenu = showAttachMenu
@@ -107,6 +115,7 @@ struct ConversationComposerContentView: View {
         self.onRemovePluginMention = onRemovePluginMention
         self.onPasteImage = onPasteImage
         self.onOpenModePicker = onOpenModePicker
+        self.onOpenModelPicker = onOpenModelPicker
         self.onSendText = onSendText
         self.onStopRecording = onStopRecording
         self.onStartRecording = onStartRecording
@@ -218,7 +227,13 @@ struct ConversationComposerContentView: View {
                     isTurnActive: isTurnActive,
                     hasAttachment: attachedImage != nil || !attachedFiles.isEmpty,
                     allowsVoiceInput: allowsVoiceInput,
+                    modelLabel: modelLabel,
+                    reasoningLabel: reasoningLabel,
+                    collaborationMode: collaborationMode,
+                    showModeChip: showModeChip,
                     onPasteImage: onPasteImage,
+                    onOpenModelPicker: onOpenModelPicker,
+                    onOpenModePicker: onOpenModePicker,
                     onSendText: onSendText,
                     onStopRecording: onStopRecording,
                     onStartRecording: onStartRecording,

--- a/apps/ios/Sources/Litter/Views/ConversationComposerEntryRowView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationComposerEntryRowView.swift
@@ -10,7 +10,13 @@ struct ConversationComposerEntryRowView: View {
     let isTurnActive: Bool
     let hasAttachment: Bool
     let allowsVoiceInput: Bool
+    let modelLabel: String?
+    let reasoningLabel: String?
+    let collaborationMode: AppModeKind
+    let showModeChip: Bool
     let onPasteImage: (UIImage) -> Void
+    let onOpenModelPicker: () -> Void
+    let onOpenModePicker: () -> Void
     let onSendText: () -> Void
     let onStopRecording: () -> Void
     let onStartRecording: () -> Void
@@ -33,7 +39,13 @@ struct ConversationComposerEntryRowView: View {
         isTurnActive: Bool,
         hasAttachment: Bool,
         allowsVoiceInput: Bool = true,
+        modelLabel: String? = nil,
+        reasoningLabel: String? = nil,
+        collaborationMode: AppModeKind = .`default`,
+        showModeChip: Bool = false,
         onPasteImage: @escaping (UIImage) -> Void,
+        onOpenModelPicker: @escaping () -> Void = {},
+        onOpenModePicker: @escaping () -> Void = {},
         onSendText: @escaping () -> Void,
         onStopRecording: @escaping () -> Void,
         onStartRecording: @escaping () -> Void,
@@ -47,7 +59,13 @@ struct ConversationComposerEntryRowView: View {
         self.isTurnActive = isTurnActive
         self.hasAttachment = hasAttachment
         self.allowsVoiceInput = allowsVoiceInput
+        self.modelLabel = modelLabel
+        self.reasoningLabel = reasoningLabel
+        self.collaborationMode = collaborationMode
+        self.showModeChip = showModeChip
         self.onPasteImage = onPasteImage
+        self.onOpenModelPicker = onOpenModelPicker
+        self.onOpenModePicker = onOpenModePicker
         self.onSendText = onSendText
         self.onStopRecording = onStopRecording
         self.onStartRecording = onStartRecording
@@ -73,131 +91,10 @@ struct ConversationComposerEntryRowView: View {
     }
 
     var body: some View {
-        HStack(alignment: .center, spacing: 4) {
-            if !voiceManager.isRecording && !voiceManager.isTranscribing && !isTurnActive {
-                Button {
-                    showAttachMenu = true
-                } label: {
-                    Image(systemName: "plus")
-                        .font(LitterFont.styled(size: 20, weight: .semibold))
-                        .foregroundColor(LitterTheme.textPrimary)
-                        .frame(width: Metrics.controlSize, height: Metrics.controlSize)
-                        .background(
-                            Circle()
-                                .fill(LitterTheme.surfaceLight.opacity(0.72))
-                        )
-                }
-                .buttonStyle(.plain)
-                .hoverEffect(.highlight)
-                .transition(.scale.combined(with: .opacity))
-                .accessibilityLabel("Attach")
-            }
-
-            ZStack(alignment: .topLeading) {
-                ConversationComposerTextView(
-                    text: $inputText,
-                    isFocused: $isComposerFocused,
-                    selectedRange: $composerSelectionRange,
-                    onPasteImage: onPasteImage,
-                    onHardwareSubmit: {
-                        if canSend { onSendText() }
-                    },
-                    horizontalInset: 5,
-                    verticalInset: 12
-                )
-
-                if inputText.isEmpty {
-                    Text("Message litter...")
-                        .font(LitterFont.styled(size: 17))
-                        .foregroundColor(LitterTheme.textMuted)
-                        .padding(.leading, 5)
-                        .padding(.top, 12)
-                        .allowsHitTesting(false)
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .overlay(alignment: .topTrailing) {
-                if shouldShowExpand {
-                    Button {
-                        showExpanded = true
-                    } label: {
-                        Image(systemName: "arrow.up.left.and.arrow.down.right")
-                            .font(LitterFont.styled(size: 12, weight: .semibold))
-                            .foregroundColor(LitterTheme.textSecondary)
-                            .padding(6)
-                            .contentShape(Rectangle())
-                    }
-                    .hoverEffect(.highlight)
-                    .padding(.top, 2)
-                    .padding(.trailing, 6)
-                    .accessibilityLabel("Expand composer")
-                    .transition(.opacity.combined(with: .scale))
-                }
-            }
-            .animation(.easeInOut(duration: 0.15), value: shouldShowExpand)
-
-            if voiceManager.isRecording {
-                AudioWaveformView(level: voiceManager.audioLevel)
-                    .frame(width: 42, height: 20)
-
-                Button(action: onStopRecording) {
-                    Image(systemName: "stop.fill")
-                        .font(LitterFont.styled(size: 13, weight: .bold))
-                        .foregroundColor(.black)
-                        .frame(width: Metrics.trailingControlSize, height: Metrics.trailingControlSize)
-                        .background(Circle().fill(LitterTheme.accentStrong))
-                        .contentShape(Circle())
-                }
-                .buttonStyle(.plain)
-                .hoverEffect(.highlight)
-                .accessibilityLabel("Stop recording")
-            } else if voiceManager.isTranscribing {
-                ProgressView()
-                    .tint(LitterTheme.accent)
-                    .frame(width: Metrics.trailingControlSize, height: Metrics.trailingControlSize)
-            } else if canSend {
-                Button(action: onSendText) {
-                    Image(systemName: "arrow.up")
-                        .font(LitterFont.styled(size: 17, weight: .bold))
-                        .foregroundColor(.black)
-                        .frame(width: Metrics.trailingControlSize, height: Metrics.trailingControlSize)
-                        .background(Circle().fill(LitterTheme.accent))
-                        .contentShape(Circle())
-                }
-                .buttonStyle(.plain)
-                .hoverEffect(.highlight)
-                .disabled(voiceManager.isRecording || voiceManager.isTranscribing)
-                .opacity(voiceManager.isRecording || voiceManager.isTranscribing ? 0.45 : 1)
-                .accessibilityLabel("Send")
-                .transition(.move(edge: .trailing).combined(with: .opacity))
-            } else if isTurnActive {
-                Button(action: onInterrupt) {
-                    Image(systemName: "stop.fill")
-                        .font(LitterFont.styled(size: 12, weight: .bold))
-                        .foregroundColor(LitterTheme.surface)
-                        .frame(width: Metrics.trailingControlSize, height: Metrics.trailingControlSize)
-                        .background(Circle().fill(LitterTheme.textPrimary))
-                        .contentShape(Circle())
-                }
-                .buttonStyle(.plain)
-                .hoverEffect(.highlight)
-                .accessibilityLabel("Cancel response")
-                .transition(.move(edge: .trailing).combined(with: .opacity))
-            } else if allowsVoiceInput {
-                Button(action: onStartRecording) {
-                    Image(systemName: "mic.fill")
-                        .font(LitterFont.styled(size: 18))
-                        .foregroundColor(LitterTheme.textSecondary)
-                        .frame(width: Metrics.trailingControlSize, height: Metrics.trailingControlSize)
-                        .contentShape(Circle())
-                }
-                .buttonStyle(.plain)
-                .hoverEffect(.highlight)
-                .accessibilityLabel("Dictate")
-            }
+        VStack(spacing: 0) {
+            textEditor
+            actionRow
         }
-        .padding(.horizontal, 6)
-        .frame(maxWidth: .infinity, minHeight: 52)
         .modifier(GlassRoundedRectModifier(cornerRadius: Metrics.inputCornerRadius))
         .frame(maxWidth: .infinity, alignment: .leading)
         .animation(.spring(response: 0.3, dampingFraction: 0.86), value: isTurnActive)
@@ -214,5 +111,144 @@ struct ConversationComposerEntryRowView: View {
                 hasAttachment: hasAttachment
             )
         }
+    }
+
+    private var textEditor: some View {
+        ZStack(alignment: .topLeading) {
+            ConversationComposerTextView(
+                text: $inputText,
+                isFocused: $isComposerFocused,
+                selectedRange: $composerSelectionRange,
+                onPasteImage: onPasteImage,
+                onHardwareSubmit: {
+                    if canSend { onSendText() }
+                },
+                horizontalInset: 10,
+                verticalInset: 10
+            )
+
+            if inputText.isEmpty {
+                Text("Message litter...")
+                    .font(LitterFont.styled(size: 17))
+                    .foregroundColor(LitterTheme.textMuted)
+                    .padding(.leading, 10)
+                    .padding(.top, 10)
+                    .allowsHitTesting(false)
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 48, alignment: .leading)
+        .overlay(alignment: .topTrailing) {
+            if shouldShowExpand {
+                Button {
+                    showExpanded = true
+                } label: {
+                    Image(systemName: "arrow.up.left.and.arrow.down.right")
+                        .font(LitterFont.styled(size: 12, weight: .semibold))
+                        .foregroundColor(LitterTheme.textSecondary)
+                        .padding(8)
+                }
+                .buttonStyle(.plain)
+                .hoverEffect(.highlight)
+                .accessibilityLabel("Expand composer")
+                .transition(.opacity.combined(with: .scale))
+            }
+        }
+        .animation(.easeInOut(duration: 0.15), value: shouldShowExpand)
+    }
+
+    private var actionRow: some View {
+        HStack(spacing: 6) {
+            if !voiceManager.isRecording && !voiceManager.isTranscribing && !isTurnActive {
+                composerCircleButton(systemName: "plus", label: "Attach") {
+                    showAttachMenu = true
+                }
+            }
+
+            if let modelLabel {
+                Button(action: onOpenModelPicker) {
+                    HStack(spacing: 4) {
+                        Text(modelLabel)
+                            .lineLimit(1)
+                        if let reasoningLabel, reasoningLabel != "default" {
+                            Text(reasoningLabel)
+                                .foregroundColor(LitterTheme.textSecondary)
+                                .lineLimit(1)
+                        }
+                        Image(systemName: "chevron.down")
+                            .font(LitterFont.styled(size: 9, weight: .bold))
+                    }
+                    .font(LitterFont.styled(size: 12, weight: .semibold))
+                    .foregroundColor(LitterTheme.textPrimary)
+                    .padding(.horizontal, 9)
+                    .frame(height: 34)
+                    .background(Capsule().fill(LitterTheme.surfaceLight.opacity(0.72)))
+                }
+                .buttonStyle(.plain)
+                .hoverEffect(.highlight)
+                .accessibilityIdentifier("conversation.modelPickerButton")
+                .accessibilityLabel("Choose model")
+                .layoutPriority(1)
+            }
+
+            if showModeChip {
+                ConversationComposerModeChip(mode: collaborationMode, onTap: onOpenModePicker)
+            }
+
+            Spacer(minLength: 0)
+
+            if voiceManager.isRecording {
+                AudioWaveformView(level: voiceManager.audioLevel)
+                    .frame(width: 42, height: 20)
+            }
+            trailingControl
+        }
+        .padding(.horizontal, 6)
+        .padding(.bottom, 6)
+        .frame(maxWidth: .infinity, minHeight: 42)
+    }
+
+    @ViewBuilder
+    private var trailingControl: some View {
+        if voiceManager.isRecording {
+            composerCircleButton(systemName: "stop.fill", label: "Stop recording", tint: .black, fill: LitterTheme.accentStrong) {
+                onStopRecording()
+            }
+        } else if voiceManager.isTranscribing {
+            ProgressView()
+                .tint(LitterTheme.accent)
+                .frame(width: Metrics.trailingControlSize, height: Metrics.trailingControlSize)
+        } else if canSend {
+            composerCircleButton(systemName: "arrow.up", label: "Send", tint: .black, fill: LitterTheme.accent) {
+                onSendText()
+            }
+        } else if isTurnActive {
+            composerCircleButton(systemName: "stop.fill", label: "Cancel response", tint: LitterTheme.surface, fill: LitterTheme.textPrimary) {
+                onInterrupt()
+            }
+        } else if allowsVoiceInput {
+            composerCircleButton(systemName: "mic.fill", label: "Dictate") {
+                onStartRecording()
+            }
+        }
+    }
+
+    private func composerCircleButton(
+        systemName: String,
+        label: String,
+        tint: Color = LitterTheme.textPrimary,
+        fill: Color = LitterTheme.surfaceLight.opacity(0.72),
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(LitterFont.styled(size: systemName == "plus" ? 20 : 16, weight: .semibold))
+                .foregroundColor(tint)
+                .frame(width: Metrics.controlSize, height: Metrics.controlSize)
+                .background(Circle().fill(fill))
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .hoverEffect(.highlight)
+        .accessibilityLabel(label)
     }
 }

--- a/apps/ios/Sources/Litter/Views/ConversationDisplayUITestHarnessView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationDisplayUITestHarnessView.swift
@@ -12,6 +12,8 @@ struct ConversationDisplayUITestHarnessView: View {
     @State private var composerText = ""
     @State private var composerFocused = false
     @State private var composerSelection = NSRange(location: 0, length: 0)
+    @State private var showAttachMenu = false
+    @State private var voiceManager = VoiceTranscriptionManager()
 
     static var isEnabled: Bool {
         ProcessInfo.processInfo.arguments.contains("--ui-test-conversation-display")
@@ -30,15 +32,24 @@ struct ConversationDisplayUITestHarnessView: View {
                         .foregroundColor(LitterTheme.textPrimary)
                         .accessibilityIdentifier("conversationDisplayHarness.title")
 
-                    ConversationComposerTextView(
-                        text: $composerText,
-                        isFocused: $composerFocused,
-                        selectedRange: $composerSelection,
-                        onPasteImage: { _ in }
+                    ConversationComposerEntryRowView(
+                        showAttachMenu: $showAttachMenu,
+                        inputText: $composerText,
+                        isComposerFocused: $composerFocused,
+                        composerSelectionRange: $composerSelection,
+                        voiceManager: voiceManager,
+                        isTurnActive: false,
+                        hasAttachment: false,
+                        modelLabel: "GPT-5",
+                        reasoningLabel: "high",
+                        collaborationMode: .default,
+                        showModeChip: true,
+                        onPasteImage: { _ in },
+                        onSendText: {},
+                        onStopRecording: {},
+                        onStartRecording: {},
+                        onInterrupt: {}
                     )
-                    .frame(height: 52)
-                    .background(LitterTheme.surface)
-                    .clipShape(RoundedRectangle(cornerRadius: 14))
 
                     ConversationTurnTimeline(
                         items: Self.seedItems,

--- a/apps/ios/Sources/Litter/Views/ConversationTimelineView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationTimelineView.swift
@@ -447,7 +447,10 @@ private struct ConversationTimelineItemRow: View, Equatable {
                     ComputerUseToolCallView(
                         data: data,
                         view: view,
-                        externalExpanded: toolDefaultExpanded(isFailed: data.status == .failed)
+                        externalExpanded: toolDefaultExpanded(
+                            isFailed: data.status == .failed,
+                            isInProgress: data.status == .inProgress
+                        )
                     )
                 )
             } else {
@@ -479,7 +482,10 @@ private struct ConversationTimelineItemRow: View, Equatable {
             return AnyView(
                 ImageGenerationToolCallView(
                     data: data,
-                    externalExpanded: toolDefaultExpanded(isFailed: data.status == .failed)
+                    externalExpanded: toolDefaultExpanded(
+                        isFailed: data.status == .failed,
+                        isInProgress: data.status == .inProgress
+                    )
                 )
             )
         case .widget(let data):
@@ -529,12 +535,15 @@ private struct ConversationTimelineItemRow: View, Equatable {
         ToolCallCardView(
             model: model,
             serverId: serverId,
-            externalExpanded: toolDefaultExpanded(isFailed: model.status == .failed)
+            externalExpanded: toolDefaultExpanded(
+                isFailed: model.status == .failed,
+                isInProgress: model.status == .inProgress
+            )
         )
     }
 
-    private func toolDefaultExpanded(isFailed: Bool) -> Bool {
-        toolDisplayMode.defaultExpanded(isFailed: isFailed)
+    private func toolDefaultExpanded(isFailed: Bool, isInProgress: Bool) -> Bool {
+        toolDisplayMode.defaultExpanded(isFailed: isFailed, isInProgress: isInProgress)
     }
 
     private func commandDefaultExpanded(_ data: ConversationCommandExecutionData) -> Bool {

--- a/apps/ios/Sources/Litter/Views/ConversationView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationView.swift
@@ -95,7 +95,7 @@ struct ConversationView: View {
 
     private var pendingSelectedModel: ModelInfo? {
         guard let model = pendingModelOverride else { return nil }
-        return snapshot.availableModels.first {
+        return composer.availableModels.first {
             modelMatchesSelection($0, model, runtime: pendingAgentRuntimeKindOverride)
         }
     }

--- a/apps/ios/Sources/Litter/Views/ConversationView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationView.swift
@@ -88,6 +88,7 @@ struct ConversationView: View {
         let supported = selectedModel.supportedReasoningEfforts.map {
             $0.reasoningEffort.wireValue
         }
+        guard !supported.isEmpty else { return nil }
         return supported.contains(trimmed)
             ? trimmed
             : selectedModel.defaultReasoningEffort.wireValue

--- a/apps/ios/Sources/Litter/Views/ConversationView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationView.swift
@@ -83,7 +83,21 @@ struct ConversationView: View {
             return nil
         }
         let trimmed = appState.reasoningEffort.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
+        guard !trimmed.isEmpty else { return nil }
+        guard let selectedModel = pendingSelectedModel else { return trimmed }
+        let supported = selectedModel.supportedReasoningEfforts.map {
+            $0.reasoningEffort.wireValue
+        }
+        return supported.contains(trimmed)
+            ? trimmed
+            : selectedModel.defaultReasoningEffort.wireValue
+    }
+
+    private var pendingSelectedModel: ModelInfo? {
+        guard let model = pendingModelOverride else { return nil }
+        return snapshot.availableModels.first {
+            modelMatchesSelection($0, model, runtime: pendingAgentRuntimeKindOverride)
+        }
     }
 
     private var supportsTurnPagination: Bool {

--- a/apps/ios/Sources/Litter/Views/ConversationView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationView.swift
@@ -1584,6 +1584,8 @@ private struct ConversationInputBar: View {
                 contextPercent: contextPercent(),
                 isTurnActive: isTurnActive,
                 showModeChip: showModeChip,
+                modelLabel: composerModelLabel,
+                reasoningLabel: composerReasoningLabel,
                 voiceManager: voiceManager,
                 showAttachMenu: $showAttachMenu,
                 onClearAttachment: clearAttachment,
@@ -1597,6 +1599,7 @@ private struct ConversationInputBar: View {
                 onRemovePluginMention: removePluginMention,
                 onPasteImage: { image in attachedImage = image },
                 onOpenModePicker: onOpenModePicker,
+                onOpenModelPicker: { showModelSelector = true },
                 onSendText: handleSend,
                 onStopRecording: stopVoiceRecording,
                 onStartRecording: startVoiceRecording,
@@ -1641,6 +1644,28 @@ private struct ConversationInputBar: View {
         let remainingTokens = max(0, effectiveWindow - usedTokens)
         let percent = Int64((Double(remainingTokens) / Double(effectiveWindow) * 100).rounded())
         return min(max(percent, 0), 100)
+    }
+
+    private var composerModelLabel: String {
+        let pending = appState.selectedModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        let selection = pending.isEmpty ? snapshot.threadModel : pending
+        let runtime = pending.isEmpty
+            ? appModel.threadSnapshot(for: snapshot.threadKey)?.agentRuntimeKind
+            : appState.selectedAgentRuntimeKind
+        if let model = snapshot.availableModels.first(where: {
+            modelMatchesSelection($0, selection, runtime: runtime)
+        }) {
+            return modelPickerDisplayName(model)
+        }
+        let trimmed = selection.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "litter" : trimmed
+    }
+
+    private var composerReasoningLabel: String? {
+        let pending = appState.reasoningEffort.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !pending.isEmpty { return pending }
+        let threadValue = snapshot.threadReasoningEffort?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return threadValue.isEmpty ? nil : threadValue
     }
 
     private func clearAttachment() {

--- a/apps/ios/Sources/Litter/Views/HeaderView.swift
+++ b/apps/ios/Sources/Litter/Views/HeaderView.swift
@@ -407,9 +407,10 @@ struct ConversationToolbarControls: View {
                 infoButton
             }
         }
-        .frame(width: 28, height: 28)
-        .contentShape(Rectangle())
+        .frame(width: 40, height: 40)
+        .contentShape(Circle())
         .buttonStyle(.plain)
+        .modifier(GlassCircleModifier())
         .hoverEffect(.highlight)
         .sheet(item: $remoteAuthSession) { session in
             InAppSafariView(url: session.url)

--- a/apps/ios/Sources/Litter/Views/ToolCallModels.swift
+++ b/apps/ios/Sources/Litter/Views/ToolCallModels.swift
@@ -29,12 +29,12 @@ enum ConversationDetailDisplayMode: String, CaseIterable, Identifiable, Equatabl
         ConversationDetailDisplayMode(rawValue: rawValue) ?? .collapsed
     }
 
-    func defaultExpanded(isFailed: Bool = false) -> Bool {
+    func defaultExpanded(isFailed: Bool = false, isInProgress: Bool = false) -> Bool {
         switch self {
         case .expanded:
             return true
         case .collapsed:
-            return isFailed
+            return isFailed || isInProgress
         case .hidden:
             return false
         }

--- a/apps/ios/Tests/LitterTests/ConversationDisplayPreferenceTests.swift
+++ b/apps/ios/Tests/LitterTests/ConversationDisplayPreferenceTests.swift
@@ -15,6 +15,17 @@ final class ConversationDisplayPreferenceTests: XCTestCase {
         XCTAssertFalse(ConversationDetailDisplayMode.hidden.defaultExpanded(isFailed: true))
     }
 
+    func testCollapsedModeExpandsInProgressToolCalls() {
+        XCTAssertTrue(ConversationDetailDisplayMode.collapsed.defaultExpanded(isInProgress: true))
+        XCTAssertFalse(
+            ConversationDetailDisplayMode.collapsed.defaultExpanded(
+                isFailed: false,
+                isInProgress: false
+            )
+        )
+        XCTAssertFalse(ConversationDetailDisplayMode.hidden.defaultExpanded(isInProgress: true))
+    }
+
     func testConversationItemsHonorHiddenDetailModes() {
         let reasoning = ConversationItem(
             id: "reasoning",

--- a/apps/ios/Tests/LitterUITests/LitterUITests.swift
+++ b/apps/ios/Tests/LitterUITests/LitterUITests.swift
@@ -35,11 +35,15 @@ final class LitterUITests: XCTestCase {
         let app = conversationDisplayHarnessApp()
         app.launch()
 
+        XCTAssertTrue(app.buttons["conversation.modelPickerButton"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.buttons["Attach"].exists)
+        XCTAssertTrue(app.buttons["Default"].exists)
         let composer = app.textViews["conversation.composerTextView"]
-        XCTAssertTrue(composer.waitForExistence(timeout: 10))
+        XCTAssertTrue(composer.exists)
         composer.tap()
         composer.typeText("SIMULATOR_INPUT_OK")
         XCTAssertEqual(composer.value as? String, "SIMULATOR_INPUT_OK")
+        XCTAssertTrue(app.buttons["Send"].waitForExistence(timeout: 2))
     }
 
     @MainActor

--- a/apps/ios/Tests/LitterUITests/LitterUITests.swift
+++ b/apps/ios/Tests/LitterUITests/LitterUITests.swift
@@ -47,6 +47,19 @@ final class LitterUITests: XCTestCase {
     }
 
     @MainActor
+    func testConversationLaunchPerformance() throws {
+        let app = conversationDisplayHarnessApp()
+        measure(metrics: [XCTApplicationLaunchMetric()]) {
+            app.launch()
+            XCTAssertTrue(
+                app.staticTexts["Conversation Display Test"].waitForExistence(timeout: 5),
+                "Conversation surface did not become interactive after launch"
+            )
+            app.terminate()
+        }
+    }
+
+    @MainActor
     func testConversationDisplayCollapsedModeKeepsCompletedDetailsCollapsed() throws {
         let app = conversationDisplayHarnessApp(reasoning: "collapsed", commands: "collapsed", tools: "collapsed")
         app.launch()

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.95.0"
+components = ["clippy", "rustfmt"]
+profile = "minimal"

--- a/shared/rust-bridge/codex-mobile-client/src/mobile_client/mod.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/mobile_client/mod.rs
@@ -1302,47 +1302,6 @@ impl MobileClient {
         .map_err(RpcClientError::Rpc)
     }
 
-    #[allow(dead_code)]
-    pub(crate) async fn server_thread_list(
-        &self,
-        server_id: &str,
-        params: upstream::ThreadListParams,
-    ) -> Result<upstream::ThreadListResponse, crate::RpcClientError> {
-        use crate::{RpcClientError, next_request_id};
-        let runtime_kinds = self
-            .get_session(server_id)
-            .map_err(|error| RpcClientError::Rpc(error.to_string()))?
-            .runtime_kinds();
-        let mut merged = upstream::ThreadListResponse {
-            data: Vec::new(),
-            next_cursor: None,
-            backwards_cursor: None,
-        };
-
-        for runtime_kind in runtime_kinds {
-            let response: upstream::ThreadListResponse = self
-                .request_typed_for_server_runtime(
-                    server_id,
-                    runtime_kind,
-                    upstream::ClientRequest::ThreadList {
-                        request_id: upstream::RequestId::Integer(next_request_id()),
-                        params: params.clone(),
-                    },
-                )
-                .await
-                .map_err(RpcClientError::Rpc)?;
-            merged.data.extend(response.data);
-            if merged.next_cursor.is_none() {
-                merged.next_cursor = response.next_cursor;
-            }
-            if merged.backwards_cursor.is_none() {
-                merged.backwards_cursor = response.backwards_cursor;
-            }
-        }
-
-        Ok(merged)
-    }
-
     pub(crate) async fn server_collaboration_mode_list(
         &self,
         server_id: &str,
@@ -2563,50 +2522,6 @@ impl MobileClient {
         info!("MobileClient: restarting app server {server_id}");
         session.restart_app_server_and_disconnect().await;
         Ok(())
-    }
-
-    /// Return the configs of all currently connected servers.
-    #[cfg(test)]
-    #[allow(dead_code)]
-    pub(crate) fn connected_servers(&self) -> Vec<ServerConfig> {
-        self.sessions_read()
-            .values()
-            .map(|s| s.config().clone())
-            .collect()
-    }
-
-    // ── Threads ───────────────────────────────────────────────────────
-
-    /// List threads from a specific server.
-    #[cfg(test)]
-    #[allow(dead_code)]
-    pub(crate) async fn list_threads(&self, server_id: &str) -> Result<Vec<ThreadInfo>, RpcError> {
-        self.get_session(server_id)?;
-        let response = self
-            .server_thread_list(
-                server_id,
-                upstream::ThreadListParams {
-                    limit: None,
-                    cursor: None,
-                    sort_key: None,
-                    sort_direction: None,
-                    model_providers: None,
-                    source_kinds: None,
-                    archived: None,
-                    cwd: None,
-                    search_term: None,
-                    use_state_db_only: false,
-                },
-            )
-            .await
-            .map_err(map_rpc_client_error)?;
-        let threads = response
-            .data
-            .into_iter()
-            .filter_map(thread_info_from_upstream_thread)
-            .collect::<Vec<_>>();
-        self.app_store.sync_thread_list(server_id, &threads);
-        Ok(threads)
     }
 
     pub async fn sync_server_account(&self, server_id: &str) -> Result<(), RpcError> {

--- a/shared/rust-bridge/codex-mobile-client/src/mobile_client/store_listener.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/mobile_client/store_listener.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 const SUBAGENT_METADATA_HYDRATE_DELAYS_MS: [u64; 3] = [150, 800, 2500];
+const IDLE_THREAD_RECONCILE_DELAYS_MS: [u64; 3] = [100, 500, 1_500];
 
 pub(super) fn spawn_store_listener(
     app_store: Arc<AppStoreReducer>,
@@ -12,6 +13,11 @@ pub(super) fn spawn_store_listener(
             match rx.recv().await {
                 Ok(event) => {
                     app_store.apply_ui_event(&event);
+                    maybe_reconcile_idle_thread(
+                        Arc::clone(&app_store),
+                        Arc::clone(&sessions),
+                        &event,
+                    );
                     maybe_hydrate_collab_agent_metadata(
                         Arc::clone(&app_store),
                         Arc::clone(&sessions),
@@ -33,6 +39,96 @@ pub(super) fn spawn_store_listener(
             }
         }
     });
+}
+
+fn maybe_reconcile_idle_thread(
+    app_store: Arc<AppStoreReducer>,
+    sessions: Arc<RwLock<HashMap<String, Arc<ServerSession>>>>,
+    event: &UiEvent,
+) {
+    let Some(key) = idle_thread_key(event).cloned() else {
+        return;
+    };
+
+    MobileClient::spawn_detached(async move {
+        for delay_ms in IDLE_THREAD_RECONCILE_DELAYS_MS {
+            // Some app-server transports publish idle just before their
+            // durable turn record becomes readable. Keep this repair off the
+            // event loop and retry only while that record is empty/active.
+            tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
+
+            let session = match sessions.read() {
+                Ok(guard) => guard.get(&key.server_id).cloned(),
+                Err(error) => {
+                    warn!("MobileClient: recovering poisoned sessions read lock");
+                    error.into_inner().get(&key.server_id).cloned()
+                }
+            };
+            let Some(session) = session else {
+                return;
+            };
+            if !session_is_current(&sessions, &key.server_id, &session) {
+                return;
+            }
+
+            let runtime_kind = app_store
+                .snapshot()
+                .threads
+                .get(&key)
+                .map(|thread| thread.agent_runtime_kind.clone())
+                .unwrap_or_else(|| "codex".to_string());
+            match read_thread_response_from_app_server_runtime(
+                Arc::clone(&session),
+                runtime_kind,
+                &key.thread_id,
+                true,
+            )
+            .await
+            {
+                Ok(response) => {
+                    if !session_is_current(&sessions, &key.server_id, &session) {
+                        return;
+                    }
+                    let durable_turn_is_complete =
+                        !response.thread.turns.is_empty()
+                            && response.thread.turns.iter().all(|turn| {
+                                !matches!(turn.status, upstream::TurnStatus::InProgress)
+                            });
+                    if let Err(error) = upsert_thread_snapshot_from_app_server_read_response(
+                        &app_store,
+                        &key.server_id,
+                        response,
+                    ) {
+                        warn!(
+                            "MobileClient: failed to reconcile idle thread for server={} thread={}: {}",
+                            key.server_id, key.thread_id, error
+                        );
+                        continue;
+                    }
+                    if durable_turn_is_complete {
+                        return;
+                    }
+                }
+                Err(error) => {
+                    warn!(
+                        "MobileClient: failed to refresh idle thread for server={} thread={}: {}",
+                        key.server_id, key.thread_id, error
+                    );
+                }
+            }
+        }
+    });
+}
+
+fn idle_thread_key(event: &UiEvent) -> Option<&ThreadKey> {
+    match event {
+        UiEvent::ThreadStatusChanged { key, notification }
+            if matches!(notification.status, upstream::ThreadStatus::Idle) =>
+        {
+            Some(key)
+        }
+        _ => None,
+    }
 }
 
 fn maybe_hydrate_collab_agent_metadata(
@@ -233,6 +329,39 @@ pub(super) async fn maybe_send_next_local_queued_follow_up(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn only_idle_status_changes_request_authoritative_reconciliation() {
+        let key = ThreadKey {
+            server_id: "srv".to_string(),
+            thread_id: "thread".to_string(),
+        };
+        let idle = UiEvent::ThreadStatusChanged {
+            key: key.clone(),
+            notification: upstream::ThreadStatusChangedNotification {
+                thread_id: key.thread_id.clone(),
+                status: upstream::ThreadStatus::Idle,
+            },
+        };
+        let active = UiEvent::ThreadStatusChanged {
+            key,
+            notification: upstream::ThreadStatusChangedNotification {
+                thread_id: "thread".to_string(),
+                status: upstream::ThreadStatus::Active {
+                    active_flags: Vec::new(),
+                },
+            },
+        };
+
+        assert_eq!(
+            idle_thread_key(&idle),
+            Some(&ThreadKey {
+                server_id: "srv".to_string(),
+                thread_id: "thread".to_string(),
+            })
+        );
+        assert_eq!(idle_thread_key(&active), None);
+    }
 
     #[test]
     fn collab_receiver_thread_ids_extracts_spawn_agent_targets() {

--- a/shared/rust-bridge/codex-mobile-client/src/mobile_client/thread_projection.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/mobile_client/thread_projection.rs
@@ -555,6 +555,24 @@ pub(super) async fn read_thread_response_from_app_server(
     })
 }
 
+pub(super) async fn read_thread_response_from_app_server_runtime(
+    session: Arc<ServerSession>,
+    runtime_kind: AgentRuntimeKind,
+    thread_id: &str,
+    include_turns: bool,
+) -> Result<upstream::ThreadReadResponse, RpcError> {
+    let response = session
+        .request_for_runtime(
+            runtime_kind,
+            "thread/read",
+            serde_json::json!({ "threadId": thread_id, "includeTurns": include_turns }),
+        )
+        .await?;
+    serde_json::from_value::<upstream::ThreadReadResponse>(response).map_err(|error| {
+        RpcError::Deserialization(format!("deserialize thread/read response: {error}"))
+    })
+}
+
 pub(super) fn upsert_thread_snapshot_from_app_server_read_response(
     app_store: &AppStoreReducer,
     server_id: &str,

--- a/shared/rust-bridge/codex-mobile-client/src/store/reducer.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/store/reducer.rs
@@ -652,6 +652,7 @@ impl AppStoreReducer {
                 thread.is_resumed = thread.is_resumed || existing.is_resumed;
                 preserve_local_overlay_items(existing, &mut thread);
                 preserve_queued_follow_ups(existing, &mut thread);
+                preserve_live_tool_items(existing, &mut thread);
                 // Preserve existing items when the incoming snapshot has none
                 // (e.g. thread/read with include_turns=false).
                 if thread.items.is_empty() && !existing.items.is_empty() {
@@ -3403,6 +3404,74 @@ fn preserve_local_overlay_items(source: &ThreadSnapshot, target: &mut ThreadSnap
     }
 }
 
+fn preserve_live_tool_items(source: &ThreadSnapshot, target: &mut ThreadSnapshot) {
+    let incoming_ids: HashSet<&str> = target.items.iter().map(|item| item.id.as_str()).collect();
+    let missing = source
+        .items
+        .iter()
+        .enumerate()
+        .filter(|item| {
+            item.1.source_turn_id.is_none()
+                && is_tool_item(&item.1.content)
+                && !incoming_ids.contains(item.1.id.as_str())
+        })
+        .map(|(index, item)| (index, item.clone()))
+        .collect::<Vec<_>>();
+    for (source_index, item) in missing {
+        let next_anchor = source.items[source_index + 1..]
+            .iter()
+            .find_map(replay_anchor_key);
+        let insertion_index = next_anchor
+            .as_ref()
+            .and_then(|anchor| {
+                target
+                    .items
+                    .iter()
+                    .position(|candidate| replay_anchor_key(candidate).as_ref() == Some(anchor))
+            })
+            .or_else(|| {
+                target.items.iter().rposition(|candidate| {
+                    matches!(
+                        candidate.content,
+                        HydratedConversationItemContent::Assistant(ref data)
+                            if data.phase == Some(crate::types::AppMessagePhase::FinalAnswer)
+                    )
+                })
+            })
+            .unwrap_or(target.items.len());
+        target.items.insert(insertion_index, item);
+    }
+}
+
+fn replay_anchor_key(item: &HydratedConversationItem) -> Option<String> {
+    match &item.content {
+        HydratedConversationItemContent::User(data) => Some(format!(
+            "user:{}:{}",
+            data.text,
+            serde_json::to_string(&data.image_data_uris).unwrap_or_default()
+        )),
+        HydratedConversationItemContent::Assistant(data) => {
+            Some(format!("assistant:{}:{:?}", data.text, data.phase))
+        }
+        _ => None,
+    }
+}
+
+fn is_tool_item(content: &HydratedConversationItemContent) -> bool {
+    matches!(
+        content,
+        HydratedConversationItemContent::CommandExecution(_)
+            | HydratedConversationItemContent::FileChange(_)
+            | HydratedConversationItemContent::McpToolCall(_)
+            | HydratedConversationItemContent::DynamicToolCall(_)
+            | HydratedConversationItemContent::MultiAgentAction(_)
+            | HydratedConversationItemContent::WebSearch(_)
+            | HydratedConversationItemContent::ImageView(_)
+            | HydratedConversationItemContent::Widget(_)
+            | HydratedConversationItemContent::ImageGeneration(_)
+    )
+}
+
 fn duplicate_local_overlay_item_ids(thread: &ThreadSnapshot) -> Vec<String> {
     let active_turn_id = thread.active_turn_id.as_deref();
     thread
@@ -5188,6 +5257,67 @@ mod tests {
             thread.info.preview.as_deref(),
             Some("First user message"),
             "existing preview should be preserved when incoming is None"
+        );
+    }
+
+    #[test]
+    fn upsert_thread_snapshot_preserves_live_tool_omitted_from_replay() {
+        let reducer = AppStoreReducer::new();
+        let key = ThreadKey {
+            server_id: "srv".to_string(),
+            thread_id: "thread".to_string(),
+        };
+        let item = |id: &str, content: HydratedConversationItemContent| {
+            HydratedConversationItem {
+                id: id.to_string(),
+                content,
+                source_turn_id: None,
+                source_turn_index: None,
+                timestamp: None,
+                is_from_user_turn_boundary: false,
+            }
+        };
+        let mut live = ThreadSnapshot::from_info("srv", make_thread_info("thread"));
+        live.items.push(item(
+            "tool",
+            HydratedConversationItemContent::CommandExecution(HydratedCommandExecutionData {
+                command: "create image".to_string(),
+                cwd: "/tmp".to_string(),
+                status: AppOperationStatus::Completed,
+                output: Some("done".to_string()),
+                exit_code: Some(0),
+                duration_ms: Some(1),
+                process_id: None,
+                actions: Vec::new(),
+            }),
+        ));
+        reducer.upsert_thread_snapshot(live);
+
+        let mut replay = ThreadSnapshot::from_info("srv", make_thread_info("thread"));
+        replay.items.push(item(
+            "final",
+            HydratedConversationItemContent::Assistant(HydratedAssistantMessageData {
+                text: "![image](/tmp/image.png)".to_string(),
+                agent_nickname: None,
+                agent_role: None,
+                phase: Some(crate::types::AppMessagePhase::FinalAnswer),
+            }),
+        ));
+        reducer.upsert_thread_snapshot(replay);
+
+        let thread = reducer
+            .snapshot()
+            .threads
+            .get(&key)
+            .cloned()
+            .expect("thread exists");
+        assert_eq!(
+            thread
+                .items
+                .iter()
+                .map(|item| item.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["tool", "final"]
         );
     }
 

--- a/shared/rust-bridge/codex-slingshot/src/json_line_wire.rs
+++ b/shared/rust-bridge/codex-slingshot/src/json_line_wire.rs
@@ -14,6 +14,47 @@ use codex_app_server_client::{JsonRpcWire, RemoteAppServerClient, RemoteAppServe
 use codex_app_server_protocol::JSONRPCMessage;
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
 
+/// Non-Codex bridges can intentionally trail the upstream app-server schema.
+/// v0.129 made lifecycle timestamps mandatory; older Pi/Local Studio bridges
+/// still emit otherwise-valid item notifications without them. Normalize at
+/// the raw JSONL boundary, before `RemoteAppServerClient` strict-decodes and
+/// silently drops the entire notification (including tool calls/results).
+fn normalize_legacy_item_lifecycle_notification(value: &mut serde_json::Value) {
+    let Some(message) = value.as_object_mut() else {
+        return;
+    };
+    let timestamp_field = match message.get("method").and_then(serde_json::Value::as_str) {
+        Some("item/started") => "startedAtMs",
+        Some("item/completed") => "completedAtMs",
+        _ => return,
+    };
+    let Some(params) = message
+        .get_mut("params")
+        .and_then(serde_json::Value::as_object_mut)
+    else {
+        return;
+    };
+    params
+        .entry(timestamp_field.to_string())
+        .or_insert_with(|| serde_json::Value::Number(0.into()));
+
+    if let Some(item) = params
+        .get_mut("item")
+        .and_then(serde_json::Value::as_object_mut)
+        && item.get("type").and_then(serde_json::Value::as_str) == Some("commandExecution")
+        && item
+            .get("cwd")
+            .and_then(serde_json::Value::as_str)
+            .is_none_or(str::is_empty)
+    {
+        // AbsolutePathBuf rejects the empty cwd emitted by older Pi bridges.
+        item.insert(
+            "cwd".to_string(),
+            serde_json::Value::String("/".to_string()),
+        );
+    }
+}
+
 struct JsonLineWire<R, W> {
     reader: BufReader<R>,
     writer: W,
@@ -24,11 +65,7 @@ where
     R: AsyncRead + Unpin + Send + 'static,
     W: AsyncWrite + Unpin + Send + 'static,
 {
-    async fn send_message(
-        &mut self,
-        message: JSONRPCMessage,
-        label: &str,
-    ) -> IoResult<()> {
+    async fn send_message(&mut self, message: JSONRPCMessage, label: &str) -> IoResult<()> {
         let payload = serde_json::to_vec(&message).map_err(IoError::other)?;
         self.writer.write_all(&payload).await.map_err(|err| {
             IoError::other(format!(
@@ -57,7 +94,13 @@ where
         if read == 0 {
             return Ok(None);
         }
-        serde_json::from_str::<JSONRPCMessage>(&line)
+        let mut value = serde_json::from_str::<serde_json::Value>(&line).map_err(|err| {
+            IoError::other(format!(
+                "remote app server at `{label}` sent invalid JSON-RPC: {err}"
+            ))
+        })?;
+        normalize_legacy_item_lifecycle_notification(&mut value);
+        serde_json::from_value::<JSONRPCMessage>(value)
             .map(Some)
             .map_err(|err| {
                 IoError::other(format!(
@@ -72,6 +115,89 @@ where
                 "failed to close JSON-lines app server `{label}`: {err}"
             ))
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_legacy_item_lifecycle_notification;
+    use codex_app_server_protocol::{JSONRPCMessage, ServerNotification};
+    use serde_json::json;
+
+    #[test]
+    fn legacy_item_lifecycle_notifications_survive_strict_upstream_decode() {
+        for (method, timestamp_field) in [
+            ("item/started", "startedAtMs"),
+            ("item/completed", "completedAtMs"),
+        ] {
+            let mut value = json!({
+                "jsonrpc": "2.0",
+                "method": method,
+                "params": {
+                    "threadId": "thread-1",
+                    "turnId": "turn-1",
+                    "item": {
+                        "type": "userMessage",
+                        "id": "user-1",
+                        "content": []
+                    }
+                }
+            });
+            normalize_legacy_item_lifecycle_notification(&mut value);
+            assert_eq!(value["params"][timestamp_field], 0);
+            let message: JSONRPCMessage = serde_json::from_value(value).expect("json-rpc");
+            let JSONRPCMessage::Notification(notification) = message else {
+                panic!("expected notification");
+            };
+            ServerNotification::try_from(notification)
+                .expect("upstream should accept normalized lifecycle notification");
+        }
+    }
+
+    #[test]
+    fn explicit_lifecycle_timestamp_is_never_overwritten() {
+        let mut value = json!({
+            "jsonrpc": "2.0",
+            "method": "item/completed",
+            "params": {
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "completedAtMs": 42,
+                "item": { "type": "userMessage", "id": "user-1", "content": [] }
+            }
+        });
+        normalize_legacy_item_lifecycle_notification(&mut value);
+        assert_eq!(value["params"]["completedAtMs"], 42);
+    }
+
+    #[test]
+    fn legacy_command_item_with_empty_cwd_survives_strict_upstream_decode() {
+        let mut value = json!({
+            "jsonrpc": "2.0",
+            "method": "item/completed",
+            "params": {
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "item": {
+                    "type": "commandExecution",
+                    "id": "command-1",
+                    "command": "printf OK",
+                    "cwd": "",
+                    "source": "agent",
+                    "status": "completed",
+                    "commandActions": [],
+                    "aggregatedOutput": "OK"
+                }
+            }
+        });
+        normalize_legacy_item_lifecycle_notification(&mut value);
+        assert_eq!(value["params"]["item"]["cwd"], "/");
+        let message: JSONRPCMessage = serde_json::from_value(value).expect("json-rpc");
+        let JSONRPCMessage::Notification(notification) = message else {
+            panic!("expected notification");
+        };
+        ServerNotification::try_from(notification)
+            .expect("upstream should accept normalized command lifecycle notification");
     }
 }
 


### PR DESCRIPTION
## Purpose

Bring the conversation UI in line with the Codex/ChatGPT composer and restore complete Pi tool lifecycle rendering before the next mobile release.

## Changes

- move model, reasoning, mode, attach, voice, send, and stop actions into one contained composer
- replace full-width conversation headers with floating back/reload/info controls
- default fresh installs to ChatGPT/Codex themes and system font
- preserve completed and live tool output in the iOS timeline
- normalize Pi item lifecycle events so shared decoding keeps tool calls/results
- pin the mobile repository Rust toolchain to prevent incompatible cache splits
- remove 120 net lines from the cross-platform UI implementation

## Local verification

- iOS simulator Debug build
- targeted LitterTests image/link display tests
- expanded/collapsed tool and command UI tests
- real composer keyboard/action UI test
- Pi JSON-line lifecycle Rust tests (3 passed)
- visual screenshot inspection on iPhone 17 Pro Max simulator

Android compilation and full mobile CI are intentionally required before merge or store upload.