### PR TITLE
release: build manual Play bundle

### DIFF
--- a/.github/workflows/android-play-release.yml
+++ b/.github/workflows/android-play-release.yml
@@ -355,6 +355,7 @@ jobs:
           trap 'status=$?; kill "$HEARTBEAT_PID" >/dev/null 2>&1 || true; wait "$HEARTBEAT_PID" 2>/dev/null || true; exit $status' EXIT
           ./apps/android/gradlew -p apps/android --no-daemon --stacktrace "--max-workers=$GRADLE_MAX_WORKERS" \
             :app:assembleRelease \
+            :app:bundleRelease \
             -PLITTER_UPLOAD_STORE_FILE="$LITTER_UPLOAD_STORE_FILE" \
             -PLITTER_UPLOAD_STORE_PASSWORD="$LITTER_UPLOAD_STORE_PASSWORD" \
             -PLITTER_UPLOAD_KEY_ALIAS="$LITTER_UPLOAD_KEY_ALIAS" \


### PR DESCRIPTION
## Purpose
Ensure the artifact-only Google Play release lane actually produces the signed AAB that its checksum and upload-artifact steps require.

## Change
- run `:app:bundleRelease` alongside `:app:assembleRelease`

## Verification
- `git diff --check`
- Android release workflow will be dispatched from the merged commit with `publish_to_play=false` and its AAB checksum verified before manual Play Console upload.