### PR TITLE
android: advance 2.0.0 release code

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -33,7 +33,7 @@ android {
         applicationId = "com.sigkitten.litter.android"
         minSdk = 26
         targetSdk = 36
-        versionCode = 200000254
+        versionCode = 200000260
         versionName = "2.0.0"
         buildConfigField("boolean", "ENABLE_ON_DEVICE_BRIDGE", "true")
         buildConfigField("String", "RUNTIME_STARTUP_MODE", "\"hybrid\"")


### PR DESCRIPTION
## Purpose
Ensure the Android 2.0.0 production bundle uses a Play-acceptable version code newer than the existing 1.6.0 code 200000255.

## Change
- Advance the checked-in Android versionCode baseline from 200000254 to 200000260.
- The release workflow will therefore select 200000261, avoiding the stale Play artifact.

## Verification
- Existing exact composer fix CI is green on iOS and Android.
- Google Play Console verified the old 200000255 bundle already exists as 1.6.0.
- This is metadata-only; versionName remains 2.0.0.