### PR TITLE
ci: expand shared tests and sync iOS project [skip mobile-release]

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Shared Rust tests
         env:
           CARGO_INCREMENTAL: "0"
-        run: cargo test --manifest-path shared/rust-bridge/Cargo.toml -p codex-mobile-client
+        run: cargo test --manifest-path shared/rust-bridge/Cargo.toml -p codex-mobile-client -p codex-slingshot
 
       - name: Release script tests
         run: |

--- a/apps/ios/Litter.xcodeproj/project.pbxproj
+++ b/apps/ios/Litter.xcodeproj/project.pbxproj
@@ -474,6 +474,7 @@
 		B1A9E717B758EA0236262500 /* ConversationOptionsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE81AFDF90E8ED46203AF90C /* ConversationOptionsSheet.swift */; };
 		B1B8E5CDA90C78B954ADADCB /* ExperimentalFeaturesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D950991BD0F0199209EB68 /* ExperimentalFeaturesView.swift */; };
 		B23DF0EC00DE8A4DE6390161 /* AnimatedSplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78076308EEAAE64BC3BFDC1F /* AnimatedSplashView.swift */; };
+		B254C9592B726152D12F4109 /* SavedServerStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782886BB7B618AF20A1843EC /* SavedServerStoreTests.swift */; };
 		B2AFC54D3C1CE47C58453313 /* codex-light.json in Resources */ = {isa = PBXBuildFile; fileRef = FA7B1E3B542D557D080E913D /* codex-light.json */; };
 		B2E94DB79FAB25F0F5AB3C86 /* LocalCodexBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = D330E51EBB1EC86C197A9296 /* LocalCodexBootstrap.swift */; };
 		B3FEC7D6A1528065E759A5B8 /* WatchHapticDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A295F9828114C38B7CB29209 /* WatchHapticDetector.swift */; };
@@ -954,6 +955,7 @@
 		77F28A803AA2BF325B0F88B9 /* ChatGPTOAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGPTOAuth.swift; sourceTree = "<group>"; };
 		78076308EEAAE64BC3BFDC1F /* AnimatedSplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedSplashView.swift; sourceTree = "<group>"; };
 		781A72E518F9230E2A641141 /* WatchModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchModels.swift; sourceTree = "<group>"; };
+		782886BB7B618AF20A1843EC /* SavedServerStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedServerStoreTests.swift; sourceTree = "<group>"; };
 		782D870FCEA68BB3752F965F /* SwiftSshCredentialProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftSshCredentialProvider.swift; sourceTree = "<group>"; };
 		795964BC1D4B7081B774B65E /* one-light.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "one-light.json"; sourceTree = "<group>"; };
 		7D3ACFB8DE4FE6FD3D957F27 /* TurnLiveActivityController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnLiveActivityController.swift; sourceTree = "<group>"; };
@@ -1258,6 +1260,7 @@
 				689720B7DCABED4F7EC8A5C6 /* RealtimeConversationProtocolTests.swift */,
 				009A217AC2D736865C5F06F5 /* RunningTurnSnapshotTests.swift */,
 				E16ACA3C8902C3687BC8518C /* SavedAppsStoreTests.swift */,
+				782886BB7B618AF20A1843EC /* SavedServerStoreTests.swift */,
 				4B606DE26237FA6DB5D4410B /* StreamingAssistantRenderCacheTests.swift */,
 				D0B91C694EA050F1FE6738A7 /* ThemeDefinitionTests.swift */,
 				03425A33EF523B27A338F941 /* ToolCallMessageParserTests.swift */,
@@ -2291,6 +2294,7 @@
 				5CADE26AD9CB723244C8F639 /* RealtimeConversationProtocolTests.swift in Sources */,
 				F36A73F7FC24709ADD299327 /* RunningTurnSnapshotTests.swift in Sources */,
 				CE6374DC534978B3A07C7688 /* SavedAppsStoreTests.swift in Sources */,
+				B254C9592B726152D12F4109 /* SavedServerStoreTests.swift in Sources */,
 				59EEAB181A610B1ABF97CC7C /* StreamingAssistantRenderCacheTests.swift in Sources */,
 				3FCF949480156948806B98DF /* ThemeDefinitionTests.swift in Sources */,
 				2AC9CF710AAC599B03215B36 /* ToolCallMessageParserTests.swift in Sources */,


### PR DESCRIPTION
## Batch infra stack (Litter v2.0.1)

Two-commit infra batch on top of `origin/main` (`a8fb7bfb`). Approved by Fable-5 for push+PR.

### Commits

1. **`078a5ed2` — `ci: run codex-slingshot tests in Mobile CI [skip mobile-release]`**
   - File: `.github/workflows/mobile-ci.yml` (1 line changed: +1/-1).
   - Appends ` -p codex-slingshot` to the existing Shared Rust tests `cargo test` command in the `shared-prep` job; `CARGO_INCREMENTAL: "0"` env and all surrounding content retained.
   - `codex-slingshot` confirmed as a workspace member (`shared/rust-bridge/Cargo.toml`).
   - Workflow YAML validated locally (`yaml.safe_load` → jobs `shared-prep`, `android`, `ios`).

2. **`0ec9ae18` — `ios: commit regenerated project wiring SavedServerStoreTests [skip mobile-release]`**
   - File: `apps/ios/Litter.xcodeproj/project.pbxproj` (+4 insertions, 0 deletions).
   - Generated via the safe regeneration script `./apps/ios/scripts/regenerate-project.sh` (xcodegen **2.45.4**) from the commit-1 tree.
   - Wires `SavedServerStoreTests.swift`: PBXBuildFile, PBXFileReference, LitterTests group membership (next to `SavedAppsStoreTests.swift`), and Sources build-phase entry.
   - Acceptance met: exactly 4 insertions, 0 deletions, only this file, only SavedServerStoreTests wiring, no other drift.

### Validation

- **Prior slingshot proof:** the codex-slingshot crate was previously validated at 14/14 tests passing on the lane host before this batch was isolated; the CI `shared-prep` job re-runs `cargo test -p codex-mobile-client -p codex-slingshot` as the PR-CI acceptance gate.
- **ENOSPC deferral:** a fresh local `cargo test -p codex-slingshot` run in the isolated worktree was attempted but could not complete — it requires the `codex` submodule populated for path deps, and the host had only ~4.7 GB free, hitting `No space left on device` mid-compile. Per batch constraints the submodule was not replaced/symlinked/copied; full local execution is deferred to the PR's self-validating Mobile CI (`shared-prep` job). Likewise the iOS `LitterTests` build/test is deferred to the CI `ios` job (`build-for-testing` + `test-without-building`), since it needs the Rust cdylib + a booted simulator and was disk-constrained on the host.
- **Submodule integrity:** both `shared/third_party/codex` (`13595c3`) and `shared/third_party/ghostty` (`a968e12`) gitlinks are byte-identical to `origin/main`; no commit touched any submodule.

### Provenance

Transparent lane authorship: implemented by the **GLM-5.2** implementation lane for Litter v2.0.1 Batch infra (commits authored as `GLM-5.2 batch-infra lane <glm-5.2@batch-infra.local>`). Approved by Fable-5. Branch `codex/v201-batch-infra`, head `0ec9ae18d3ddd5e4098af0402aabc8afa7842d0b`.

Heads: local = remote = `0ec9ae18d3ddd5e4098af0402aabc8afa7842d0b`.