### PR TITLE
fix(opencode): route turn/interrupt to owning runtime; keep new threads across list sync [skip mobile-release]

### DIFF
--- a/shared/rust-bridge/codex-mobile-client/src/mobile_client/event_loop.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/mobile_client/event_loop.rs
@@ -356,7 +356,7 @@ impl MobileClient {
         })
     }
 
-    fn runtime_for_request(
+    pub(crate) fn runtime_for_request(
         &self,
         server_id: &str,
         request: &upstream::ClientRequest,
@@ -386,6 +386,12 @@ impl MobileClient {
             }
             upstream::ClientRequest::TurnStart { params, .. } => Some(params.thread_id.as_str()),
             upstream::ClientRequest::TurnSteer { params, .. } => Some(params.thread_id.as_str()),
+            // turn/interrupt must go to the runtime that owns the thread.
+            // Without this arm it falls through to the `codex` default channel
+            // and, on a multi-runtime host, the cancel lands on the ChatGPT
+            // app-server which doesn't know the OpenCode thread id
+            // (`server error -32600: thread not found`).
+            upstream::ClientRequest::TurnInterrupt { params, .. } => Some(params.thread_id.as_str()),
             _ => None,
         };
         thread_id
@@ -1211,7 +1217,7 @@ fn find_thread_id_value(value: &serde_json::Value) -> Option<String> {
     }
 }
 
-fn client_request_wire_method(request: &upstream::ClientRequest) -> &'static str {
+pub(crate) fn client_request_wire_method(request: &upstream::ClientRequest) -> &'static str {
     match request {
         upstream::ClientRequest::GetAccount { .. } => "account/read",
         upstream::ClientRequest::GetAccountRateLimits { .. } => "account/rateLimits/read",
@@ -1228,6 +1234,7 @@ fn client_request_wire_method(request: &upstream::ClientRequest) -> &'static str
         upstream::ClientRequest::ThreadTurnsList { .. } => "thread/turns/list",
         upstream::ClientRequest::TurnStart { .. } => "turn/start",
         upstream::ClientRequest::TurnSteer { .. } => "turn/steer",
+        upstream::ClientRequest::TurnInterrupt { .. } => "turn/interrupt",
         upstream::ClientRequest::CollaborationModeList { .. } => "collaboration_mode/list",
         _ => "unknown",
     }
@@ -1949,5 +1956,17 @@ mod tests {
         // Upstream replaced `permissionProfile` with `activePermissionProfile`;
         // legacy compat only needs to confirm the response decodes.
         let _ = response.active_permission_profile;
+    }
+
+    #[test]
+    fn client_request_wire_method_maps_turn_interrupt() {
+        let request = upstream::ClientRequest::TurnInterrupt {
+            request_id: upstream::RequestId::Integer(crate::next_request_id()),
+            params: upstream::TurnInterruptParams {
+                thread_id: "thread-1".to_string(),
+                turn_id: "turn-1".to_string(),
+            },
+        };
+        assert_eq!(client_request_wire_method(&request), "turn/interrupt");
     }
 }

--- a/shared/rust-bridge/codex-mobile-client/src/mobile_client/tests.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/mobile_client/tests.rs
@@ -695,6 +695,38 @@ mod mobile_client_tests {
     }
 
     #[test]
