### PR TITLE
ios: stabilize composer typing and dictation

### DIFF
--- a/apps/ios/Sources/Litter/Views/ConversationComposerEntryRowView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationComposerEntryRowView.swift
@@ -169,6 +169,7 @@ struct ConversationComposerEntryRowView: View {
                     HStack(spacing: 4) {
                         Text(modelLabel)
                             .lineLimit(1)
+                            .truncationMode(.middle)
                         if let reasoningLabel, reasoningLabel != "default" {
                             Text(reasoningLabel)
                                 .foregroundColor(LitterTheme.textSecondary)
@@ -187,7 +188,8 @@ struct ConversationComposerEntryRowView: View {
                 .hoverEffect(.highlight)
                 .accessibilityIdentifier("conversation.modelPickerButton")
                 .accessibilityLabel("Choose model")
-                .layoutPriority(1)
+                .frame(maxWidth: 150)
+                .layoutPriority(0)
             }
 
             if showModeChip {
@@ -201,6 +203,8 @@ struct ConversationComposerEntryRowView: View {
                     .frame(width: 42, height: 20)
             }
             trailingControl
+                .fixedSize()
+                .layoutPriority(3)
         }
         .padding(.horizontal, 6)
         .padding(.bottom, 6)
@@ -250,5 +254,6 @@ struct ConversationComposerEntryRowView: View {
         .buttonStyle(.plain)
         .hoverEffect(.highlight)
         .accessibilityLabel(label)
+        .accessibilityIdentifier("conversation.\(label.lowercased().replacingOccurrences(of: " ", with: "-"))Button")
     }
 }

--- a/apps/ios/Sources/Litter/Views/ConversationComposerTextView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationComposerTextView.swift
@@ -69,6 +69,7 @@ struct ConversationComposerTextView: UIViewRepresentable {
         textView.onHardwareSubmit = onHardwareSubmit
         textView.accessibilityIdentifier = "conversation.composerTextView"
         textView.text = text
+        context.coordinator.textReconciler = ComposerTextReconciler(initialText: text)
         context.coordinator.applyStyling(to: textView)
         context.coordinator.updateScrollState(for: textView)
         return textView
@@ -78,15 +79,23 @@ struct ConversationComposerTextView: UIViewRepresentable {
         context.coordinator.parent = self
         uiView.onPasteImage = onPasteImage
         uiView.onHardwareSubmit = onHardwareSubmit
-        uiView.textContainerInset = UIEdgeInsets(
+        let nextInsets = UIEdgeInsets(
             top: verticalInset,
             left: horizontalInset,
             bottom: verticalInset,
             right: horizontalInset
         )
+        if uiView.textContainerInset != nextInsets {
+            uiView.textContainerInset = nextInsets
+        }
         context.coordinator.applyStyling(to: uiView)
 
-        if uiView.text != text, uiView.markedTextRange == nil {
+        if uiView.markedTextRange == nil,
+           context.coordinator.textReconciler.shouldApply(
+               presentedText: text,
+               currentUIKitText: uiView.text,
+               isEditing: uiView.isFirstResponder
+           ) {
             context.coordinator.isSynchronizingText = true
             uiView.text = text
             context.coordinator.applySelectedRange(to: uiView)
@@ -117,11 +126,13 @@ struct ConversationComposerTextView: UIViewRepresentable {
     final class Coordinator: NSObject, UITextViewDelegate {
         var parent: ConversationComposerTextView
         var isSynchronizingText = false
+        var textReconciler: ComposerTextReconciler
         private var requestedFocusState: Bool?
         private var focusSyncWorkItem: DispatchWorkItem?
 
         init(_ parent: ConversationComposerTextView) {
             self.parent = parent
+            textReconciler = ComposerTextReconciler(initialText: parent.text)
         }
 
         func textViewDidBeginEditing(_ textView: UITextView) {
@@ -135,11 +146,16 @@ struct ConversationComposerTextView: UIViewRepresentable {
         func textViewDidChange(_ textView: UITextView) {
             guard !isSynchronizingText else { return }
             let updatedText = textView.text ?? ""
+            textReconciler.recordUIKitEdit(updatedText)
             if parent.text != updatedText {
                 parent.text = updatedText
             }
             updateSelectedRange(from: textView)
-            updateScrollState(for: textView)
+            // While focused the view is already scroll-enabled. Avoid forcing
+            // TextKit to measure the entire draft again for every keystroke.
+            if !textView.isFirstResponder {
+                updateScrollState(for: textView)
+            }
         }
 
         func textViewDidChangeSelection(_ textView: UITextView) {
@@ -175,11 +191,22 @@ struct ConversationComposerTextView: UIViewRepresentable {
         }
 
         func applyStyling(to textView: UITextView) {
-            textView.font = composerFont()
-            textView.textColor = UIColor(LitterTheme.textPrimary)
+            let font = composerFont()
+            if textView.font != font {
+                textView.font = font
+            }
+            let color = UIColor(LitterTheme.textPrimary)
+            if textView.textColor != color {
+                textView.textColor = color
+            }
         }
 
         func updateScrollState(for textView: UITextView) {
+            if parent.isFocused || textView.isFirstResponder {
+                if !textView.isScrollEnabled { textView.isScrollEnabled = true }
+                if !textView.alwaysBounceVertical { textView.alwaysBounceVertical = true }
+                return
+            }
             let availableWidth = max(textView.bounds.width, 1)
             let fittingHeight = textView.sizeThatFits(
                 CGSize(width: availableWidth, height: .greatestFiniteMagnitude)
@@ -238,11 +265,50 @@ struct ConversationComposerTextView: UIViewRepresentable {
                     || parent.selectedRange.length != range.length else {
                 return
             }
-            DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
-                self.parent.selectedRange = range
-            }
+            // UITextView delegate callbacks are already on the main thread.
+            // Writing selection asynchronously lets older cursor positions
+            // arrive after newer keystrokes and can visibly reorder edits.
+            parent.selectedRange = range
         }
+    }
+}
+
+/// Keeps UIKit authoritative while the user is actively editing. SwiftUI may
+/// re-render the representable with the previously presented binding value
+/// before the latest delegate write has propagated. Re-applying that stale
+/// value resets autocorrection state and the cursor, causing lag and scrambled
+/// characters during rapid typing.
+struct ComposerTextReconciler {
+    private(set) var lastPresentedText: String
+    private(set) var lastUIKitEdit: String?
+
+    init(initialText: String) {
+        lastPresentedText = initialText
+    }
+
+    mutating func recordUIKitEdit(_ text: String) {
+        lastUIKitEdit = text
+    }
+
+    mutating func shouldApply(
+        presentedText: String,
+        currentUIKitText: String,
+        isEditing: Bool
+    ) -> Bool {
+        defer { lastPresentedText = presentedText }
+        guard presentedText != currentUIKitText else {
+            if lastUIKitEdit == presentedText { lastUIKitEdit = nil }
+            return false
+        }
+
+        if isEditing,
+           presentedText == lastPresentedText,
+           currentUIKitText == lastUIKitEdit {
+            return false
+        }
+
+        lastUIKitEdit = nil
+        return true
     }
 }
 

--- a/apps/ios/Sources/Litter/Views/ConversationDisplayUITestHarnessView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationDisplayUITestHarnessView.swift
@@ -40,7 +40,7 @@ struct ConversationDisplayUITestHarnessView: View {
                         voiceManager: voiceManager,
                         isTurnActive: false,
                         hasAttachment: false,
-                        modelLabel: "GPT-5",
+                        modelLabel: ProcessInfo.processInfo.environment["CODEXIOS_UI_TEST_MODEL_LABEL"] ?? "GPT-5",
                         reasoningLabel: "high",
                         collaborationMode: .default,
                         showModeChip: true,

--- a/apps/ios/Sources/Litter/Views/ConversationView.swift
+++ b/apps/ios/Sources/Litter/Views/ConversationView.swift
@@ -1990,7 +1990,8 @@ private struct ConversationInputBar: View {
             nextText.contains("$")
 
         guard needsPopupEvaluation else {
-            hideComposerPopups()
+            // The common typing path has no active popup state. Avoid walking
+            // and cancelling every suggestion subsystem on each keystroke.
             return
         }
 

--- a/apps/ios/Tests/LitterTests/ConversationDisplayPreferenceTests.swift
+++ b/apps/ios/Tests/LitterTests/ConversationDisplayPreferenceTests.swift
@@ -2,6 +2,43 @@ import XCTest
 @testable import Litter
 
 final class ConversationDisplayPreferenceTests: XCTestCase {
+    func testComposerIgnoresStaleRenderWhileUIKitEditIsInFlight() {
+        var reconciler = ComposerTextReconciler(initialText: "hello")
+        reconciler.recordUIKitEdit("hello!")
+
+        XCTAssertFalse(reconciler.shouldApply(
+            presentedText: "hello",
+            currentUIKitText: "hello!",
+            isEditing: true
+        ))
+        XCTAssertFalse(reconciler.shouldApply(
+            presentedText: "hello!",
+            currentUIKitText: "hello!",
+            isEditing: true
+        ))
+    }
+
+    func testComposerAppliesIntentionalExternalEdit() {
+        var reconciler = ComposerTextReconciler(initialText: "hello")
+
+        XCTAssertTrue(reconciler.shouldApply(
+            presentedText: "prefilled prompt",
+            currentUIKitText: "hello",
+            isEditing: true
+        ))
+    }
+
+    func testComposerAppliesBindingWhenNotEditing() {
+        var reconciler = ComposerTextReconciler(initialText: "hello")
+        reconciler.recordUIKitEdit("hello!")
+
+        XCTAssertTrue(reconciler.shouldApply(
+            presentedText: "hello",
+            currentUIKitText: "hello!",
+            isEditing: false
+        ))
+    }
+
     func testDisplayModeResolvesUnknownValuesToCollapsed() {
         XCTAssertEqual(ConversationDetailDisplayMode.resolve("expanded"), .expanded)
         XCTAssertEqual(ConversationDetailDisplayMode.resolve("hidden"), .hidden)

--- a/apps/ios/Tests/LitterUITests/LitterUITests.swift
+++ b/apps/ios/Tests/LitterUITests/LitterUITests.swift
@@ -47,6 +47,30 @@ final class LitterUITests: XCTestCase {
     }
 
     @MainActor
+    func testConversationComposerKeepsDictationVisibleWithLongModelName() throws {
+        let app = conversationDisplayHarnessApp()
+        app.launchEnvironment["CODEXIOS_UI_TEST_MODEL_LABEL"] = "HomeLab DeepSeek V4 Flash 0731 Experimental"
+        app.launch()
+
+        let dictate = app.buttons["conversation.dictateButton"]
+        XCTAssertTrue(dictate.waitForExistence(timeout: 10))
+        XCTAssertTrue(dictate.isHittable)
+    }
+
+    @MainActor
+    func testConversationComposerPreservesRapidKeyboardInput() throws {
+        let app = conversationDisplayHarnessApp()
+        app.launch()
+
+        let composer = app.textViews["conversation.composerTextView"]
+        XCTAssertTrue(composer.waitForExistence(timeout: 10))
+        composer.tap()
+        let prompt = "Rapid typing keeps every character in the correct order."
+        composer.typeText(prompt)
+        XCTAssertEqual(composer.value as? String, prompt)
+    }
+
+    @MainActor
     func testConversationLaunchPerformance() throws {
         let app = conversationDisplayHarnessApp()
         measure(metrics: [XCTApplicationLaunchMetric()]) {


### PR DESCRIPTION
## Purpose
Fix severe composer typing lag/character reordering and keep speech-to-text reachable on phone-width layouts.

## Changes
- keep UIKit authoritative while a live edit is propagating through SwiftUI
- update selection synchronously and avoid full draft measurement on every keystroke
- skip popup cancellation work for ordinary typing
- constrain long model labels and protect the trailing dictation/send control
- add reconciliation unit coverage and rapid-input/dictation UI regressions

## Verification
- `ConversationDisplayPreferenceTests`: 7 passed, 0 failed
- simulator UI: 2 passed, 0 failed
- rapid 54-character input preserved exactly; XCTest synthesis ~1.14s
- `make ios-device-fast`: signed device build succeeded
- installed Litter 2.0.0 (200000254) on iPhone 15 Pro Max

Physical XCTest runner install is blocked by its separate invalid signing identity (`0xe8008018`); the signed app itself installs successfully. No store release until CI and installed-app verification are complete.