### PR TITLE
fix(status): don't gate connected servers on opencode OpenAI sign-in

### DIFF
--- a/apps/android/app/src/main/java/com/litter/android/state/SnapshotExtensions.kt
+++ b/apps/android/app/src/main/java/com/litter/android/state/SnapshotExtensions.kt
@@ -90,10 +90,23 @@ val AppServerSnapshot.connectionProgressLabel: String?
         null -> null
     }
 
+/**
+ * True when the server reports it needs the app's OpenAI account to be useful
+ * and no account is configured. Servers with an available opencode runtime are
+ * exempt: opencode holds its own credentials on the server (its configured
+ * provider), so the app's OpenAI sign-in isn't required to use it.
+ */
+val AppServerSnapshot.needsAppOpenaiSignIn: Boolean
+    get() = if (transportState != AppServerTransportState.CONNECTED || !requiresOpenaiAuth || account != null) {
+        false
+    } else {
+        !agentRuntimes.any { it.kind == "opencode" && it.available }
+    }
+
 val AppServerSnapshot.statusLabel: String
     get() = when {
         connectionProgressLabel != null -> connectionProgressLabel!!
-        transportState == AppServerTransportState.CONNECTED && requiresOpenaiAuth && account == null ->
+        needsAppOpenaiSignIn ->
             "Sign in required"
         else -> transportState.displayLabel
     }
@@ -103,7 +116,7 @@ val AppServerSnapshot.statusColor: Color
         currentConnectionStep?.state == AppConnectionStepState.FAILED -> Color(0xFFFF6B6B)
         currentConnectionStep?.state == AppConnectionStepState.AWAITING_USER_INPUT -> WarningOrange
         connectionProgressLabel != null -> AccentGreen
-        transportState == AppServerTransportState.CONNECTED && requiresOpenaiAuth && account == null ->
+        needsAppOpenaiSignIn ->
             WarningOrange
         else -> transportState.accentColor
     }
@@ -120,7 +133,7 @@ val AppServerSnapshot.statusDotState: com.litter.android.ui.common.StatusDotStat
             com.litter.android.ui.common.StatusDotState.PENDING
         connectionProgressLabel != null ->
             com.litter.android.ui.common.StatusDotState.PENDING
-        transportState == AppServerTransportState.CONNECTED && requiresOpenaiAuth && account == null ->
+        needsAppOpenaiSignIn ->
             com.litter.android.ui.common.StatusDotState.PENDING
         transportState == AppServerTransportState.CONNECTED ->
             com.litter.android.ui.common.StatusDotState.OK

--- a/apps/ios/Sources/Litter/Models/AppServerSnapshot+UI.swift
+++ b/apps/ios/Sources/Litter/Models/AppServerSnapshot+UI.swift
@@ -50,11 +50,22 @@ extension AppServerSnapshot {
         currentConnectionStep?.detail ?? connectionProgress?.terminalMessage
     }
 
+    /// True when the server reports it needs the app's OpenAI account to be
+    /// useful and no account is configured. Servers with an available opencode
+    /// runtime are exempt: opencode holds its own credentials on the server
+    /// (its configured provider), so the app's OpenAI sign-in isn't required
+    /// to use it.
+    var needsAppOpenaiSignIn: Bool {
+        guard transportState == .connected, requiresOpenaiAuth, account == nil else { return false }
+        let opencodeAvailable = agentRuntimes.contains { $0.kind == "opencode" && $0.available }
+        return !opencodeAvailable
+    }
+
     var statusLabel: String {
         if let connectionProgressLabel {
             return connectionProgressLabel
         }
-        if transportState == .connected, requiresOpenaiAuth, account == nil {
+        if needsAppOpenaiSignIn {
             return "Sign in required"
         }
         return transportState.displayLabel
@@ -70,7 +81,7 @@ extension AppServerSnapshot {
         if connectionProgressLabel != nil {
             return LitterTheme.accent
         }
-        if transportState == .connected, requiresOpenaiAuth, account == nil {
+        if needsAppOpenaiSignIn {
             return .orange
         }
         return transportState.accentColor
@@ -88,7 +99,7 @@ extension AppServerSnapshot {
         if connectionProgressLabel != nil {
             return .pending
         }
-        if transportState == .connected, requiresOpenaiAuth, account == nil {
+        if needsAppOpenaiSignIn {
             return .pending
         }
         switch transportState {


### PR DESCRIPTION
Closes #303

## Summary
A connected ssh-bridge server exposing both `opencode` and `codex` runtimes stayed yellow ("Sign in required") because the status dot is gated on `requiresOpenaiAuth && account == nil` — values sourced from the **codex** runtime's `account/read`. When codex on the remote host isn't logged into OpenAI, it forces the whole server yellow even though an **opencode** runtime is available and manages its own server-side credentials.

## Changes
- New `needsAppOpenaiSignIn` projection: `connected && requiresOpenaiAuth && account == nil && !(agentRuntimes contains kind=="opencode" && available)`.
- Applied to `statusLabel`, `statusColor`, `statusDotState` on iOS (`AppServerSnapshot+UI.swift`).
- Same projection applied on Android (`SnapshotExtensions.kt`).

## Behavior
- Connected server with an available opencode runtime → **green** (opencode works without the app's OpenAI account).
- Codex-only server (or one genuinely needing the app's OpenAI login) → still "Sign in required" (yellow).

## Verification
- Manually tested on iOS simulator and Android emulator against an opencode SSH server: status renders green while connected.