+    fn turn_interrupt_routes_to_owning_runtime_not_codex() {
+        let client = MobileClient::new();
+        let key = ThreadKey {
+            server_id: "srv".to_string(),
+            thread_id: "thread-opencode".to_string(),
+        };
+        client
+            .app_store
+            .upsert_thread_snapshot(ThreadSnapshot::from_info(
+                &key.server_id,
+                make_thread_info(&key.thread_id),
+            ));
+        client.note_thread_runtime(key.clone(), "opencode".to_string());
+
+        let request = upstream::ClientRequest::TurnInterrupt {
+            request_id: upstream::RequestId::Integer(crate::next_request_id()),
+            params: upstream::TurnInterruptParams {
+                thread_id: key.thread_id.clone(),
+                turn_id: "turn-1".to_string(),
+            },
+        };
+        // Regression for 0xSero/litter#283: turn/interrupt must be routed to
+        // the runtime that owns the thread, not the default "codex" channel
+        // (which yields `server error -32600: thread not found` on
+        // multi-runtime hosts).
+        assert_eq!(
+            client.runtime_for_request(&key.server_id, &request),
+            "opencode".to_string()
+        );
+    }
+
+    #[test]
     fn thread_runtime_infers_claude_from_existing_thread_model_provider() {
         let client = MobileClient::new();
         let key = ThreadKey {

--- a/shared/rust-bridge/codex-mobile-client/src/store/reducer.rs
+++ b/shared/rust-bridge/codex-mobile-client/src/store/reducer.rs
@@ -310,6 +310,24 @@ impl AppStoreReducer {
         self.emit(AppStoreUpdateRecord::ActiveThreadChanged { key: None });
     }
 
+    /// Whether a thread that is absent from an incoming `thread/list` page
+    /// should survive the reconcile anyway. Besides the active thread and
+    /// local-studio, never evict a thread we are actively using: one with an
+    /// in-flight turn, queued follow-ups, a staged local overlay, or one
+    /// created within the last minute. The brand-new-thread window matters
+    /// because a just-started OpenCode session may not appear in
+    /// `GET /session` until its first message lands; evicting it then causes
+    /// the first `turn/start` overlay and its streamed events to be dropped
+    /// (0xSero/litter#283).
+    fn keep_thread_absent_from_incoming_page(thread: &ThreadSnapshot) -> bool {
+        thread.active_turn_id.is_some()
+            || !thread.queued_follow_ups.is_empty()
+            || !thread.local_overlay_items.is_empty()
+            || thread.info.created_at.is_some_and(|created_at| {
+                created_at > 0 && (now_ms() as i64 / 1000).saturating_sub(created_at) < 60
+            })
+    }
+
     pub fn sync_thread_list(&self, server_id: &str, threads: &[ThreadInfo]) {
         self.sync_thread_list_for_runtime(server_id, "codex".to_string(), threads);
     }
@@ -338,7 +356,8 @@ impl AppStoreReducer {
                 let keep = key.server_id != server_id
                     || incoming_ids.contains(&key.thread_id)
                     || active_thread_key.as_ref() == Some(key)
-                    || thread.agent_runtime_kind == "local-studio";
+                    || thread.agent_runtime_kind == "local-studio"
+                    || Self::keep_thread_absent_from_incoming_page(thread);
                 if !keep {
                     removed_thread_keys.push(key.clone());
                 }
@@ -499,7 +518,8 @@ impl AppStoreReducer {
                 let keep = key.server_id != server_id
                     || incoming_ids.contains(&key.thread_id)
                     || active_thread_key.as_ref() == Some(key)
-                    || thread.agent_runtime_kind == "local-studio";
+                    || thread.agent_runtime_kind == "local-studio"
+                    || Self::keep_thread_absent_from_incoming_page(thread);
                 if !keep {
                     removed_thread_keys.push(key.clone());
                 }
@@ -3985,6 +4005,50 @@ mod tests {
         let snapshot = reducer.snapshot();
         let server = snapshot.servers.get("srv").expect("server snapshot");
         assert_eq!(server.wake_mac.as_deref(), Some("aa:bb:cc:dd:ee:ff"));
+    }
+
+    #[test]
+    fn sync_thread_list_preserves_recently_created_thread_not_in_incoming_page() {
+        let reducer = AppStoreReducer::new();
+        let fresh_key = ThreadKey {
+            server_id: "srv".to_string(),
+            thread_id: "fresh".to_string(),
+        };
+        let mut info = make_thread_info("fresh");
+        info.created_at = Some((now_ms() / 1000) as i64);
+        reducer.upsert_thread_snapshot(ThreadSnapshot::from_info("srv", info));
+
+        // The incoming page does not include the just-created thread (e.g. a
+        // brand-new OpenCode session is not yet returned by GET /session).
+        reducer.sync_thread_list("srv", &[make_thread_info("other")]);
+
+        let snapshot = reducer.snapshot();
+        assert!(snapshot.threads.contains_key(&fresh_key));
+        assert!(snapshot.threads.contains_key(&ThreadKey {
+            server_id: "srv".to_string(),
+            thread_id: "other".to_string(),
+        }));
+    }
+
+    #[test]
+    fn sync_thread_list_evicts_old_inactive_thread_not_in_incoming_page() {
+        let reducer = AppStoreReducer::new();
+        let stale_key = ThreadKey {
+            server_id: "srv".to_string(),
+            thread_id: "stale".to_string(),
+        };
+        let mut info = make_thread_info("stale");
+        info.created_at = Some((now_ms() / 1000) as i64 - 3600);
+        reducer.upsert_thread_snapshot(ThreadSnapshot::from_info("srv", info));
+
+        reducer.sync_thread_list("srv", &[make_thread_info("other")]);
+
+        let snapshot = reducer.snapshot();
+        assert!(!snapshot.threads.contains_key(&stale_key));
+        assert!(snapshot.threads.contains_key(&ThreadKey {
+            server_id: "srv".to_string(),
+            thread_id: "other".to_string(),
+        }));
     }
 
     #[test]


### PR DESCRIPTION
## Purpose

Land PR #284's correctness fix for the first-message-in-a-new-thread failure when using the OpenCode provider (issue #283), adapted to current `main`.

Two client-side defects on multi-runtime hosts (a host serving both an OpenCode runtime and a ChatGPT/codex app-server, e.g. the headless `agent-harness`):

1. **`turn/interrupt` routed to the wrong runtime** — `runtime_for_request` matched every thread-scoped request except `TurnInterrupt`, so it fell through to the default `codex` channel. Cancelling a turn landed on the ChatGPT app-server, which doesn't know the OpenCode thread id and replied `server error -32600: thread not found`. Fix: route `TurnInterrupt` by the thread's owning runtime (same as `TurnStart`/`TurnSteer`) and map its wire method in `client_request_wire_method`.

2. **Brand-new thread evicted by a `thread/list` sync** — `sync_thread_list_for_runtime` / `finalize_thread_list_sync` evict every thread not in the incoming page unless it's the active thread or local-studio. A just-started OpenCode session is not returned by `GET /session` until its first message lands, so during that window the snapshot is evicted; `mutate_thread_with_result` and `stage_local_user_message_overlay` then silently no-op. Fix: never evict a thread with an in-flight turn, queued follow-ups, a staged local overlay, or created within the last minute (`keep_thread_absent_from_incoming_page`).

## Relationship to PR #284

This is the exact change from PR #284 (head `bf088945`, author @DatScreamer) cherry-picked onto current `main` with one minimal test-only adaptation. All credit for the fix belongs to @DatScreamer.

PR #284's original head was authored against an older `codex_app_server_protocol` where `ClientRequest::TurnInterrupt` had no `request_id` field. Current `main`'s upstream protocol (generated by the macro at `shared/third_party/codex/codex-rs/app-server-protocol/src/protocol/common.rs`) requires `request_id: RequestId` on every `ClientRequest` variant, so PR #284's two test-only constructions failed to compile on main with `E0063: missing field request_id` (this is the same `E0063` that the original fork-CI run `31670696810` reported at `event_loop.rs:1963` and `tests.rs:712`).

The only deviation from PR #284's patch is two added lines, one in each test construction, mirroring the existing crate idiom (`ffi/client.rs:2657`):

```rust
request_id: upstream::RequestId::Integer(crate::next_request_id()),
```

Production code needed no change (it only matches `TurnInterrupt { params, .. }`). `next_request_id()` is `pub(crate)` in `lib.rs` and already used elsewhere in the crate.

`git range-diff` confirms the patch is otherwise byte-identical to PR #284; the only metadata change vs the PR is the `[skip mobile-release]` subject suffix (required for this repo's CI).

## Key changes

- `event_loop.rs`: route `TurnInterrupt` by owning runtime in `runtime_for_request`; map `turn/interrupt` in `client_request_wire_method`; bump both to `pub(crate)` for test access; + regression test `client_request_wire_method_maps_turn_interrupt`.
- `reducer.rs`: add `keep_thread_absent_from_incoming_page`; apply at both `sync_thread_list` eviction sites; + 2 regression tests.
- `tests.rs`: + `turn_interrupt_routes_to_owning_runtime_not_codex`.

All four PR #284 tests are retained.

## Validation (host, this branch @ `11c4e1c7`)

```
cargo check --locked -p codex-mobile-client                     -> 0 errors
cargo test  --locked -p codex-mobile-client --lib               -> 756 passed; 0 failed; 2 ignored
cargo test  --locked -p codex-slingshot --lib                    -> 14  passed; 0 failed
cargo test  --locked -p codex-mobile-client --lib <4 PR tests>   -> 4 passed
    mobile_client::event_loop::tests::client_request_wire_method_maps_turn_interrupt ... ok
    store::reducer::tests::sync_thread_list_evicts_old_inactive_thread_not_in_incoming_page ... ok
    store::reducer::tests::sync_thread_list_preserves_recently_created_thread_not_in_incoming_page ... ok
    mobile_client::tests::mobile_client_tests::turn_interrupt_routes_to_owning_runtime_not_codex ... ok
```

iOS/Android device builds and release lanes were not run (no destructive/release actions).

## Submodule preservation

`shared/third_party/codex` (`13595c36e`) and `shared/third_party/ghostty` (`a968e120d`) are unchanged; this commit does not touch submodules.
