### PR TITLE
ci: add read-only mobile store status [skip mobile-release]

### DIFF
--- a/.github/workflows/store-status.yml
+++ b/.github/workflows/store-status.yml
@@ -1,0 +1,208 @@
+name: Store Status
+
+on:
+  workflow_dispatch:
+    inputs:
+      ios_version:
+        description: "iOS marketing version to inspect (blank = all versions)."
+        required: false
+        default: ""
+        type: string
+      ios_build_number:
+        description: "Specific iOS build number to inspect (blank = highest uploaded build only)."
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+  # actions: read is required only for the preflight guard that refuses the
+  # dispatch while any android-play-release run is queued/in-progress.
+  actions: read
+
+concurrency:
+  group: store-status-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Refuse if android-play-release is queued or running
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          workflow_id="$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows" \
+            --jq '.workflows[] | select(.path == ".github/workflows/android-play-release.yml") | .id' \
+            | head -n 1)"
+          if [ -z "${workflow_id:-}" ]; then
+            echo "::error::Could not resolve android-play-release.yml workflow id."
+            exit 1
+          fi
+          active_count="$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$workflow_id/runs?per_page=100" \
+            --jq '[.workflow_runs[] | select(.status == "queued" or .status == "in_progress" or .status == "waiting" or .status == "requested" or .status == "pending")] | length')"
+          if [ "${active_count:-0}" -gt 0 ]; then
+            echo "::error::android-play-release has ${active_count} queued/in-progress run(s); refusing store-status dispatch."
+            exit 1
+          fi
+          echo "Preflight OK: no android-play-release run is queued or in progress."
+
+  asc-status:
+    needs: preflight
+    runs-on: macos-26
+    timeout-minutes: 10
+    environment: release
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+    steps:
+      - name: Validate required secrets
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY_P8_B64: ${{ secrets.ASC_PRIVATE_KEY_P8_B64 }}
+          IOS_APP_STORE_APP_ID: ${{ secrets.IOS_APP_STORE_APP_ID }}
+        run: |
+          set -euo pipefail
+          for name in ASC_KEY_ID ASC_ISSUER_ID ASC_PRIVATE_KEY_P8_B64 IOS_APP_STORE_APP_ID; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::Missing required secret: $name"
+              exit 1
+            fi
+          done
+
+      - name: Install App Store Connect CLI
+        run: |
+          brew install jq
+          HOMEBREW_NO_AUTO_UPDATE=0 brew install asc
+
+      - name: Decode App Store Connect API key
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_PRIVATE_KEY_P8_B64: ${{ secrets.ASC_PRIVATE_KEY_P8_B64 }}
+        run: |
+          set -euo pipefail
+          ASC_KEY_PATH="$RUNNER_TEMP/AuthKey_${ASC_KEY_ID}.p8"
+          echo "$ASC_PRIVATE_KEY_P8_B64" | base64 --decode > "$ASC_KEY_PATH"
+          chmod 600 "$ASC_KEY_PATH"
+          echo "ASC_PRIVATE_KEY_PATH=$ASC_KEY_PATH" >> "$GITHUB_ENV"
+
+      - name: Read App Store state (read-only)
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY_PATH: ${{ env.ASC_PRIVATE_KEY_PATH }}
+          IOS_APP_STORE_APP_ID: ${{ secrets.IOS_APP_STORE_APP_ID }}
+          IOS_VERSION: ${{ inputs.ios_version }}
+          IOS_BUILD_NUMBER: ${{ inputs.ios_build_number }}
+        run: |
+          set -euo pipefail
+          APP_ID="$IOS_APP_STORE_APP_ID"
+          mkdir -p store-state
+
+          # App record.
+          asc apps list --bundle-id com.sigkitten.litter --output json > store-state/apps.json
+
+          # Highest uploaded build across all versions (authoritative).
+          asc builds list --app "$APP_ID" --limit 1 --sort -uploadedDate --output json > store-state/builds-highest.json
+
+          # Specific build, when requested.
+          if [ -n "${IOS_BUILD_NUMBER:-}" ]; then
+            asc builds list --app "$APP_ID" --version "$IOS_VERSION" --build-number "$IOS_BUILD_NUMBER" \
+              --sort -uploadedDate --output json > store-state/builds-specific.json
+          fi
+
+          # App Store versions + appStoreState.
+          if [ -n "${IOS_VERSION:-}" ]; then
+            asc versions list --app "$APP_ID" --version "$IOS_VERSION" --platform IOS --output json > store-state/versions.json
+          else
+            asc versions list --app "$APP_ID" --platform IOS --output json > store-state/versions.json
+          fi
+
+          # App Review status (read-only; best-effort so an empty review queue
+          # does not fail the read).
+          asc review status --app "$APP_ID" --output json > store-state/review-status.json 2>/dev/null \
+            || echo '{"data":[]}' > store-state/review-status.json
+          asc review submissions-list --app "$APP_ID" --output json > store-state/review-submissions.json 2>/dev/null \
+            || echo '{"data":[]}' > store-state/review-submissions.json
+
+          highest_build="$(jq -r '.data[0].attributes.version // empty' store-state/builds-highest.json)"
+          requested_state="$(jq -r '[.data[]?.attributes.appStoreState // .data[]?.attributes.appStoreVersionState // .data[]?.attributes.state // empty][0] // empty' store-state/versions.json 2>/dev/null || true)"
+
+          jq -n \
+            --arg bundleId "com.sigkitten.litter" \
+            --arg appId "$APP_ID" \
+            --arg highestBuild "$highest_build" \
+            --arg requestedVersion "${IOS_VERSION:-}" \
+            --arg requestedBuild "${IOS_BUILD_NUMBER:-}" \
+            --arg requestedState "$requested_state" \
+            '{bundleId: $bundleId, appId: $appId, highestUploadedBuild: $highestBuild, requestedVersion: $requestedVersion, requestedBuildNumber: $requestedBuild, requestedAppStoreState: $requestedState}' \
+            > store-state/summary.json
+
+          echo "App Store state captured: highest build = ${highest_build:-<none>}"
+
+      - name: Upload store-state artifact (JSON only)
+        uses: actions/upload-artifact@v6
+        with:
+          name: asc-store-state
+          path: store-state
+          if-no-files-found: error
+          retention-days: 7
+
+  play-status:
+    needs: preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Validate required secrets
+        env:
+          LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64: ${{ secrets.LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64 }}
+        run: |
+          set -euo pipefail
+          if [ -z "${LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64:-}" ]; then
+            echo "::error::Missing required secret: LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64"
+            exit 1
+          fi
+
+      - name: Decode Google Play service account (RUNNER_TEMP only)
+        env:
+          LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64: ${{ secrets.LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64 }}
+        run: |
+          set -euo pipefail
+          service_account_json="$RUNNER_TEMP/play-service-account.json"
+          if printf '%s' "$LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64" | base64 --decode 2>/dev/null > "$service_account_json" \
+            && jq -e . "$service_account_json" >/dev/null 2>&1; then
+            :
+          else
+            printf '%s' "$LITTER_PLAY_SERVICE_ACCOUNT_JSON_B64" > "$service_account_json"
+            jq -e . "$service_account_json" >/dev/null
+          fi
+          chmod 600 "$service_account_json"
+          echo "LITTER_PLAY_SERVICE_ACCOUNT_JSON=$service_account_json" >> "$GITHUB_ENV"
+
+      - name: Read Google Play tracks (read-only)
+        env:
+          LITTER_PLAY_SERVICE_ACCOUNT_JSON: ${{ env.LITTER_PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          set -euo pipefail
+          mkdir -p store-state
+          python3 tools/scripts/list-play-tracks.py \
+            --package com.sigkitten.litter.android \
+            --service-account-json "$LITTER_PLAY_SERVICE_ACCOUNT_JSON" \
+            --pretty \
+            --output store-state/play-tracks.json
+
+      - name: Upload store-state artifact (JSON only)
+        uses: actions/upload-artifact@v6
+        with:
+          name: play-store-state
+          path: store-state
+          if-no-files-found: error
+          retention-days: 7

--- a/tools/scripts/list-play-tracks.py
+++ b/tools/scripts/list-play-tracks.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Read-only Google Play track / versionCode listing.
+
+Reads the current track state for a package by creating an ephemeral
+(uncommitted draft) edit, fetching its track list, and deleting the edit.
+Deletion is performed in a ``finally`` block so it runs on every normal and
+error path. This tool performs no published-state changes of any kind: it
+never publishes bundles, promotes artifacts, updates track entries, or
+commits an edit.
+
+Output is a single normalized JSON document.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import datetime as dt
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+DEFAULT_PACKAGE = "com.sigkitten.litter.android"
+PLAY_PUBLISHER_SCOPE = "https://www.googleapis.com/auth/androidpublisher"
+PLAY_EDITS_BASE = "https://androidpublisher.googleapis.com/androidpublisher/v3/applications"
+
+
+def b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def issue_token(service_account_path: pathlib.Path) -> str:
+    """Exchange a service-account JSON for an androidpublisher access token."""
+    payload = json.loads(service_account_path.read_text())
+    now = int(dt.datetime.now(tz=dt.timezone.utc).timestamp())
+    header = {"alg": "RS256", "typ": "JWT"}
+    claim = {
+        "iss": payload["client_email"],
+        "scope": PLAY_PUBLISHER_SCOPE,
+        "aud": payload["token_uri"],
+        "exp": now + 3600,
+        "iat": now,
+    }
+    signing_input = (
+        f"{b64url(json.dumps(header, separators=(',', ':')).encode())}."
+        f"{b64url(json.dumps(claim, separators=(',', ':')).encode())}"
+    )
+    key_path: pathlib.Path | None = None
+    with tempfile.NamedTemporaryFile("w", delete=False) as handle:
+        handle.write(payload["private_key"])
+        key_path = pathlib.Path(handle.name)
+    try:
+        signature = subprocess.run(
+            ["openssl", "dgst", "-sha256", "-sign", str(key_path)],
+            check=True,
+            input=signing_input.encode(),
+            capture_output=True,
+        ).stdout
+    finally:
+        if key_path is not None:
+            key_path.unlink(missing_ok=True)
+    assertion = f"{signing_input}.{b64url(signature)}".encode()
+    body = urllib.parse.urlencode(
+        {
+            "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            "assertion": assertion.decode(),
+        }
+    ).encode()
+    request = urllib.request.Request(
+        payload["token_uri"],
+        data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            return json.loads(response.read().decode())["access_token"]
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"Google token exchange failed: {exc.read().decode()}") from exc
+
+
+def api_request_json(
+    url: str,
+    token: str,
+    *,
+    method: str = "GET",
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+        "User-Agent": "litter-list-play-tracks/1.0",
+    }
+    data: bytes | None = None
+    if payload is not None:
+        data = json.dumps(payload).encode()
+        headers["Content-Type"] = "application/json"
+    request = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:
+            return json.loads(response.read().decode() or "{}")
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode()
+        raise RuntimeError(f"HTTP {exc.code} for {url}: {body}") from exc
+
+
+def list_tracks(package: str, token: str, base_url: str = PLAY_EDITS_BASE) -> dict[str, Any]:
+    """Create an ephemeral edit, read tracks, and delete the edit.
+
+    The DELETE is issued inside ``finally`` so it is attempted on every exit
+    path (normal return and any exception, including KeyboardInterrupt).
+    """
+    edits_url = f"{base_url}/{package}/edits"
+    edit = api_request_json(edits_url, token, method="POST", payload={})
+    edit_id = edit.get("id")
+    if not edit_id:
+        raise RuntimeError("create-edit preflight returned no edit id")
+    delete_failure: Exception | None = None
+    try:
+        tracks_payload = api_request_json(
+            f"{edits_url}/{urllib.parse.quote(str(edit_id), safe='')}/tracks",
+            token,
+            method="GET",
+        )
+    finally:
+        try:
+            api_request_json(
+                f"{edits_url}/{urllib.parse.quote(str(edit_id), safe='')}",
+                token,
+                method="DELETE",
+            )
+        except Exception as exc:  # noqa: BLE001 - preserve original error
+            delete_failure = exc
+    if delete_failure is not None:
+        raise RuntimeError(f"failed to delete ephemeral edit {edit_id}: {delete_failure}") from delete_failure
+    return tracks_payload
+
+
+def _to_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def normalize(package: str, tracks_payload: dict[str, Any], generated_at: str) -> dict[str, Any]:
+    tracks = tracks_payload.get("tracks") or []
+    by_track: dict[str, Any] = {}
+    overall_highest: int | None = None
+    for track in tracks:
+        name = track.get("track")
+        if not name:
+            continue
+        releases: list[dict[str, Any]] = []
+        track_highest: int | None = None
+        for release in track.get("releases") or []:
+            codes = [
+                c
+                for c in (_to_int(v) for v in (release.get("versionCodes") or []))
+                if c is not None
+            ]
+            for c in codes:
+                if overall_highest is None or c > overall_highest:
+                    overall_highest = c
+                if track_highest is None or c > track_highest:
+                    track_highest = c
+            releases.append(
+                {
+                    "name": release.get("name"),
+                    "versionCodes": codes,
+                    "status": release.get("status"),
+                    "userFraction": release.get("userFraction"),
+                }
+            )
+        by_track[name] = {
+            "releases": releases,
+            "highestVersionCode": track_highest,
+        }
+    return {
+        "packageName": package,
+        "generatedAtUtc": generated_at,
+        "readOnly": True,
+        "highestVersionCode": overall_highest,
+        "tracks": by_track,
+    }
+
+
+def _self_test() -> int:
+    """In-process mock of the Play API proving create -> GET tracks -> DELETE
+    ordering and that DELETE still fires when the tracks GET fails."""
+    import http.server
+    import threading
+
+    calls: list[tuple[str, str]] = []
+    state: dict[str, Any] = {"fail_get": False}
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, *args: Any) -> None:  # silence
+            return
+
+        def _send(self, code: int, obj: Any) -> None:
+            body = json.dumps(obj).encode()
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_POST(self) -> None:
+            calls.append(("POST", self.path))
+            if self.path.endswith("/edits"):
+                self._send(200, {"id": "edit-1", "expiryTimeSeconds": "3600"})
+            else:
+                self._send(404, {})
+
+        def do_GET(self) -> None:
+            calls.append(("GET", self.path))
+            if self.path.endswith("/edits/edit-1/tracks"):
+                if state["fail_get"]:
+                    self._send(500, {"error": {"message": "forced"}})
+                else:
+                    self._send(200, {
+                        "kind": "androidpublisher#tracksListResponse",
+                        "tracks": [
+                            {
+                                "track": "internal",
+                                "releases": [
+                                    {"name": "1", "versionCodes": ["200000253"], "status": "completed"},
+                                ],
+                            },
+                            {
+                                "track": "production",
+                                "releases": [
+                                    {"name": "1", "versionCodes": ["200000250", "200000249"], "status": "completed"},
+                                ],
+                            },
+                        ],
+                    })
+            else:
+                self._send(404, {})
+
+        def do_DELETE(self) -> None:
+            calls.append(("DELETE", self.path))
+            if self.path.endswith("/edits/edit-1"):
+                self._send(200, {})
+            else:
+                self._send(404, {})
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base = f"http://127.0.0.1:{server.server_address[1]}/applications"
+    try:
+        # Happy path.
+        payload = list_tracks("com.example", "fake-token", base_url=base)
+        assert calls[-3:] == [
+            ("POST", "/applications/com.example/edits"),
+            ("GET", "/applications/com.example/edits/edit-1/tracks"),
+            ("DELETE", "/applications/com.example/edits/edit-1"),
+        ], f"unexpected call order: {calls[-3:]}"
+        normalized = normalize("com.example", payload, "test")
+        assert normalized["highestVersionCode"] == 200000253, normalized
+        assert normalized["tracks"]["production"]["highestVersionCode"] == 200000250, normalized
+
+        # Error path: GET tracks returns 500; DELETE must still fire in finally.
+        calls.clear()
+        state["fail_get"] = True
+        try:
+            list_tracks("com.example", "fake-token", base_url=base)
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("expected list_tracks to raise on GET 500")
+        assert ("POST", "/applications/com.example/edits") in calls, calls
+        assert ("DELETE", "/applications/com.example/edits/edit-1") in calls, f"DELETE missing on error path: {calls}"
+
+        print("self-test: OK (create -> GET tracks -> DELETE; DELETE fires on error path)")
+        return 0
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--package", default=os.environ.get("LITTER_PLAY_PACKAGE", DEFAULT_PACKAGE))
+    parser.add_argument(
+        "--service-account-json",
+        default=os.environ.get("LITTER_PLAY_SERVICE_ACCOUNT_JSON", ""),
+        help="Path to the Google Play service account JSON (or LITTER_PLAY_SERVICE_ACCOUNT_JSON).",
+    )
+    parser.add_argument("--output", help="Write normalized JSON to this file instead of stdout.")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON.")
+    parser.add_argument("--self-test", action="store_true", help="Run the in-process mock test and exit.")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return _self_test()
+
+    if not args.service_account_json:
+        raise SystemExit("error: --service-account-json or LITTER_PLAY_SERVICE_ACCOUNT_JSON is required")
+    service_account_path = pathlib.Path(args.service_account_json).expanduser()
+    if not service_account_path.exists():
+        raise SystemExit(f"error: service account JSON not found: {service_account_path}")
+
+    token = issue_token(service_account_path)
+    tracks_payload = list_tracks(args.package, token)
+    generated_at = (
+        dt.datetime.now(tz=dt.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+    normalized = normalize(args.package, tracks_payload, generated_at)
+    text = json.dumps(normalized, indent=2 if args.pretty else None, sort_keys=True)
+    if args.output:
+        out_path = pathlib.Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(text + "\n")
+        print(f"Wrote {out_path}")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Purpose

Add a **read-only** store-status workflow (`.github/workflows/store-status.yml`) and a single companion script (`tools/scripts/list-play-tracks.py`). This lets us answer the two live-store questions for `com.sigkitten.litter` / `com.sigkitten.litter.android` without touching release lanes:

- Apple: current App Store review/live state, highest uploaded build, and per-version `appStoreState`.
- Google Play: live `internal`/`alpha`/`beta`/`production` tracks and the highest uploaded `versionCode` across all tracks.

## What it outputs

**`asc-status` job** (read-only `asc`): `apps.json`, `builds-highest.json`, optional `builds-specific.json`, `versions.json` (with `appStoreState`), `review-status.json`, `review-submissions.json`, and a compact `summary.json`.

**`play-status` job**: `play-tracks.json` — normalized `{ packageName, generatedAtUtc, readOnly, highestVersionCode, tracks: { <track>: { releases, highestVersionCode } } }`.

Both jobs upload store-state JSON artifacts with `retention-days: 7`.

## Structural no-mutation guarantee

- `list-play-tracks.py` contains **no** publish/promote/upload/track-update/`edits:commit` code path. It performs exactly three HTTP operations: `POST /edits` (create an empty **uncommitted draft** edit), `GET /edits/{id}/tracks` (read), and `DELETE /edits/{id}` (cleanup).
- The `DELETE` is issued inside a `finally` block, so it is attempted on every normal and error path (including `KeyboardInterrupt`).
- The Apple job uses only `asc` `list`/`status` verbs (`apps list`, `builds list`, `versions list`, `review status`, `review submissions-list`) — no `submit`, `attach-build`, `edit`, `upload`, `finalize`, or `create`.

## finally-deletion self-test

`python3 tools/scripts/list-play-tracks.py --self-test` runs an in-process mock of the Play API and asserts:
1. `POST /edits` → `GET /edits/{id}/tracks` → `DELETE /edits/{id}` ordering.
2. Correct normalization (`highestVersionCode`, per-track highest).
3. **DELETE still fires when the tracks GET returns 500** (the finally path).

## Permission rationale

`permissions` is `contents: read` plus `actions: read`. `actions: read` exists **only** for the mandatory preflight guard, which refuses the dispatch while any `android-play-release` run is `queued`/`in_progress`/`waiting`/`requested`/`pending`. It is read-only (no `actions: write`). Explicitly approved.

## Exact validation

- `python3 -m py_compile tools/scripts/list-play-tracks.py` → OK
- `python3 tools/scripts/list-play-tracks.py --self-test` → OK (create→GET→DELETE; DELETE on error path)
- Static scan: no `edits:commit` / `publishReleaseBundle` / `promoteReleaseArtifact` / `gradlew` / `method="PUT"` / `method="PATCH"`; verb counts `POST=1 GET=1 DELETE=1`.
- YAML parsed with `pyyaml safe_load` (3 jobs, `workflow_dispatch` only, 10-min timeouts, `environment: release` only on secret-using jobs, self-concurrency).

## First-dispatch expectations

First `workflow_dispatch` on `main` (after merge) is expected to report, without mutating anything:
- ASC: version 2.0.0 build 200000260 (`ff700735-25ed-4f5c-92a3-c38876566602`) / version id `4a170018-7882-4b8b-a682-1cf0a8332f87` `appStoreState`, and the highest uploaded build.
- Play: highest `versionCode` per track, expected to be absent of `200000261` (that release was built but never published).

## Guarantee

**No store mutation occurs** — no App Store submit/finalize and no Google Play publish/promote/commit. The Play edit is created, read, and deleted in one pass and is never committed.